### PR TITLE
Fix lazy loading example

### DIFF
--- a/src/routes/solid-router/advanced-concepts/lazy-loading.mdx
+++ b/src/routes/solid-router/advanced-concepts/lazy-loading.mdx
@@ -11,8 +11,10 @@ In Solid Router, you can lazy load components using the `lazy` function from Sol
 import { lazy } from "solid-js";
 import { Router, Route } from "@solidjs/router";
 
-const Home = () => import("./Home");
+const Home = lazy(() => import("./Home"));
+
 const Users = lazy(() => import("./Users"));
+
 const App = () => (
   <Router>
     <Route path="/" component={Home} />

--- a/src/routes/solid-router/advanced-concepts/lazy-loading.mdx
+++ b/src/routes/solid-router/advanced-concepts/lazy-loading.mdx
@@ -15,8 +15,8 @@ const Home = () => import("./Home");
 const Users = lazy(() => import("./Users"));
 const App = () => (
   <Router>
-    <Route path="/" component={<Home />} />
-    <Route path="/users" component={<Users />} />
+    <Route path="/" component={Home} />
+    <Route path="/users" component={Users} />
   </Router>
 );
 ```


### PR DESCRIPTION
Component invocations like `<Home />` are not supported by the Router.