### PR TITLE
Add deno option for new projects

### DIFF
--- a/src/routes/solid-start/getting-started.mdx
+++ b/src/routes/solid-start/getting-started.mdx
@@ -32,6 +32,12 @@ pnpm create solid
 bun create solid
 ```
 </div>
+
+<div id="deno">
+```bash frame="none"
+deno run -A npm:create-solid
+```
+</div>
 </TabsCodeBlocks>
 
 **2. Choose a template**


### PR DESCRIPTION
Adding deno as an option to create a new app:
- `deno run -A npm:create-solid`

After
<img width="708" alt="Screenshot 2024-10-31 at 18 15 49" src="https://github.com/user-attachments/assets/1a58f637-14e0-4620-a8a1-fdca789b7f1f">

Similar to:
- https://github.com/solidjs/solid-start/pull/1663