### PR TITLE
Add deno instructions to quick-start

### DIFF
--- a/src/routes/quick-start.mdx
+++ b/src/routes/quick-start.mdx
@@ -13,7 +13,7 @@ Additionally, we offer a [JavaScript](https://stackblitz.com/github/solidjs/temp
 <Callout title="Prerequisites">
 
     - Familiarity with the command line
-    - Install [Node.js](https://nodejs.org/en)
+    - Install [Node.js](https://nodejs.org/en) or [Deno](https://deno.com)
 
 </Callout>
 
@@ -46,6 +46,12 @@ pnpm dlx degit solidjs/templates/js my-app
 <div id="bun">
 ```bash frame="none"
 bunx degit solidjs/templates/js my-app
+```
+</div>
+
+<div id="deno">
+```bash frame="none"
+deno -A npm:degit solidjs/templates/js my-app
 ```
 </div>
 </TabsCodeBlocks>
@@ -83,6 +89,12 @@ pnpm install
 bun install
 ```
 </div>
+
+<div id="deno">
+```bash frame="none"
+deno install
+```
+</div>
 </TabsCodeBlocks>
 
 4. Run the application:
@@ -109,6 +121,11 @@ pnpm dev
 <div id="bun">
 ```bash frame="none"
 bun dev
+```
+</div>
+<div id="deno">
+```bash frame="none"
+deno task dev
 ```
 </div>
 </TabsCodeBlocks>
@@ -144,6 +161,11 @@ pnpm dlx degit solidjs/templates/ts my-app
 bunx degit solidjs/templates/ts my-app
 ```
 </div>
+<div id="deno">
+```bash frame="none"
+deno -A npm:degit solidjs/templates/ts my-app
+```
+</div>
 </TabsCodeBlocks>
 
 2. Navigate to your application's directory:
@@ -178,6 +200,11 @@ pnpm install
 bun install
 ```
 </div>
+<div id="deno">
+```bash frame="none"
+deno install
+```
+</div>
 </TabsCodeBlocks>
 
 4. Run the application:
@@ -204,6 +231,11 @@ pnpm dev
 <div id="bun">
 ```bash frame="none"
 bun dev
+```
+</div>
+<div id="deno">
+```bash frame="none"
+deno task dev
 ```
 </div>
 </TabsCodeBlocks>


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

This PR adds Deno as an option for installing and then running projects with Solid. 

- Deno now appears alongside npm, yarn, pnpm, and bun in each of the command line snippets on the `/quick-start` page for creating and running JavaScript or TypeScript projects.
- Deno added as an optional prerequisite (as an alternative to Node)

Each suggestion has been tested and validated with Deno v2.1.2

### Related issues & labels

- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->  `good first issue`, `documentation`
