### PR TITLE
Typo: Add possessive apostrophe in actions.mdx

### DIFF
--- a/src/routes/solid-router/concepts/actions.mdx
+++ b/src/routes/solid-router/concepts/actions.mdx
@@ -3,7 +3,7 @@ title: "Actions"
 ---
 
 When developing applications, it is common to need to communicate new information to the server based on user interactions.
-Actions are Solid Routers solution to this problem.
+Actions are Solid Router’s solution to this problem.
 
 ## What are actions?
 


### PR DESCRIPTION
“Solid Routers” should be possessive.

<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->
Current:
> Actions are Solid Routers solution to this problem.

An apostrophe should be added before the s and it is a possessive instead of a plural.