### PR TITLE
Catch-all parameters description change

### DIFF
--- a/src/routes/solid-start/building-your-application/routing.mdx
+++ b/src/routes/solid-start/building-your-application/routing.mdx
@@ -177,9 +177,9 @@ They are defined using square brackets with `...` before the label for the route
         |-- [...post].tsx
 ```
 
-The value of the catch-all route will be an array of strings, where each string is a segment of the URL path that matched the catch-all route.
-For example, with the route `[...post]`, the value of `post` will be a property on the `params` object that is returned by the `useParams` hook. 
-It will be a string with the value of the dynamic segment.
+A catch-all route will have one parameter which is a forward-slash delimited string of all the URL segments after the last valid segment.
+For example, with the route `[..post]` and a URL path of `/post/foo` the `params` object returned from the `useParams` primitive will have a `post` property with the value of `foo`.
+For a URL path of `/post/foo/baz` it will be `foo/baz`.
 
 ```tsx title="routes/blog/[...post].tsx"
 import { useParams } from "@solidjs/router";


### PR DESCRIPTION
From the users perspective the value returned by `useParms` in the `params` object is a string, not an array. I think it is better to speak about the string which is returned rather than the array you can see if you insect the `params` proxy object with `Object.entries`.

Additionally, `useParams` only returns segments after the last valid segment.

I replaced the word "hook" with "primitive" per the writing guide.

I will attach a repo to demonstrate this shortly.