### PR TITLE
Fix minor typo for equivalent store usage

### DIFF
--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -340,9 +340,9 @@ setStore("users", 0, {
 
 // is equivalent to
 
-setStore("users", 1, (user) => ({
+setStore("users", 0, (user) => ({
 	...user,
-	id: 69420,
+	id: 109,
 }))
 ```
 


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description

Fixes a potential minor typo in the docs. If the store usage examples are to be equivalent, I think the user index and the ID should be the same as well. 

