### PR TITLE
Fixing onMount doc page; typo, incomplete sentence, wrong element type

### DIFF
--- a/src/routes/reference/lifecycle/on-mount.mdx
+++ b/src/routes/reference/lifecycle/on-mount.mdx
@@ -4,7 +4,7 @@ order: 5
 ---
 
 Registers a method that runs after initial rendering is done and the elements are mounted to the page.
-Ideal for using [refs](/reference/jsx-attributes/ref) and managing other one-time setup that requires the
+Ideal for using [refs](/reference/jsx-attributes/ref) and managing other one-time setup.
 
 ```tsx
 import { onMount } from "solid-js"
@@ -16,11 +16,11 @@ function onMount(fn: () => void): void
 This is an alias for an effect that is non-tracking, meaning that it is equivalent to a [`createEffect`](/reference/basic-reactivity/create-effect) with no dependencies.
 
 ```tsx
-// example that shoes how to use onMount to get a ref to an element
+// example that shows how to use onMount to get a reference to an element
 import { onMount } from "solid-js"
 
 function MyComponent() {
-	let ref: HTMLDivElement
+	let ref: HTMLButtonElement
 
 	// when the component is mounted, the button will be disabled
 	onMount(() => {


### PR DESCRIPTION
Was trying to learn about how the onMount works and noticed the page has a bunch of issues so here I am trying to help clean it up!