### PR TITLE
fix: classList example

### DIFF
--- a/src/routes/concepts/components/class-style.mdx
+++ b/src/routes/concepts/components/class-style.mdx
@@ -85,7 +85,7 @@ When the value is `true`, the class is applied; when `false`, it is removed.
 const [current, setCurrent] = createSignal("foo");
 
 <button
-	classList={current() === "foo" ? "selected" : ""}
+	classList={{ "selected" : current() === "foo" }}
 	onClick={() => setCurrent("foo")}
 >
 	foo


### PR DESCRIPTION
Just noticed this incorrect example, probably pulled from the first example in [the original tutorial](https://www.solidjs.com/tutorial/bindings_classlist?solved).