### PR TITLE
Default export is required for page components

### DIFF
--- a/src/routes/solid-start/building-your-application/routing.mdx
+++ b/src/routes/solid-start/building-your-application/routing.mdx
@@ -63,7 +63,7 @@ When a file is named `index`, it will be rendered when there are no additional U
 - `example.com` ➜ `/routes/index.tsx`
 - `example.com/socials` ➜ `/routes/socials/index.tsx`
 
-For a route to be rendered as a page, it should default export a component. 
+For a route to be rendered as a page, it must default export a component. 
 This component represents the content that will be rendered when users visit the page:
 
 ```tsx filename="routes/index.tsx"


### PR DESCRIPTION
In my testing having a non-default export:

```jsx
export function ComponentName() {}
```

Results in the route not being found. (goes to the catch-all)

Therefore, I'm suggesting replacing "should" with "must".