### PR TITLE
improve translations docs by expanding on current instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,20 +131,16 @@ Though it is not a hard requirement, we'd deeply appreciate if you could recomme
 
 #### Adding support to a new language
 
-1. Create a dictionary file in `src/i18n/dictionaries`. The name should follow our locale convention.
+1. Create a dictionary file in `src/i18n/dictionaries/{locale}/ui.ts`. The name should follow our locale convention.
 
-   - language (ISO 639-1 - set 1): https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
+  - language (ISO 639-1 - set 1): https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
+  - country code(optional) (ISO 3166-1 alpha-2): https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+  - E.g.: Canadian French would be: `fr-ca` 
 
-- country code (ISO 3166-1 alpha-2): https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
-
-- E.g.: Canadian French would be: `fr-ca`
-
-2. Add it to the barrel file: `src/i18n/dictionaries/index.ts`. So it will be identified by the routing system.
-
-3. Add the important UI translations.
-
-> [!TIP]
-> To save time, you can use chatGPT to translate the `default.ts` dictionary to the language and adjust based on context.
+2. Add the `import` and language information to the objects in the barrel file: `./src/i18n/dictionaries/index.ts`. So it will be identified by the routing system, and an entry its added to the language dropdown.
+3. Add the language to the `array` in `./scripts/collections/index.mjs` so internal files are created.
+4. Add the important UI translations to `./src/i18n/dictionaries/{locale}/ui.ts` 
+5. Add at least the index page `./src/routes/{locale}/index.mdx`, so others and yourself could see things in action.
 
 #### Adding translations to a supported language
 


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x ] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->
There's this pr about adding some Spanish translation https://github.com/solidjs/solid-docs/pull/762

I pulled that PR and tried it in localhost, having faced some issues I've added more details about how to get a language running, because I was trying to actually see the added translation on the local version of the site.

Additionally, I've removed the ChatGPT tip because it was getting in the way of the instructions and more importantly, I don't think encouraging machine translation is a good idea. Specially when you can't read the language.

### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
