### PR TITLE
Fix Component typing typo

### DIFF
--- a/content/guides/how-to-guides/get-ready-for-solid/installation-and-setup.mdx
+++ b/content/guides/how-to-guides/get-ready-for-solid/installation-and-setup.mdx
@@ -6,7 +6,7 @@ Here we'll provide quick guides on how to setup and install your Solid app. We'l
 
 ## Installation
 
-Solid has some [vite templates](https://github.com/solidjs/templates) to get you started. To make use of them just run these commands:
+Solid has some [Vite templates](https://github.com/solidjs/templates) to get you started. To make use of them just run these commands:
 
 #### Javascript
 
@@ -42,7 +42,7 @@ In the command below you can replace `tailwindcss` with `windicss`, `sass` or `u
 
 <Aside>
   {" "}
-  For more templates visit our <Link href="https://github.com/solidjs/templates" target="_blank">vite templates GitHub repository</Link>
+  For more templates visit our <Link href="https://github.com/solidjs/templates" target="_blank">Vite templates GitHub repository</Link>
 </Aside>
 
 ## Setup Typescript In Pre-existing Solid Javascript Projects
@@ -111,14 +111,14 @@ If you used `tsc --init`, your `tsconfig.json` should have a lot of boilerplate,
 ```
 
 ```tsx
-// Mytscomponent.tsx
+// MyTsComponent.tsx
 
 import { Component } from "solid-js";
 
-function MyTsComponent(): Component {
+const MyTsComponent: Component = () => {
   return (
     <div>
-      <h1> This is a typescript component </h1>
+      <h1> This is a TypeScript component </h1>
     </div>
   );
 }
@@ -126,7 +126,7 @@ function MyTsComponent(): Component {
 export default MyTsComponent;
 ```
 
-Let's make use of our Typescript component in our Javascript component
+Let's make use of our TypeScript component in our JavaScript component
 
 ```jsx
 // MyJsComponent.jsx
@@ -155,7 +155,7 @@ Solid makes use of [Vite](https://vitejs.dev/) so making use of environment vari
 **Step 1:** Let's create a `.env` file and declare a value in it called `VITE_VARIABLE_NAME`
 
 ```
-VITE_VARIABLE_NAME="I am a vite environment variable"
+VITE_VARIABLE_NAME="I am a Vite environment variable"
 ```
 
 **Step 2:** Make use of the environment variable in your Solid app.


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

Type example component function as a `Component`, instead of typing the return value as `Component`.

Also fix some capitalization bugs.

### Related issues & labels

As reported in [this Discord thread](https://discord.com/channels/722131463138705510/1314135978532802560)
