### PR TITLE
Docs<list-rendering>: complete example

### DIFF
--- a/src/routes/concepts/control-flow/list-rendering.mdx
+++ b/src/routes/concepts/control-flow/list-rendering.mdx
@@ -132,7 +132,7 @@ If you were using `<For>`, the entire list would be re-rendered when a value cha
 import { createSignal, Index } from "solid-js"
 
 function FormList() {
-
+	const [inputs, setInputs] = createSignal(['input1','input2','input3'])
 	return(
 		<form>
 			<Index each={inputs()}>


### PR DESCRIPTION
I believe this example of list-rendering can be improved by adding this line  as mentioned in #798.
`const [inputs, setInputs] = createSignal(['input1','input2','input3'])`