### PR TITLE
Correction to Optional Parameters

### DIFF
--- a/src/routes/solid-start/building-your-application/routing.mdx
+++ b/src/routes/solid-start/building-your-application/routing.mdx
@@ -150,7 +150,7 @@ export default function UserPage() {
 #### Optional parameter
 
 If you have optional parameters in your route, you can use the double square brackets (`[[id]]`) to define the dynamic segment.
-This will match any number of segments, including none.
+This will match a route with or without a parameter.
 
 ```tsx {3}
 |-- routes/
@@ -161,7 +161,7 @@ This will match any number of segments, including none.
 In this case, some pages that could be matched include:
 * `/users`
 * `/users/1`
-* `/users/1/2`
+* `/users/abc`
 
 #### Catch-all routes
 


### PR DESCRIPTION
Docs page/section: [Optional parameter](https://docs.solidjs.com/solid-start/building-your-application/routing#optional-parameter)

Per my testing some information in this section is incorrect

"This will match any number of segments, including none."
- Per the example given, it will only match the `/users` path with or without a parameter (`/users` || `/users/1`)

"In this case, some pages that could be matched include:"
- The doc incorrectly states `/users/1/2` will be matched.

Example repo: [optional-parameters-743-example](https://github.com/klequis/optional-parameters-743-example)