### PR TITLE
docs: fix "nitro documentation" typo in `defineConfig` docs

### DIFF
--- a/src/routes/solid-start/reference/config/define-config.mdx
+++ b/src/routes/solid-start/reference/config/define-config.mdx
@@ -46,7 +46,7 @@ export default defineConfig({
 
 SolidStart uses [Nitro](https://nitro.unjs.io/) to run on a number of platforms. 
 The `server` option exposes some Nitro options including the build and deployment presets. 
-An overview of all available presets is available in the [Deploy section of the Nitro documumentation](https://nitro.unjs.io/deploy).
+An overview of all available presets is available in the [Deploy section of the Nitro documentation](https://nitro.unjs.io/deploy).
 
  Some common ones include:
 


### PR DESCRIPTION
Noticed a small typo in the docs :)