### PR TITLE
Update Index File Naming Convention

### DIFF
--- a/src/routes/solid-start/building-your-application/routing.mdx
+++ b/src/routes/solid-start/building-your-application/routing.mdx
@@ -77,7 +77,7 @@ export default function Index() {
 By default, the component that is rendered for a route comes from the default export of the `index.tsx` file in each folder.
 However, this can make it difficult to find the correct `index.tsx` file when searching, since there will be multiple files with that name.
 
-To avoid this, you can rename the `index.tsx` file to the name of the folder it is in and it will be rendered as the default export for that route:
+To avoid this, you can rename the `index.tsx` file to the name of the folder it is in, enclosed in parentheses. This way, it will be treated as the default export for that route:
 
 ```jsx {2, 4, 6}
 |-- routes/                       // example.com
@@ -88,7 +88,7 @@ To avoid this, you can rename the `index.tsx` file to the name of the folder it 
         |-- job-1.tsx             // example.com/work/job-1
         |-- job-2.tsx
     |-- socials/
-        |-- socials.tsx           // example.com/socials
+        |-- (socials).tsx           // example.com/socials
 ```
 
 #### Escaping nested routes

--- a/src/routes/solid-start/building-your-application/routing.mdx
+++ b/src/routes/solid-start/building-your-application/routing.mdx
@@ -77,7 +77,9 @@ export default function Index() {
 By default, the component that is rendered for a route comes from the default export of the `index.tsx` file in each folder.
 However, this can make it difficult to find the correct `index.tsx` file when searching, since there will be multiple files with that name.
 
-To avoid this, you can rename the `index.tsx` file to the name of the folder it is in, enclosed in parentheses. This way, it will be treated as the default export for that route:
+To avoid this, you can rename the `index.tsx` file to the name of the folder it is in, enclosed in parenthesis. 
+
+This way, it will be treated as the default export for that route:
 
 ```jsx {2, 4, 6}
 |-- routes/                       // example.com


### PR DESCRIPTION
Updated index file naming convention in documentation to reflect correct usage. Enclosed index.tsx file names in parentheses to ensure proper default export behavior for route components.