### PR TITLE
docs(api-routes): fixes `Request` link

### DIFF
--- a/src/routes/solid-start/building-your-application/api-routes.mdx
+++ b/src/routes/solid-start/building-your-application/api-routes.mdx
@@ -48,7 +48,7 @@ export function DELETE() {
 
 API routes get passed an `APIEvent` object as their first argument. 
 This object contains:
-- `request`: [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Response) object representing the request sent by the client.
+- `request`: [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) object representing the request sent by the client.
 - `params`: Object that contains the dynamic route parameters. For example, if the route is `/api/users/:id`, and the request is made to `/api/users/123`, then `params` will be `{ id: 123 }`.
 - `fetch`: An internal `fetch` function that can be used to make requests to other API routes without worrying about the `origin` of the URL.
 


### PR DESCRIPTION
As reported in #763, the link for the `Request` page was wrong.

https://github.com/solidjs/solid-docs-next/blob/main/src/routes/solid-start/building-your-application/api-routes.mdx?plain=1#L51