### PR TITLE
docs: fix typo, remove mention of renderToBufferDestination

### DIFF
--- a/src/routes/solid-start/building-your-application/route-prerendering.mdx
+++ b/src/routes/solid-start/building-your-application/route-prerendering.mdx
@@ -17,7 +17,7 @@ export default defineConfig({
 });
 ```
 
-When you wish for all your routes to be pre-renderToBufferDestination, you can pass `true` to the `crawlLinks` option:
+When you wish for all your routes to be pre-rendered, you can pass `true` to the `crawlLinks` option:
 
 ```js { 6 }
 import { defineConfig } from "@solidjs/start/config";


### PR DESCRIPTION
fix typo following issue reported here https://discord.com/channels/722131463138705510/861229287868858379/1244591935025578055