### PR TITLE
docs: format code in examples in `guides/fetching-data.mdx`

### DIFF
--- a/src/routes/guides/fetching-data.mdx
+++ b/src/routes/guides/fetching-data.mdx
@@ -34,8 +34,7 @@ When there is a change in the source signal, an internal fetch process is trigge
 ```jsx
 import { createSignal, createResource, Switch, Match, Show } from "solid-js";
 
-const fetchUser = async (id) =>
- {
+const fetchUser = async (id) => {
   const response = await fetch(`https://swapi.dev/api/people/${id}/`);
   return response.json();
 }
@@ -91,7 +90,7 @@ import { createSignal, createResource, Switch, Match, Suspense } from "solid-js"
 const fetchUser = async (id) => {
   const response = await fetch(`https://swapi.dev/api/people/${id}/`);
   return response.json();
- }
+}
 
 function App() {
   const [userId, setUserId] = createSignal();

--- a/src/routes/guides/fetching-data.mdx
+++ b/src/routes/guides/fetching-data.mdx
@@ -62,7 +62,6 @@ function App() {
           <div>{JSON.stringify(user())}</div>
         </Match>
       </Switch>
-
     </div>
   );
 }
@@ -105,7 +104,6 @@ function App() {
       onInput={(e) => setUserId(e.currentTarget.value)}
     />
       <Suspense fallback={<div>Loading...</div>}>
-
         <Switch>
           <Match when={user.error}>
             <span>Error: {user.error.message}</span>

--- a/src/routes/guides/fetching-data.mdx
+++ b/src/routes/guides/fetching-data.mdx
@@ -149,15 +149,19 @@ function TodoList() {
     <>
       <ul>
         <For each={tasks()}>
-          {task => (
+          {(task) => (
             <li>{task.name}</li>
           )}
         </For>
       </ul>
-      <button onClick={() => {
-        mutate((todos) => [...todos, "do new task"]) // add todo for user
-        // make a call to send to database
-      }}>Add Task</button>
+      <button
+        onClick={() => {
+          mutate((todos) => [...todos, "do new task"]); // add todo for user
+          // make a call to send to database
+        }}
+      >
+        Add Task
+      </button>
     </>
   );
 }


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description
This pull request improves the code formatting in the documentation examples.

### Related issues
- None

### Suggested labels 
- `typo or grammar fix`
