### PR TITLE
Remove duplicate phrasing in state management docs

### DIFF
--- a/src/routes/guides/state-management.mdx
+++ b/src/routes/guides/state-management.mdx
@@ -42,8 +42,7 @@ One way data flow simplifies the management of data and user interactions, which
 
 ## Managing basic state
 
-State is the data that is used to determine what content to display to the user.
-It is the source of truth for the application, and is used to determine what content to display to the user.
+State is the source of truth for the application, and is used to determine what content to display to the user.
 State is represented by a [signal](/concepts/signals), which is a reactive primitive that manages state and notifies the UI of any changes.
 
 To create a piece of state, you use the [`createSignal`](/reference/basic-reactivity/create-signal) function and pass in the initial value of the state:


### PR DESCRIPTION
I noticed the phrase `is used to determine what content to display to the user` was used twice in the same sentence in this portion of the docs; this PR should clean that up. 