### PR TITLE
fix(modify-mutable.mdx): Fix typo

### DIFF
--- a/src/routes/reference/store-utilities/modify-mutable.mdx
+++ b/src/routes/reference/store-utilities/modify-mutable.mdx
@@ -2,7 +2,7 @@
 title: modifyMutable
 ---
 
-`modifyMutable` streamlines the process of making multiple changes to a mutable Store, as obtained through the use of [createMutable]/reference/store-utilities/create-mutable).
+`modifyMutable` streamlines the process of making multiple changes to a mutable Store, as obtained through the use of [`createMutable`](/reference/store-utilities/create-mutable).
 
 It operates within a single [`batch`](/reference/reactive-utilities/batch), ensuring that dependent computations are updated just once, rather than triggering updates for each individual change.
 


### PR DESCRIPTION
Fix typo preventing anchor creation and wrap text with `code` in `modify-mutable.mdx`.