### PR TITLE
Update intro-to-reactivity.mdx

### DIFF
--- a/src/routes/concepts/intro-to-reactivity.mdx
+++ b/src/routes/concepts/intro-to-reactivity.mdx
@@ -167,7 +167,7 @@ function Counter() {
 ```
 
 Components, much like other functions, will only run _once_.
-This means that if a signal is accessed outside of the return statement, will run on initialization, but any updates to the signal will not trigger an update.
+This means that if a signal is accessed outside of the return statement, it will run on initialization, but any updates to the signal will not trigger an update.
 
 ```jsx
 function Counter() {


### PR DESCRIPTION
Typo omitting "it" from sentence.