### PR TITLE
Fix reference collection

### DIFF
--- a/scripts/collections/build-file-tree.mjs
+++ b/scripts/collections/build-file-tree.mjs
@@ -24,11 +24,21 @@ export async function buildFileTree(entry = COLLECTIONS_ROOT) {
 				})
 			);
 
+			const children = entryPath.includes("/reference/")
+				? nested
+						.filter(Boolean)
+						.sort((firstChild, secondChild) =>
+							firstChild.title
+								.toLowerCase()
+								.localeCompare(secondChild.title.toLowerCase())
+						)
+				: nested.filter(Boolean);
+
 			return {
 				type: "section",
 				title: info.title,
 				pages: info.pages,
-				children: nested.filter(Boolean),
+				children,
 			};
 		} else if (!entryPath.includes("data.json")) {
 			const file = await fs.readFile(entryPath, "utf-8");

--- a/src/ui/docs-layout.tsx
+++ b/src/ui/docs-layout.tsx
@@ -14,14 +14,13 @@ interface DocsLayoutProps {
 export const DocsLayout = (props: DocsLayoutProps) => {
 	const location = useLocation();
 
-	const lastSegmentPath = () => location.pathname.split("/").reverse()[0];
 	const collection = () =>
 		location.pathname.includes("/reference/")
 			? props.entries.reference
 			: props.entries.learn;
 
 	const entryIndex = () =>
-		collection()!.findIndex((element) => lastSegmentPath() === element.slug);
+		collection()!.findIndex((element) => location.pathname === element.path);
 
 	const titles = () => {
 		const fullEntry = collection


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
Two changes were made in this PR, both in regards to the reference collection.

The first change fixes a bug in the DocsLayout, which can lead to a wrong title and pagination being displayed, as you can see here:
https://docs.solidjs.com/reference/reactive-utilities/on

Instead of showing the title and pagination for the reactive utility "on", the docs page shows that for the JSX attribute "on:*".  
The entryIndex is only comparing the slug value of the given reference entries, which is not unique ("on" for both entries).
The fix matches the entire location.pathname to the element.path to find the correct collection item.
Both the learn and reference collections are impacted by this change.

The second change matches the child order of the reference collection to the alphabetically ordered reference navbar, by sorting the entries by title.

It was possible that the pagination would not link to the next and/or previous reference docs page in the navbar, see here:
https://docs.solidjs.com/reference/jsx-attributes/once

The pagination should link to the pages "Switch Match" and "attr:*", since these are the surrounding elements in the navbar, but instead links to "on:*" and "prop:*".
This change does not effect the learn collection. Only the reference navbar is getting sorted alphabetically (see src/ui/layout/main-navigation.tsx).