### PR TITLE
fix: typo in router docs

### DIFF
--- a/src/routes/solid-router/concepts/actions.mdx
+++ b/src/routes/solid-router/concepts/actions.mdx
@@ -90,7 +90,7 @@ export function MyComponent() {
 ```
 
 Using `useSubmission` leaves the implementation details of how you trigger `echo` up to you.
-Whe handling user inputs, for example, it is better to use a `form` for a multitude of reasons.
+When handling user inputs, for example, it is better to use a `form` for a multitude of reasons.
 
 ## Using forms to submit data
 


### PR DESCRIPTION
Hello, thanks for the amazing library!
I'm building a project with solid-start and was going through the documentation when I found a typo.