### PR TITLE
Fix Component typing typo

### DIFF
--- a/src/routes/configuration/typescript.mdx
+++ b/src/routes/configuration/typescript.mdx
@@ -131,7 +131,7 @@ bunx tsc --init
 ```typescript
 import { type Component } from "solid-js";
 
-const MyTsComponent(): Component = () => {
+const MyTsComponent: Component = () => {
 	return (
 		<div>
 			<h1>This is a TypeScript component</h1>


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

Type example component function as a `Component`, instead of typing the return value as `Component`.

Also fix some capitalization bugs.

### Related issues & labels

As reported in [this Discord thread](https://discord.com/channels/722131463138705510/1314135978532802560)

(replacing #975)