### PR TITLE
Use route component in Protected Routes example

### DIFF
--- a/src/routes/solid-start/advanced/auth.mdx
+++ b/src/routes/solid-start/advanced/auth.mdx
@@ -12,7 +12,7 @@ async function getPrivatePosts() {
 	if(!user) {
 		return null  // or throw an error
 	}
-	
+
 	return db.getPosts({ userId: user.id, private: true })
 }
 ```
@@ -21,7 +21,7 @@ The `getUser` function can be [implemented using sessions](/solid-start/advanced
 
 ## Protected Routes
 
-Routes can be protected by checking the user or session object during data fetching. 
+Routes can be protected by checking the user or session object during data fetching.
 This example uses [Solid Router](/solid-router).
 
 ```tsx
@@ -29,18 +29,16 @@ const getPrivatePosts = cache(async function() {
 	"use server"
 	const user = await getUser()
 	if(!user) {
-		throw redirect("/login"); 
+		throw redirect("/login");
 	}
-	
+
 	return db.getPosts({ userId: user.id, private: true })
 })
 
-export const route = {
-  load() {
-    void getPrivatePosts()
-  }
-} satisfies RouteDefinition
+export default function Page() {
+	const posts = createAsync(() => getPrivatePosts());
+}
 ```
 
-Once the user hits this route, the router will immediately attempt to fetch `getPrivatePosts` data. 
+Once the user hits this route, the router will attempt to fetch `getPrivatePosts` data.
 If the user is not signed in, `getPrivatePosts` will throw and the router will redirect to the login page.


### PR DESCRIPTION
`load` functions ignore retuned/thrown `redirect/reload/etc`. While it can be called in `load` as an optimisation, it's necessary for `getPrivatePosts` to be called in the component body.