### PR TITLE
add docs for `bool:`

### DIFF
--- a/src/routes/reference/jsx-attributes/bool.mdx
+++ b/src/routes/reference/jsx-attributes/bool.mdx
@@ -4,7 +4,7 @@ title: bool:*
 
 `bool:*` controls the presence of an attribute in an element.
 When the value is `truthy` it adds the `attribute` to the element.
-When the value is `falsy` it removes the `attribute` from the element.
+Alternatively, when the value is `falsy` it removes the `attribute` from the element.
 Mostly useful for Web Components.
 
 ```tsx

--- a/src/routes/reference/jsx-attributes/bool.mdx
+++ b/src/routes/reference/jsx-attributes/bool.mdx
@@ -2,7 +2,7 @@
 title: bool:*
 ---
 
-It controls the presence of an attribute in an element.
+`bool:*` controls the presence of an attribute in an element.
 When the value is `truthy` it adds the `attribute` to the element.
 When the value is `falsy` it removes the `attribute` from the element.
 Mostly useful for Web Components.

--- a/src/routes/reference/jsx-attributes/bool.mdx
+++ b/src/routes/reference/jsx-attributes/bool.mdx
@@ -1,0 +1,30 @@
+---
+title: bool:*
+---
+
+It controls the presence of an attribute in an element.
+When the value is `truthy` it adds the `attribute` to the element.
+When the value is `falsy` it removes the `attribute` from the element.
+Mostly useful for Web Components.
+
+```tsx
+<my-element bool:status={prop.value} />
+```
+
+Assuming `prop.value` is `truthy`, then it becomes
+
+```tsx
+<my-element status />
+```
+
+And when `falsy`
+
+```tsx
+<my-element bool:status={""} />
+```
+
+Becomes
+
+```tsx
+<my-element />
+```

--- a/src/routes/reference/jsx-attributes/bool.mdx
+++ b/src/routes/reference/jsx-attributes/bool.mdx
@@ -5,7 +5,7 @@ title: bool:*
 `bool:*` controls the presence of an attribute in an element.
 When the value is `truthy` it adds the `attribute` to the element.
 Alternatively, when the value is `falsy` it removes the `attribute` from the element.
-Mostly useful for Web Components.
+This attribute is most useful for Web Components.
 
 ```tsx
 <my-element bool:status={prop.value} />

--- a/src/routes/reference/jsx-attributes/bool.mdx
+++ b/src/routes/reference/jsx-attributes/bool.mdx
@@ -11,20 +11,11 @@ Mostly useful for Web Components.
 <my-element bool:status={prop.value} />
 ```
 
-Assuming `prop.value` is `truthy`, then it becomes
-
 ```tsx
+// Assuming `prop.value` is `truthy`, then it becomes
 <my-element status />
-```
 
-And when `falsy`
-
-```tsx
-<my-element bool:status={""} />
-```
-
-Becomes
-
-```tsx
+// And when `falsy`, then it becomes
 <my-element />
+
 ```

--- a/src/routes/reference/jsx-attributes/data.json
+++ b/src/routes/reference/jsx-attributes/data.json
@@ -3,6 +3,7 @@
 	"pages": [
 		"attr.mdx",
 		"classlist.mdx",
+		"bool.mdx",
 		"innerhtml-or-textcontent.mdx",
 		"on_.mdx",
 		"on-and-oncapture.mdx",


### PR DESCRIPTION
Documents possible upcoming feature that may be added to the next solid version.  

`bool:` it controls the presence of an attribute by evaluating a value to truthy.

Note: should be merged only if the feature actually lands

Thanks!