### PR TITLE
Metaprovider included in docs

### DIFF
--- a/src/routes/solid-start/building-your-application/head-and-metadata.mdx
+++ b/src/routes/solid-start/building-your-application/head-and-metadata.mdx
@@ -17,12 +17,14 @@ The common elements used in the [`head`](https://developer.mozilla.org/en-US/doc
 When applying metadata to a specific route, you can use the `Title`:
 
 ```tsx {6}
-import { Title } from "@solidjs/meta";
+import { Title, MetaProvider } from "@solidjs/meta";
 
 export default function About() {
   return (
     <>
-      <Title>About</Title>
+      <MetaProvider>
+        <Title>About</Title>
+      </MetaProvider>
       <h1>About</h1>
     </>
   );
@@ -44,11 +46,14 @@ export default function MySiteTitle(props) {
 
 ```tsx { 6 }
 import MySiteTitle from "~/components/MySiteTitle";
+import { MetaProvider } from "@solidjs/meta"
 
 export default function About() {
   return (
     <>
-      <MySiteTitle>About</MySiteTitle>
+      <MetaProvider>
+        <MySiteTitle>About</MySiteTitle>
+      </MetaProvider>
       <h1>About</h1>
     </>
   );
@@ -60,7 +65,7 @@ export default function About() {
 Resources can be used to create titles specific to the dynamic parts of the route:
 
 ```tsx { 10 }
-import { Title } from "@solidjs/meta";
+import { Title, MetaProvider } from "@solidjs/meta";
 import { RouteSectionProps } from "@solidjs/router";
 import { createResource, Show } from "solid-js";
 
@@ -69,7 +74,9 @@ export default function User(props: RouteSectionProps) {
 
   return (
     <Show when={user()}>
-      <Title>{user()?.name}</Title>
+      <MetaProvider>
+        <Title>{user()?.name}</Title>
+      </MetaProvider>
       <h1>{user()?.name}</h1>
     </Show>
   );

--- a/src/routes/solid-start/building-your-application/head-and-metadata.mdx
+++ b/src/routes/solid-start/building-your-application/head-and-metadata.mdx
@@ -16,7 +16,7 @@ The common elements used in the [`head`](https://developer.mozilla.org/en-US/doc
 
 When applying metadata to a specific route, you can use the `Title`:
 
-```tsx {6}
+```tsx {7}
 import { Title, MetaProvider } from "@solidjs/meta";
 
 export default function About() {
@@ -44,7 +44,7 @@ export default function MySiteTitle(props) {
 }
 ```
 
-```tsx { 6 }
+```tsx {8}
 import MySiteTitle from "~/components/MySiteTitle";
 import { MetaProvider } from "@solidjs/meta"
 
@@ -64,7 +64,7 @@ export default function About() {
 
 Resources can be used to create titles specific to the dynamic parts of the route:
 
-```tsx { 10 }
+```tsx {11}
 import { Title, MetaProvider } from "@solidjs/meta";
 import { RouteSectionProps } from "@solidjs/router";
 import { createResource, Show } from "solid-js";


### PR DESCRIPTION
I think that the examples in the docs for head and metadata should include that you need to wrap the title in MetaProvider because otherwise a `<MetaProvider /> should be in the tree` error will get thrown at you when you save your file. I thought not worthing opening an issue, so I just added it myself there.