### PR TITLE
Remove non-existing style from css module example

### DIFF
--- a/src/routes/solid-start/building-your-application/css-and-styling.mdx
+++ b/src/routes/solid-start/building-your-application/css-and-styling.mdx
@@ -86,7 +86,7 @@ import styles from "./Card.module.css";
 const Card = (props) => {
   return (
     <div class={styles.card}>
-      <h1 class={styles.title}>{props.title}</h1>
+      <h1>{props.title}</h1>
       <p>{props.text}</p>
     </div>
   );


### PR DESCRIPTION
I believe it's a mistake since the CSS module example has no title class, and it could be confusing.

![CleanShot 2024-06-02 at 15 53 46@2x](https://github.com/solidjs/solid-docs-next/assets/5693018/cdc1f78c-00b4-42af-816f-c655d4b013b2)
