### PR TITLE
Docs(stores): Add callout and example for nested stores

### DIFF
--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -209,7 +209,7 @@ This separation facilitates the tracking and control of the components that are 
 
   const [users, setUsers] = createStore(store.users)
 
-  setStore((currentUsers) => [
+  setUsers((currentUsers) => [
     ...currentUsers,
     {
       id: 3,
@@ -220,6 +220,7 @@ This separation facilitates the tracking and control of the components that are 
   ])
 
 ```
+  Changes made through `setUsers` will update the `store.users` property and reading `users` from this derived store will also be in sync with the values from `store.users`.
 
   Note that the above relies on `store.users` to be set already in the existing store.
 

--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -260,9 +260,11 @@ setStore("users", [1, 3], "loggedIn", false)
 ```
 
     <Callout>
-    If your *store* is array, you can specify a range of indices using an object with `from` and `to` keys.
+    If your *store* is an array, you can specify a range of indices using an object with `from` and `to` keys.
 
 ```jsx
+const [store, setStore] = createStore([]) // A store that is an array
+...
 setStore({ from: 1, to: store.length - 1 }, "loggedIn", false)
 ```
 

--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -198,6 +198,32 @@ Separating the read and write capabilities of a store provides a valuable debugg
 
 This separation facilitates the tracking and control of the components that are accessing or changing the values.
 </Callout>
+<Callout type="advanced">
+  A little hidden feature of stores is that you can also create nested stores to help with setting nested properties.
+
+```jsx
+  const [store, setStore] = createStore({
+    userCount: 3,
+    users: [ ... ],
+  })
+
+  const [users, setUsers] = createStore(store.users)
+
+  setStore((currentUsers) => [
+    ...currentUsers,
+    {
+      id: 3,
+      username: "michael584",
+      location: "Nigeria",
+      loggedIn: false,
+    },
+  ])
+
+```
+
+  Note that the above relies on `store.users` to be set already in the existing store.
+
+</Callout>
 
 ## Path syntax flexibility
 


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
Clarifies a bit more about the array range syntax for array stores to help make it more clear what we mean by "if your store is an array" (confusion in [recent conversation](https://discord.com/channels/722131463138705510/722131463889223772/1289263061395574929))

Adds a callout for an advanced tip for users to be able to create nested stores to create nested setters. Added an example for users to follow as well. I chose to mark it as "advanced" because I'm not fully aware of any pitfalls of this approach.

### Related issues & labels

- Closes #618 
