### PR TITLE
Replace `load` with `preload`

### DIFF
--- a/src/i18n/dictionaries/en/ui.ts
+++ b/src/i18n/dictionaries/en/ui.ts
@@ -28,7 +28,7 @@ export default {
 	"main.nav.section.solid.router": "Solid-Router",
 	"main.nav.section.solid.router.components": "Components",
 	"main.nav.section.solid.router.data.apis": "Data APIs",
-	"main.nav.section.solid.router.load.functions": "Load Functions",
+	"main.nav.section.solid.router.preload.functions": "Preload Functions",
 	"main.nav.section.solid.router.primitives": "Primitives",
 	"main.nav.no.routes": "No routes found",
 

--- a/src/routes/guides/routing-and-navigation.mdx
+++ b/src/routes/guides/routing-and-navigation.mdx
@@ -463,7 +463,7 @@ function preloadUser({ params, location }) {
 The preload function is then passed in the `<Route>` definition:
 
 ```jsx
-<Route path="/users/:id" component={User} preload={loadUser} />
+<Route path="/users/:id" component={User} preload={preloadUser} />
 ```
 
 ---

--- a/src/routes/solid-router/guides/migration.mdx
+++ b/src/routes/solid-router/guides/migration.mdx
@@ -26,7 +26,7 @@ Removing the second way to define route components to reduce confusion and edge 
 ## `data` functions & `useRouteData`
 
 `data` functions & `useRouteData` have been replaced by a load mechanism.
-This allows link hover preloads, since the load function can be run as much as wanted without worrying about reactivity.
+This allows link hover preloads, since the preload function can be run as much as wanted without worrying about reactivity.
 
 This supports deduping/cache APIs which give more control over how things are cached.
 It also addresses TypeScript issues with getting the right types in the Component without `typeof` checks.
@@ -39,15 +39,15 @@ import { Route } from "@solidjs/router";
 
 const User = lazy(() => import("./pages/users/[id].js"));
 
-// load function
-function loadUser({ params, location }) {
+// preload function
+function preloadUser({ params, location }) {
 	const [user] = createResource(() => params.id, fetchUser);
 	return user;
 }
 
 // Pass it in the route definition
 <Router preload={false}>
-	<Route path="/users/:id" component={User} load={loadUser} />
+	<Route path="/users/:id" component={User} preload={preloadUser} />
 </Router>;
 ```
 

--- a/src/routes/solid-router/guides/migration.mdx
+++ b/src/routes/solid-router/guides/migration.mdx
@@ -35,7 +35,7 @@ That being said the old pattern can be reproduced by turning off preloads at the
 
 ```js
 import { lazy } from "solid-js";
-import { Route } from "@solidjs/router";
+import { Router, Route } from "@solidjs/router";
 
 const User = lazy(() => import("./pages/users/[id].js"));
 
@@ -54,13 +54,16 @@ function preloadUser({ params, location }) {
 And then in your component taking the page props and putting them in a Context.
 
 ```js
+import { createContext, useContext } from "solid-js";
+
+const UserContext = createContext();
+
 function User(props) {
-	<UserContext.Provider value={props.data}>
-		{/* my component content  */}
+	<UserContext.Provider value={props.data()}>
+		{/* my component content that includes <UserDetails /> in any depth  */}
 	</UserContext.Provider>;
 }
 
-// Somewhere else
 function UserDetails() {
 	const user = useContext(UserContext);
 	// render stuff

--- a/src/routes/solid-router/rendering-modes/ssr.mdx
+++ b/src/routes/solid-router/rendering-modes/ssr.mdx
@@ -14,4 +14,4 @@ import { Router } from "@solidjs/router";
 <Router url={isServer ? req.url : ""} />;
 ```
 
-Solid Router also provides a way to define a `load` function that loads parallel to the routes [render-as-you-fetch](https://epicreact.dev/render-as-you-fetch/).
+Solid Router also provides a way to define a `preload` function that loads parallel to the routes [render-as-you-fetch](https://epicreact.dev/render-as-you-fetch/).

--- a/src/routes/solid-start/building-your-application/data-loading.mdx
+++ b/src/routes/solid-start/building-your-application/data-loading.mdx
@@ -104,10 +104,10 @@ With this method, however, there are some caveats to be aware of:
 1. The [`preload`](/solid-router/reference/preload-functions/preload) function is called **once** per route, which is the first time the user comes to that route.
    Following that, the fine-grained resources that remain alive synchronize with state/url changes to refetch data when needed.
    If the data needs a refresh, the [`refetch`](/guides/fetching-data#refetch) function returned in the `createResource` can be used.
-2. Before the route is rendered, the `load` function is called.
+2. Before the route is rendered, the `preload` function is called.
    It does not share the same `context` as the route.
-   The context tree that is exposed to the `load` function is anything above the `Page` component.
-3. On both the server and the client, the `load` function is called.
+   The context tree that is exposed to the `preload` function is anything above the `Page` component.
+3. On both the server and the client, the `preload` function is called.
    The resources can avoid refetching if they serialized their data in the server render.
    The server-side render will only wait for the resources to fetch and serialize if the resource signals are accessed under a `Suspense` boundary.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

Replace `load` with `preload` because the `load` prop of the Route Component has changed, but it still remains in the documentation.

I fixed it by following the steps below:

1. Searched for all instances of 'load' in the document.
2. Reviewed the results and found those that refer to the `load` prop.
3. Replaced them with `preload`.

FYI:
- I wonder if I should not fix src/routes/solid-router/guides/migration.mdx, but I fixed it for now. If I should revert it, please let me know.

### Related issues & labels

- Closes #963 <!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
