### PR TITLE
Fix error in cache duration.

### DIFF
--- a/src/routes/solid-router/reference/data-apis/cache.mdx
+++ b/src/routes/solid-router/reference/data-apis/cache.mdx
@@ -67,7 +67,7 @@ export default function User(props) {
 `cache` accomplishes the following:
 
 1. Deduping on the server for the lifetime of the request.
-2. Preloading the cache in the browser - this lasts 10 seconds.
+2. Preloading the cache in the browser - this lasts 5 seconds.
    When a route is preloaded on hover or when load is called when entering a route it will make sure to dedupe calls.
 3. A reactive refetch mechanism based on key.
    This prevents routes that are not new from retriggering on action revalidation.


### PR DESCRIPTION
I believe cache expires after five seconds, not ten.

Relevant: https://github.com/solidjs/solid-router/blob/098a7947ae24f85d05bde76bf26d5c803ae90a08/src/data/cache.ts#L15