### PR TITLE
fix: Add bang operator to prevent type error.

### DIFF
--- a/src/routes/solid-router/getting-started/installation-and-setup.mdx
+++ b/src/routes/solid-router/getting-started/installation-and-setup.mdx
@@ -50,7 +50,13 @@ To configure your routes, import the `Router` component and then start the appli
 import { render } from "solid-js/web";
 import { Router } from "@solidjs/router";
 
-render(() => <Router />, document.getElementById("app")!);
+const wrapper = document.getElementById("app");
+
+if (!wrapper) {
+  throw new Error("Wrapper div not found");
+}
+
+render(() => <App />, wrapper)
 ```
 
 This sets up the router that will match on the url and render the appropriate route.

--- a/src/routes/solid-router/getting-started/installation-and-setup.mdx
+++ b/src/routes/solid-router/getting-started/installation-and-setup.mdx
@@ -50,7 +50,7 @@ To configure your routes, import the `Router` component and then start the appli
 import { render } from "solid-js/web";
 import { Router } from "@solidjs/router";
 
-render(() => <Router />, document.getElementById("app"));
+render(() => <Router />, document.getElementById("app")!);
 ```
 
 This sets up the router that will match on the url and render the appropriate route.


### PR DESCRIPTION

Without the bang operator, it gives an error like so:

![image](https://github.com/solidjs/solid-docs-next/assets/64446617/da953c12-b03e-4527-8273-4e9248fd2fa7)
