### PR TITLE
fix: unkeyed show argument

### DIFF
--- a/src/routes/reference/components/show.mdx
+++ b/src/routes/reference/components/show.mdx
@@ -9,11 +9,11 @@ The Show control flow is used to conditional render part of the view: it renders
 import { Show } from "solid-js"
 import type { JSX } from "solid-js"
 
-function Show<T>(props: {
+function Show<T, K>(props: {
 	when: T | undefined | null | false
 	keyed: boolean
 	fallback?: JSX.Element
-	children: JSX.Element | ((item: T) => JSX.Element)
+	children: JSX.Element | ((item: T | Accessor<T>) => JSX.Element)
 }): () => JSX.Element
 ```
 
@@ -32,6 +32,8 @@ Show can also be used as a way of keying blocks to a specific data model. For ex
 	{(user) => <div>{user.firstName}</div>}
 </Show>
 ```
+
+If the `keyed` property is not used, the argument of a child function will be an accessor containing the item.
 
 ## Props
 


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

The reference for Show does not document the unkeyed function argument being an accessor.

### Related issues & labels

- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->bug
