### PR TITLE
Add missing link to stores doc

### DIFF
--- a/src/routes/concepts/derived-values/derived-signals.mdx
+++ b/src/routes/concepts/derived-values/derived-signals.mdx
@@ -16,6 +16,7 @@ In the above example, the `double` function relies on the `count` signal to prod
 When the `count` signal is changed, the `double` function will be called again to produce a new value.
 
 Similarly you can create a derived signal that relies on a store value because stores use signals under the hood.
+Learn more about [stores](/concepts/stores).
 
 ```js
 const fullName = () => store.firstName + ' ' + store.lastName;

--- a/src/routes/concepts/derived-values/derived-signals.mdx
+++ b/src/routes/concepts/derived-values/derived-signals.mdx
@@ -16,7 +16,7 @@ In the above example, the `double` function relies on the `count` signal to prod
 When the `count` signal is changed, the `double` function will be called again to produce a new value.
 
 Similarly you can create a derived signal that relies on a store value because stores use signals under the hood.
-Learn more about [stores](/concepts/stores).
+To learn more about how stores work, [you can visit the stores section](/concepts/stores).
 
 ```js
 const fullName = () => store.firstName + ' ' + store.lastName;
@@ -27,4 +27,4 @@ It is important to note that these functions do not store a value themselves; in
 If included within a component's body, these derived signals will trigger an update when necessary.
 
 While you can create derived values in this manner, Solid created the [`createMemo`](/reference/basic-reactivity/create-memo) primitive.
-Learn more about [memos](/concepts/derived-values/memos).
+To dive deeper into how memos work, [check out the memos section](/concepts/derived-values/memos).


### PR DESCRIPTION
Stores go after derived signals in "Learn" section, so at this point a new reader (hi btw) isn't familiar with stores.