### PR TITLE
fix: update eslint config to use correct values

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,7 +26,7 @@ module.exports = {
 	},
 	plugins: ["@typescript-eslint", "solid"],
 	rules: {
-		indent: ["warning", "tab"],
+		indent: ["warn", "tab"],
 		quotes: ["error", "double"],
 		semi: "warn",
 	},


### PR DESCRIPTION
This is just a small fix, WebStorm was constantly complaining about this incorrect value in the `.eslintrc.cjs`.