### PR TITLE
Fix A tag styling typo activeClass + inactiveClass

### DIFF
--- a/src/routes/solid-router/concepts/navigation.mdx
+++ b/src/routes/solid-router/concepts/navigation.mdx
@@ -37,12 +37,12 @@ const App = (props) => (
 
 ### Styling links
 
-In addition, the `<A>` component also provides an `active` and `inactive` prop.
+In addition, the `<A>` component also provides an `activeClass` and `inactiveClass` prop.
 This prop accepts a string that, when provided, will apply the specified class to the anchor tag based on the current route.
-If the current route matches the `href` prop, the `active` class will be applied, otherwise the `inactive` class will be applied.
+If the current route matches the `href` prop, the `activeClass` class will be applied, otherwise the `inactiveClass` class will be applied.
 
 ```jsx
-<A href="/users" active="underlined" inactive="default">
+<A href="/users" activeClass="underlined" inactiveClass="default">
 	Users
 </A>
 ```


### PR DESCRIPTION
The docs mistakenly say to use the `active` and `inactive` attributes to style the `<A>` element when it should be `activeClass` and `inactiveClass`