### PR TITLE
Fix: use count() in createEffect on State Management page

### DIFF
--- a/src/routes/guides/state-management.mdx
+++ b/src/routes/guides/state-management.mdx
@@ -121,7 +121,7 @@ function Counter() {
 	};
 
 	createEffect(() => {
-		setDoubleCount((prev) => prev * 2); // Update doubleCount whenever count changes
+		setDoubleCount(count() * 2); // Update doubleCount whenever count changes
 	});
 
 	return (
@@ -173,7 +173,7 @@ function Counter() {
 	};
 
 	createEffect(() => {
-		setDoubleCount((prev) => prev * 2); // Update doubleCount whenever count changes
+		setDoubleCount(count() * 2); // Update doubleCount whenever count changes
 	});
 
 	const doubleCount = () => count() * 2
@@ -295,7 +295,7 @@ function App() {
 	const squaredCount = createMemo(() => count() * count());
 
 	createEffect(() => {
-		setDoubleCount((prev) => prev * 2);
+		setDoubleCount(count() * 2);
 	});
 
 	return (


### PR DESCRIPTION
`setDoubleCount((prev) => prev * 2);` should be `setDoubleCount(count() * 2);`, like in the [example referenced on the page](https://playground.solidjs.com/anonymous/b05dddaa-e62a-4c56-b745-5704f3a40194)