### PR TITLE
remove hardcoded Solid-Router version from docs

### DIFF
--- a/src/routes/solid-router/index.mdx
+++ b/src/routes/solid-router/index.mdx
@@ -5,7 +5,7 @@ title: Overview
 # Overview
 
 <Callout title="Prerequisites">
-	The docs are based on Solid Router v0.10.x.
+	The docs are based on latest Solid-Router.
 	To use this version, you need to have Solid v1.8.4 or later installed.
 </Callout>
 


### PR DESCRIPTION
We're currently on version `0.14.x`, so the docs are outdated and wrong. Our APIs is kept in sync with the latest release.