### PR TITLE
Add keyboard focus indicator

### DIFF
--- a/src/ui/layout/main-navigation.tsx
+++ b/src/ui/layout/main-navigation.tsx
@@ -172,7 +172,7 @@ export function MainNavigation(props: NavProps) {
 						<Tabs.List class="sticky top-0 grid grid-cols-2 w-full z-10 md:dark:bg-slate-900 md:bg-slate-50">
 							<Tabs.Trigger
 								value="learn"
-								class="inline-block py-3 outline-none hover:bg-blue-500/30 dark:hover:bg-blue-300/20 dark:focus-visible:bg-blue-800 dark:text-slate-100 font-medium"
+								class="inline-block py-3 outline-none hover:bg-blue-500/30 focus-visible:bg-blue-500/40 dark:hover:bg-blue-300/20 dark:focus-visible:bg-blue-800 dark:text-slate-100 font-medium"
 								onClick={() => {
 									setSelectedTab("learn");
 								}}
@@ -181,7 +181,7 @@ export function MainNavigation(props: NavProps) {
 							</Tabs.Trigger>
 							<Tabs.Trigger
 								value="reference"
-								class="inline-block py-3 outline-none hover:bg-blue-500/30 dark:hover:bg-blue-300/20 dark:focus-visible:bg-blue-800 dark:text-slate-100 font-medium"
+								class="inline-block py-3 outline-none hover:bg-blue-500/30 focus-visible:bg-blue-500/40 dark:hover:bg-blue-300/20 dark:focus-visible:bg-blue-800 dark:text-slate-100 font-medium"
 								onClick={() => {
 									setSelectedTab("reference");
 								}}


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description (required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do? -->
Added `focus-visible:bg-blue-500/40` to the "Learn" and "Reference" tabs.

### Related issues & labels
- Closes #899
- Suggested label(s) (optional): 'enhancement', 'accessibility'

### Comments
Unfortunately, I couldn't launch the site locally due to the following error, which was already mentioned on [Discord](https://discord.com/channels/722131463138705510/1284824315002621973/1284826341388189757).
```
[vite] Error when evaluating SSR module /src/ui/search.tsx:
|- Error: Endpoint and API Key are required to create a Profile
    at new H (file:///Users/nycheporuk/Projects/solid-docs/node_modules/.pnpm/@oramacloud+client@1.3.16_typescript@5.6.2_zod@3.23.8/node_modules/@oramacloud/client/dist/index.js:5:5300)
    at new Ye (file:///Users/nycheporuk/Projects/solid-docs/node_modules/.pnpm/@oramacloud+client@1.3.16_typescript@5.6.2_zod@3.23.8/node_modules/@oramacloud/client/dist/index.js:5:6855)
    at getOramaClient (/Users/nycheporuk/Projects/solid-docs/src/ui/search.tsx:27:10)
    at eval (/Users/nycheporuk/Projects/solid-docs/src/ui/search.tsx:32:16)
    at async instantiateModule (file:///Users/nycheporuk/Projects/solid-docs/node_modules/.pnpm/vite@5.4.7_@types+node@20.16.5_terser@5.33.0/node_modules/vite/dist/node/chunks/dep-DG6Lorbi.js:52914:5)
```
To address this, I created a mini app with the same color scheme to select a suitable focus background color.
Focus ⬇️  hover ⬇️
<img width="162" alt="image" src="https://github.com/user-attachments/assets/8e2dfcda-4d7e-4eca-87d4-f401be691fcb">
