### PR TITLE
fix: update to @solid-primitives/marker@0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@kobalte/core": "^0.13.4",
 		"@lunariajs/core": "^0.0.31",
 		"@oramacloud/client": "^1.3.14",
-		"@solid-primitives/marker": "^0.0.3",
+		"@solid-primitives/marker": "^0.1.0",
 		"@solidjs/meta": "^0.29.4",
 		"@solidjs/router": "^0.14.3",
 		"@solidjs/start": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.3.14
         version: 1.3.14(typescript@5.5.4)
       '@solid-primitives/marker':
-        specifier: ^0.0.3
-        version: 0.0.3(solid-js@1.8.17)
+        specifier: ^0.1.0
+        version: 0.1.0(solid-js@1.8.17)
       '@solidjs/meta':
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.8.17)
@@ -1548,8 +1548,8 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
 
-  '@solid-primitives/marker@0.0.3':
-    resolution: {integrity: sha512-HxWbG1uAHjymmEBdrrAz2fdxPWfTRmy/+n+MR10gZi+6iCvX1Io/gwQURI7Iz+BP0G6QUllctuIiXw4qztMI4w==}
+  '@solid-primitives/marker@0.1.0':
+    resolution: {integrity: sha512-vRbqZ1z0qVYXLg5UmG4q5zAZeT6rOl2FcTyis7lnrp7WtY/WynsqIbiDEmnE9LJJPWdAz6HGZBgsOXeWkbPelw==}
     peerDependencies:
       solid-js: ^1.6.12
 
@@ -5884,7 +5884,7 @@ snapshots:
       '@solid-primitives/trigger': 1.0.11(solid-js@1.8.17)
       solid-js: 1.8.17
 
-  '@solid-primitives/marker@0.0.3(solid-js@1.8.17)':
+  '@solid-primitives/marker@0.1.0(solid-js@1.8.17)':
     dependencies:
       solid-js: 1.8.17
 


### PR DESCRIPTION
Fixes a memory leak in the search which was caused by the `@solid-primitives/marker` package.
See https://github.com/solidjs-community/solid-primitives/issues/681