### PR TITLE
fix bug in reactivity validation example

### DIFF
--- a/src/routes/advanced-concepts/fine-grained-reactivity.mdx
+++ b/src/routes/advanced-concepts/fine-grained-reactivity.mdx
@@ -206,7 +206,7 @@ createEffect(() => {
 });
 
 setInterval(() => {
-	setCount((prev) => prev + 1);
+	setCount(count() + 1);
 }, 1000);
 ```
 


### PR DESCRIPTION
The setter method implemented in the example doesn't support passing a function. It only accepts raw values.