### PR TITLE
Remove incorrect 'state' example from create-resource.mdx

### DIFF
--- a/src/routes/reference/basic-reactivity/create-resource.mdx
+++ b/src/routes/reference/basic-reactivity/create-resource.mdx
@@ -8,11 +8,11 @@ There are two ways to use `createResource`: you can pass the fetcher function as
 The source signal will retrigger the fetcher whenever it changes, and its value will be passed to the fetcher.
 
 ```tsx
-const [data, { mutate, refetch, state }] = createResource(fetchData)
+const [data, { mutate, refetch }] = createResource(fetchData)
 ```
 
 ```tsx
-const [data, { mutate, refetch, state }] = createResource(source, fetchData)
+const [data, { mutate, refetch }] = createResource(source, fetchData)
 ```
 
 In these snippets, the fetcher is the function `fetchData`, and `data()` is undefined until `fetchData` finishes resolving. 
@@ -49,7 +49,7 @@ async function fetchData(source, { value, refetching }) {
 	// or equal to the optional data passed: `refetch(info)`
 }
 
-const [data, { mutate, refetch, state }] = createResource(getQuery, fetchData)
+const [data, { mutate, refetch }] = createResource(getQuery, fetchData)
 
 // read value
 data()
@@ -102,7 +102,7 @@ You can use the new `ssrLoadFrom` option for this.
 Instead of using the default `server` value, you can pass `initial` and the resource will use `initialValue` as if it were the result of the first fetch for both SSR and hydration.
 
 ```tsx
-const [data, { mutate, refetch, state }] = createResource(() => params.id, fetchUser, {
+const [data, { mutate, refetch }] = createResource(() => params.id, fetchUser, {
 	initialValue: preloadedData,
 	ssrLoadFrom: "initial",
 })


### PR DESCRIPTION

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

Example code for createResource includes a `state` attribute on the second return value that is actually on the first.

### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): documentation
