### PR TITLE
Fix pnpm command and first tsx example in typescript.mdx

### DIFF
--- a/src/routes/configuration/typescript.mdx
+++ b/src/routes/configuration/typescript.mdx
@@ -95,7 +95,7 @@ yarn dlx tsc --init
 
 <div id="pnpm">
 ```bash frame="none"
-pnpm dlx tsc --init
+pnpm tsc --init
 ```
 </div>
 
@@ -129,17 +129,17 @@ bunx tsc --init
 4. Create a TypeScript or `.tsx` file to test the setup.
 
 ```typescript
-import { type Component } from "solid-js"
+import { type Component } from "solid-js";
 
-function MyTsComponent(): JSX.Element {
+const MyTsComponent(): Component = () => {
 	return (
 		<div>
 			<h1>This is a TypeScript component</h1>
 		</div>
-	)
+	);
 }
 
-export default MyTsComponent
+export default MyTsComponent;
 ```
 
 If using an existing JavaScript component, import the TypeScript component:


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] (N/A) This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
`pnpm tsc` is the correct way to invoke the typescript compiler for pnpm. `pnpm dlx tsc` yields a "This is not the tsc command you are looking for" error message. Changed the function in the first tsx example to be type `Component` as imported, rather than returning the unimported `JSX.Element` type. Also added some semicolons.

### Related issues & labels
N/A
