### PR TITLE
Add Json response helper to response-helpers.mdx

### DIFF
--- a/src/routes/solid-router/reference/data-apis/response-helpers.mdx
+++ b/src/routes/solid-router/reference/data-apis/response-helpers.mdx
@@ -5,11 +5,12 @@ title: Response helpers
 ## Redirect
 
 Signature: `redirect(path, options)`
-Redirects to the next route
+
+Redirects to the next route.
 
 ```js
 const getUser = cache(() => {
-  const user = await api.getCurrentUser()
+  const user = await api.getCurrentUser();
   if (!user) throw redirect("/login");
   return user;
 })
@@ -19,16 +20,34 @@ const getUser = cache(() => {
 
 Signature: `reload(options)`
 
-Reloads the data on the current page
+Reloads the data at the given cache key on the current route.
 
 ```js
 const getTodo = cache(async (id: number) => {
-	const todo = await fetchTodo(id);
-	return todo;
+  const todo = await fetchTodo(id);
+  return todo;
 }, "todo");
 
 const updateTodo = action(async (todo: Todo) => {
-	await updateTodo(todo.id, todo);
-	reload({ revalidate: getTodo.keyFor(id) });
+	await putTodo(todo.id, todo);
+	return reload({ revalidate: getTodo.keyFor(id) });
+});
+```
+
+## Json
+
+Signature: `json(data, options)`
+
+Returns JSON data from an action while also providing options for controlling revalidation of cache data on the route.
+
+```js
+const getTodo = cache(async (id: number) => {
+  const todo = await fetchTodo(id);
+  return todo;
+}, "todo");
+
+const getCompletedTodos = action(async () => {
+  const completedTodos = await fetchTodo({ status: 'complete' });
+  return json(completedTodos, { revalidate: getTodo.keyFor(id) });
 });
 ```


### PR DESCRIPTION
The [Returning Responses](https://docs.solidjs.com/solid-start/advanced/return-responses#returning-responses) docs mention `json()`, but `json()` is not listed in the [Response Helpers doc page](https://docs.solidjs.com/solid-router/reference/data-apis/response-helpers).

I added `json()` to that doc page.