### PR TITLE
Add Data Fetching Guide

### DIFF
--- a/src/routes/solid-start/data.json
+++ b/src/routes/solid-start/data.json
@@ -4,6 +4,7 @@
 		"index.mdx",
 		"getting-started.mdx",
 		"building-your-application",
-		"advanced"
+		"advanced",
+		"guides"
 	]
 }

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -2,9 +2,9 @@
 title: "Data Fetching"
 ---
 
-This guide will walk you through the basics of data fetching in SolidStart, providing practical examples and best practices.
+This guide provides practical examples for common data-fetching tasks in SolidStart.
 
-Here's a minimal example of data fetching in SolidStart:
+Here's a simple example:
 
 ```tsx title="src/routes/index.tsx"
 import { For } from "solid-js";

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -4,8 +4,6 @@ title: "Data Fetching"
 
 This guide will walk you through the basics of data fetching in SolidStart, providing practical examples and best practices.
 
-## Basics
-
 Here's a minimal example of data fetching in SolidStart:
 
 ```tsx title="src/routes/index.tsx"
@@ -13,225 +11,207 @@ import { For } from "solid-js";
 import { query, createAsync } from "@solidjs/router";
 
 const getPosts = query(async () => {
-  const posts = await fetch("https://my-api.com/blog");
-  return await posts.json();
+	const posts = await fetch("https://my-api.com/blog");
+	return await posts.json();
 }, "posts");
 
 export default function Page() {
-  const posts = createAsync(() => getPosts());
-  return (
-    <ul>
-      <For each={posts()}>{(post) => <li>{post.title}</li>}</For>
-    </ul>
-  );
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+		</ul>
+	);
 }
 ```
-
-This example demonstrates a basic data fetching using [`query`](https://docs.solidjs.com/solid-router/reference/data-apis/query) and [`createAsync`](https://docs.solidjs.com/solid-router/reference/data-apis/create-async).
-
-
-<Callout type="info">
-  Note that `query` and `createAsync` are imported from `@solidjs/router`. By default, SolidStart uses [Solid Router](https://docs.solidjs.com/solid-router) under the hood. That means we can take advantage of all Solid Router data fetching primitives in SolidStart.
-</Callout>
 
 ## Reference
 
 - Solid Router [`query`](https://docs.solidjs.com/solid-router/reference/data-apis/query)
 - Solid Router [`createAsync`](https://docs.solidjs.com/solid-router/reference/data-apis/create-async)
+- Solid Router [`preload`](https://docs.solidjs.com/solid-router/reference/preload-functions/preload)
 - Solid [`createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource)
+- Solid [`<Suspense>`](https://docs.solidjs.com/reference/components/suspense)
+- Solid [`<ErrorBoundary>`](https://docs.solidjs.com/reference/components/error-boundary)
 
-## Examples
+## How to show loading UI
 
-### Preloading Data
+To show a loading UI while data is fetching, you can use [Solid `<Suspense>`](https://docs.solidjs.com/reference/components/suspense):
 
-You can use the [`preload`](https://docs.solidjs.com/solid-router/reference/preload-functions/preload) function to preload a query:
-
-```tsx title="src/routes/index.tsx"
-import { For } from "solid-js";
-import { query, createAsync, type RouteDefinition } from "@solidjs/router";
-
-const getPosts = query(async () => {
-  const posts = await fetch("https://my-api.com/blog");
-  return await posts.json();
-}, "posts");
-
-export const route = {
-  preload: () => getPosts(),
-} satisfies RouteDefinition;
-
-export default function Page() {
-  const posts = createAsync(() => getPosts());
-  return (
-    <ul>
-      <For each={posts()}>{(post) => <li>{post.title}</li>}</For>
-    </ul>
-  );
-}
-```
-
-In this example, we call `getPosts` inside the `preload` function, and because we have used `query` the result is cached and becomes immediately available in the component.
-
-The `preload` function runs in parallel with route loading. This happens when:
-
-- A user visits the route for the first time
-- A user hovers over a link to the route
-
-### Server-Only Queries
-
-By default, queries can run on both the server and client. Add [`"use server"`](https://docs.solidjs.com/solid-start/reference/server/use-server) to make a query run only on the server:
-
-```tsx {6} title="src/routes/index.tsx"
-import { For } from "solid-js";
-import { query, createAsync, type RouteDefinition } from "@solidjs/router";
-import { db } from "~/lib/db";
-
-const getPosts = query(async () => {
-  "use server";
-  const posts = await db.from("posts").select();
-  return await posts.json();
-}, "posts");
-
-export const route = {
-  preload: () => getPosts(),
-} satisfies RouteDefinition;
-
-export default function Page() {
-  const posts = createAsync(() => getPosts());
-  return (
-    <ul>
-      <For each={posts()}>{(post) => <li>{post.title}</li>}</For>
-    </ul>
-  );
-}
-```
-
-Because `getPosts` only runs on the server, it's safe to access your database directly.
-
-### Parameterized Queries
-
-Here's how to create queries that accept parameters:
-
-```tsx title="src/routes/posts/[id]/index.tsx"
-import {
-  query,
-  createAsync,
-  useParams,
-  type RouteDefinition,
-} from "@solidjs/router";
-
-const getPost = query(async (id: string) => {
-  const post = await fetch(`https://my-api.com/blog/posts/${id}`);
-  return await post.json();
-}, "post");
-
-export const route = {
-  preload: ({ params }) => getPost(params.id),
-} satisfies RouteDefinition;
-
-export default function Page() {
-  const params = useParams();
-  const post = createAsync(() => getPost(params.id));
-  return <div>{post().title}</div>;
-}
-```
-
-### Loading UI
-
-You can use [Solid `<Suspense>`](https://docs.solidjs.com/reference/components/suspense) to show an instant loading state while SolidStart streams in the result.
-
-```tsx title="src/routes/index.tsx"
+```tsx {1} {14} {16} title="src/routes/index.tsx"
 import { Suspense, For } from "solid-js";
 import { query, createAsync } from "@solidjs/router";
 
 const getPosts = query(async () => {
-  const posts = await fetch("https://my-api.com/blog");
-  return await posts.json();
+	const posts = await fetch("https://my-api.com/blog");
+	return await posts.json();
 }, "posts");
 
 export default function Page() {
-  const posts = createAsync(() => getPosts());
-  return (
-    <ul>
-      {/* Show a fallback while the data is fetching. */}
-      <Suspense fallback={<div>Loading...</div>}>
-        <For each={posts()}>{(post) => <li>{post.title}</li>}</For>
-      </Suspense>
-    </ul>
-  );
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			{/* Show a fallback while the data is fetching. */}
+			<Suspense fallback={<div>Loading...</div>}>
+				<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+			</Suspense>
+		</ul>
+	);
 }
 ```
 
-This will prevent the whole component from being blocked by data requests, and the user will be able to interact with the parts of the page that are ready.
+## How to handle errors
 
-### Error Handling
+To show a fallback in case data fetching fails, you can use [Solid `<ErrorBoundary>`](https://docs.solidjs.com/reference/components/error-boundary) .
 
-You can use [Solid `<ErrorBoundary>`](https://docs.solidjs.com/reference/components/error-boundary) to show a fallback in case data fetching fails.
+```tsx {1} {14} {18} title="src/routes/index.tsx"
+import { ErrorBoundary, Suspense, For } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
 
-```tsx title="src/routes/index.tsx"
-import { ErrorBoundary, For } from "solid-js";
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/blog");
+	return await posts.json();
+}, "posts");
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			{/* Show a fallback while the data is fetching. */}
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<Suspense fallback={<div>Loading...</div>}>
+					<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+				</Suspense>
+			</ErrorBoundary>
+		</ul>
+	);
+}
+```
+
+## How to preload data
+
+To optimize data fetching during user navigation, you can [`preload`](https://docs.solidjs.com/solid-router/reference/preload-functions/preload) to preload a query:
+
+```tsx {2} {9-11} title="src/routes/index.tsx"
+import { ErrorBoundary } from "solid-js";
 import { query, createAsync, type RouteDefinition } from "@solidjs/router";
 
 const getPosts = query(async () => {
-  const posts = await fetch("https://my-api.com/blog");
-  return await posts.json();
+	const posts = await fetch("https://my-api.com/blog");
+	return await posts.json();
 }, "posts");
 
 export const route = {
-  preload: () => getPosts(),
+	preload: () => getPosts(),
 } satisfies RouteDefinition;
 
 export default function Page() {
-  const posts = createAsync(() => getPosts());
-  return (
-    <ul>
-      {/* Show a fallback while the data is fetching. */}
-      <ErrorBoundary fallback={<div>Something went wrong!</div>}>
-        <For each={posts()}>{(post) => <li>{post.title}</li>}</For>
-      </ErrorBoundary>
-    </ul>
-  );
+	const post = createAsync(() => getPosts());
+	return (
+		<div>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<h1>{post().title}</h1>
+			</ErrorBoundary>
+		</div>
+	);
 }
 ```
 
-### Client-Side Data Fetching
+## How to create parameterized queries
 
-While `createAsync` is the recommended way to fetch data, sometimes you need client-side only fetching. For these cases, use the [`createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource) primitive:
+To create a query that accept parameters, you can pass any number of arguments to your query function:
 
-```tsx title="src/routes/index.tsx"
+```tsx {9-10} {15} {19-20} title="src/routes/posts/[id]/index.tsx"
+import { ErrorBoundary } from "solid-js";
+import {
+	query,
+	createAsync,
+	useParams,
+	type RouteDefinition,
+} from "@solidjs/router";
+
+const getPost = query(async (id: string) => {
+	const post = await fetch(`https://my-api.com/blog/posts/${id}`);
+	return await post.json();
+}, "post");
+
+export const route = {
+	preload: ({ params }) => getPost(params.id),
+} satisfies RouteDefinition;
+
+export default function Page() {
+	const params = useParams();
+	const post = createAsync(() => getPost(params.id));
+	return (
+		<div>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<h1>{post().title}</h1>
+			</ErrorBoundary>
+		</div>
+	);
+}
+```
+
+## How to directly use database or an ORM
+
+To directly use your database or ORM in a query, add [`"use server"`](https://docs.solidjs.com/solid-start/reference/server/use-server) to your query function:
+
+```tsx {7} title="src/routes/index.tsx"
+import { For, ErrorBoundary } from "solid-js";
+import { query, createAsync, type RouteDefinition } from "@solidjs/router";
+import { db } from "~/lib/db";
+
+// This query only executes on the server
+const getPosts = query(async () => {
+	"use server";
+	const posts = await db.from("posts").select();
+	return await posts.json();
+}, "posts");
+
+export const route = {
+	preload: () => getPosts(),
+} satisfies RouteDefinition;
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+			</ErrorBoundary>
+		</ul>
+	);
+}
+```
+
+## How to use `createResource` for client-side fetching
+
+To fetch data only on the client side, you can use the [`createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource) primitive:
+
+```tsx {1} {4-7} title="src/routes/index.tsx"
 import { createResource, ErrorBoundary, Suspense, For } from "solid-js";
 
 export default function Page() {
-  const [posts] = createResource(async () => {
-    const posts = await fetch("https://my-api.com/blog");
-    return await posts.json();
-  });
+	const [posts] = createResource(async () => {
+		const posts = await fetch("https://my-api.com/blog");
+		return await posts.json();
+	});
 
-  return (
-    <ul>
-      {/* Optional: show a fallback while the data is fetching. */}
-      <ErrorBoundary fallback={<div>Something went wrong!</div>}>
-        {/* Optional: Show a fallback while the data is fetching. */}
-        <Suspense fallback={<div>Loading...</div>}>
-          <For each={posts()}>{(post) => <li>{post.title}</li>}</For>
-        </Suspense>
-      </ErrorBoundary>
-    </ul>
-  );
+	return (
+		<ul>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<Suspense fallback={<div>Loading...</div>}>
+					<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+				</Suspense>
+			</ErrorBoundary>
+		</ul>
+	);
 }
 ```
 
-You can use [`<Suspense>`](https://docs.solidjs.com/reference/components/suspense) and [`<ErrorBoundary>`](https://docs.solidjs.com/reference/components/error-boundary) for showing loading UI and handling errors.
+## When to use Tanstack Query
 
-Be aware that you should not use `query` with `useResource`.
-
-<Callout type="caution">
-  `query` should not be used with `useResource`.
-</Callout>
-
-
-## Using Tanstack Query
-
-Consider [Tanstack Query](https://tanstack.com/query/latest) if you need advanced features like automatic background refetching or infinite queries. It's particularly appealing if you're already familiar with it from other projects. However, keep in mind that it will increase your bundle size slightly.
+Consider [Tanstack Query](https://tanstack.com/query/latest) if you need advanced features like automatic background re-fetching or infinite queries. It's particularly appealing if you're already familiar with it from other projects. However, keep in mind that it will increase your bundle size slightly.
 
 Here is a basic example of using Tanstack Query:
 
@@ -241,26 +221,24 @@ import { useParams } from "@solidjs/router";
 import { createQuery } from "@tanstack/solid-query";
 
 export default function Page() {
-  const params = useParams();
-  const postQuery = createQuery(() => ({
-    queryKey: ["posts", params.id],
-    queryFn: async (id: string) => {
-      const post = await fetch(`https://my-api.com/posts/${id}`);
-      return await post.json();
-    },
-    throwOnError: true,
-  }));
+	const params = useParams();
+	const postQuery = createQuery(() => ({
+		queryKey: ["posts", params.id],
+		queryFn: async (id: string) => {
+			const post = await fetch(`https://my-api.com/posts/${id}`);
+			return await post.json();
+		},
+		throwOnError: true,
+	}));
 
-  return (
-    <div>
-      {/* Optional: show a fallback while the data is fetching. */}
-      <ErrorBoundary fallback={<div>Something went wrong!</div>}>
-        {/* Optional: Show a fallback while the data is fetching. */}
-        <Suspense fallback={<div>Loading...</div>}>
-          <div>{postQuery.data?.name}</div>
-        </Suspense>
-      </ErrorBoundary>
-    </div>
-  );
+	return (
+		<div>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<Suspense fallback={<div>Loading...</div>}>
+					<div>{postQuery.data?.name}</div>
+				</Suspense>
+			</ErrorBoundary>
+		</div>
+	);
 }
 ```

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -27,15 +27,6 @@ export default function Page() {
 
 In this example, a [`query`](/solid-router/reference/data-apis/query) is created. In order to access it's data within the component, the [`createAsync`](/solid-router/reference/data-apis/create-async) primitive was used.
 
-## Reference
-
-- Solid Router [`query`](https://docs.solidjs.com/solid-router/reference/data-apis/query)
-- Solid Router [`createAsync`](https://docs.solidjs.com/solid-router/reference/data-apis/create-async)
-- Solid Router [`preload`](https://docs.solidjs.com/solid-router/reference/preload-functions/preload)
-- Solid [`createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource)
-- Solid [`<Suspense>`](https://docs.solidjs.com/reference/components/suspense)
-- Solid [`<ErrorBoundary>`](https://docs.solidjs.com/reference/components/error-boundary)
-
 ## Showing loading UI
 
 To display a loading UI while data is being fetched, you can use [Solid `<Suspense>`](/reference/components/suspense):
@@ -220,7 +211,7 @@ export default function Page() {
 }
 ```
 
-You can [read more about `createResource` here](/reference/basic-reactivity/create-resource) .
+You can [read more about `createResource` here](/reference/basic-reactivity/create-resource).
 
 <Callout type="info" title="Advanced Data Handling">
     For advanced features like automatic background re-fetching or infinite queries, you can use [Tanstack Query.](https://tanstack.com/query/latest/docs/framework/solid/overview)

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -25,6 +25,8 @@ export default function Page() {
 }
 ```
 
+In this example, we created a [`query`](https://docs.solidjs.com/solid-router/reference/data-apis/query) and [`createAsync`](https://docs.solidjs.com/solid-router/reference/data-apis/create-async) primitive to access the query data inside our component.
+
 ## Reference
 
 - Solid Router [`query`](https://docs.solidjs.com/solid-router/reference/data-apis/query)
@@ -36,9 +38,13 @@ export default function Page() {
 
 ## How to show loading UI
 
-To show a loading UI while data is fetching, you can use [Solid `<Suspense>`](https://docs.solidjs.com/reference/components/suspense):
+To show a loading UI while data is loading, you can use [Solid `<Suspense>`](https://docs.solidjs.com/reference/components/suspense):
 
-```tsx {1} {14} {16} title="src/routes/index.tsx"
+1. Import `Suspense` from `solid-js`
+2. Wrap the data rendering in `<Suspense>`
+3. Provide a fallback component that will be displayed while the data is loading using the `fallback` prop
+
+```tsx {1} {13} {15} title="src/routes/index.tsx"
 import { Suspense, For } from "solid-js";
 import { query, createAsync } from "@solidjs/router";
 
@@ -51,7 +57,6 @@ export default function Page() {
 	const posts = createAsync(() => getPosts());
 	return (
 		<ul>
-			{/* Show a fallback while the data is fetching. */}
 			<Suspense fallback={<div>Loading...</div>}>
 				<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
 			</Suspense>
@@ -62,9 +67,13 @@ export default function Page() {
 
 ## How to handle errors
 
-To show a fallback in case data fetching fails, you can use [Solid `<ErrorBoundary>`](https://docs.solidjs.com/reference/components/error-boundary) .
+To show a fallback UI in case data fetching fails, you can use [Solid `<ErrorBoundary>`](https://docs.solidjs.com/reference/components/error-boundary):
 
-```tsx {1} {14} {18} title="src/routes/index.tsx"
+1. Import `ErrorBoundary` from `solid-js`.
+2. Wrap the data rendering in `<ErrorBoundary>`
+3. Provide a fallback component that will be displayed if an error occurs using the `fallback` prop.
+
+```tsx {1} {13} {17} title="src/routes/index.tsx"
 import { ErrorBoundary, Suspense, For } from "solid-js";
 import { query, createAsync } from "@solidjs/router";
 
@@ -77,7 +86,6 @@ export default function Page() {
 	const posts = createAsync(() => getPosts());
 	return (
 		<ul>
-			{/* Show a fallback while the data is fetching. */}
 			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
 				<Suspense fallback={<div>Loading...</div>}>
 					<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
@@ -90,7 +98,11 @@ export default function Page() {
 
 ## How to preload data
 
-To optimize data fetching during user navigation, you can [`preload`](https://docs.solidjs.com/solid-router/reference/preload-functions/preload) to preload a query:
+To optimize data fetching during user navigation, you can use [`preload`](https://docs.solidjs.com/solid-router/reference/preload-functions/preload) to preload a query:
+
+1. Export a `route` object with a `preload` function
+2. Run your query inside the `preload` function
+3. Use the query as usual in your component
 
 ```tsx {2} {9-11} title="src/routes/index.tsx"
 import { ErrorBoundary } from "solid-js";
@@ -119,7 +131,7 @@ export default function Page() {
 
 ## How to create parameterized queries
 
-To create a query that accept parameters, you can pass any number of arguments to your query function:
+To create a query that accepts parameters, you can pass any number of arguments to your query function:
 
 ```tsx {9-10} {15} {19-20} title="src/routes/posts/[id]/index.tsx"
 import { ErrorBoundary } from "solid-js";
@@ -152,20 +164,20 @@ export default function Page() {
 }
 ```
 
+In this example, we used [`useParams`](https://docs.solidjs.com/solid-router/reference/primitives/use-params) to get the `id` path parameter and passed it to the `getPost` query to get the data for that specific post.
+
 ## How to directly use database or an ORM
 
-To directly use your database or ORM in a query, add [`"use server"`](https://docs.solidjs.com/solid-start/reference/server/use-server) to your query function:
+To directly use your database or ORM in a query, you should make the query server-only so your database credentials are not exposed to the client. You can do that by adding [`"use server"`](https://docs.solidjs.com/solid-start/reference/server/use-server) to the first line of your query function:
 
-```tsx {7} title="src/routes/index.tsx"
+```tsx {3} {6-7} title="src/routes/index.tsx"
 import { For, ErrorBoundary } from "solid-js";
 import { query, createAsync, type RouteDefinition } from "@solidjs/router";
 import { db } from "~/lib/db";
 
-// This query only executes on the server
 const getPosts = query(async () => {
 	"use server";
-	const posts = await db.from("posts").select();
-	return await posts.json();
+	return await db.from("posts").select();
 }, "posts");
 
 export const route = {
@@ -196,7 +208,6 @@ export default function Page() {
 		const posts = await fetch("https://my-api.com/blog");
 		return await posts.json();
 	});
-
 	return (
 		<ul>
 			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
@@ -209,36 +220,6 @@ export default function Page() {
 }
 ```
 
-## When to use Tanstack Query
-
-Consider [Tanstack Query](https://tanstack.com/query/latest) if you need advanced features like automatic background re-fetching or infinite queries. It's particularly appealing if you're already familiar with it from other projects. However, keep in mind that it will increase your bundle size slightly.
-
-Here is a basic example of using Tanstack Query:
-
-```tsx title="src/routes/posts/[id]/index.tsx"
-import { ErrorBoundary, Suspense } from "solid-js";
-import { useParams } from "@solidjs/router";
-import { createQuery } from "@tanstack/solid-query";
-
-export default function Page() {
-	const params = useParams();
-	const postQuery = createQuery(() => ({
-		queryKey: ["posts", params.id],
-		queryFn: async (id: string) => {
-			const post = await fetch(`https://my-api.com/posts/${id}`);
-			return await post.json();
-		},
-		throwOnError: true,
-	}));
-
-	return (
-		<div>
-			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
-				<Suspense fallback={<div>Loading...</div>}>
-					<div>{postQuery.data?.name}</div>
-				</Suspense>
-			</ErrorBoundary>
-		</div>
-	);
-}
-```
+<Callout type="info">
+    [Tanstack Query](https://tanstack.com/query/latest/docs/framework/solid/overview) can be used for more advanced features such as automatic background re-fetching or infinite queries.
+</Callout>

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -198,7 +198,7 @@ export default function Page() {
 
 ## Fetching data on the client
 
-To fetch data only on the client side, you can use the [`createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource) primitive:
+When you only need to fetch data on the client side, you can use the [`createResource`](/reference/basic-reactivity/create-resource) primitive:
 
 ```tsx {1} {4-7} title="src/routes/index.tsx"
 import { createResource, ErrorBoundary, Suspense, For } from "solid-js";

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -1,0 +1,266 @@
+---
+title: "Data Fetching"
+---
+
+This guide will walk you through the basics of data fetching in SolidStart, providing practical examples and best practices.
+
+## Basics
+
+Here's a minimal example of data fetching in SolidStart:
+
+```tsx title="src/routes/index.tsx"
+import { For } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+  const posts = await fetch("https://my-api.com/blog");
+  return await posts.json();
+}, "posts");
+
+export default function Page() {
+  const posts = createAsync(() => getPosts());
+  return (
+    <ul>
+      <For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+    </ul>
+  );
+}
+```
+
+This example demonstrates a basic data fetching using [`query`](https://docs.solidjs.com/solid-router/reference/data-apis/query) and [`createAsync`](https://docs.solidjs.com/solid-router/reference/data-apis/create-async).
+
+
+<Callout type="info">
+  Note that `query` and `createAsync` are imported from `@solidjs/router`. By default, SolidStart uses [Solid Router](https://docs.solidjs.com/solid-router) under the hood. That means we can take advantage of all Solid Router data fetching primitives in SolidStart.
+</Callout>
+
+## Reference
+
+- Solid Router [`query`](https://docs.solidjs.com/solid-router/reference/data-apis/query)
+- Solid Router [`createAsync`](https://docs.solidjs.com/solid-router/reference/data-apis/create-async)
+- Solid [`createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource)
+
+## Examples
+
+### Preloading Data
+
+You can use the [`preload`](https://docs.solidjs.com/solid-router/reference/preload-functions/preload) function to preload a query:
+
+```tsx title="src/routes/index.tsx"
+import { For } from "solid-js";
+import { query, createAsync, type RouteDefinition } from "@solidjs/router";
+
+const getPosts = query(async () => {
+  const posts = await fetch("https://my-api.com/blog");
+  return await posts.json();
+}, "posts");
+
+export const route = {
+  preload: () => getPosts(),
+} satisfies RouteDefinition;
+
+export default function Page() {
+  const posts = createAsync(() => getPosts());
+  return (
+    <ul>
+      <For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+    </ul>
+  );
+}
+```
+
+In this example, we call `getPosts` inside the `preload` function, and because we have used `query` the result is cached and becomes immediately available in the component.
+
+The `preload` function runs in parallel with route loading. This happens when:
+
+- A user visits the route for the first time
+- A user hovers over a link to the route
+
+### Server-Only Queries
+
+By default, queries can run on both the server and client. Add [`"use server"`](https://docs.solidjs.com/solid-start/reference/server/use-server) to make a query run only on the server:
+
+```tsx {6} title="src/routes/index.tsx"
+import { For } from "solid-js";
+import { query, createAsync, type RouteDefinition } from "@solidjs/router";
+import { db } from "~/lib/db";
+
+const getPosts = query(async () => {
+  "use server";
+  const posts = await db.from("posts").select();
+  return await posts.json();
+}, "posts");
+
+export const route = {
+  preload: () => getPosts(),
+} satisfies RouteDefinition;
+
+export default function Page() {
+  const posts = createAsync(() => getPosts());
+  return (
+    <ul>
+      <For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+    </ul>
+  );
+}
+```
+
+Because `getPosts` only runs on the server, it's safe to access your database directly.
+
+### Parameterized Queries
+
+Here's how to create queries that accept parameters:
+
+```tsx title="src/routes/posts/[id]/index.tsx"
+import {
+  query,
+  createAsync,
+  useParams,
+  type RouteDefinition,
+} from "@solidjs/router";
+
+const getPost = query(async (id: string) => {
+  const post = await fetch(`https://my-api.com/blog/posts/${id}`);
+  return await post.json();
+}, "post");
+
+export const route = {
+  preload: ({ params }) => getPost(params.id),
+} satisfies RouteDefinition;
+
+export default function Page() {
+  const params = useParams();
+  const post = createAsync(() => getPost(params.id));
+  return <div>{post().title}</div>;
+}
+```
+
+### Loading UI
+
+You can use [Solid `<Suspense>`](https://docs.solidjs.com/reference/components/suspense) to show an instant loading state while SolidStart streams in the result.
+
+```tsx title="src/routes/index.tsx"
+import { Suspense, For } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+  const posts = await fetch("https://my-api.com/blog");
+  return await posts.json();
+}, "posts");
+
+export default function Page() {
+  const posts = createAsync(() => getPosts());
+  return (
+    <ul>
+      {/* Show a fallback while the data is fetching. */}
+      <Suspense fallback={<div>Loading...</div>}>
+        <For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+      </Suspense>
+    </ul>
+  );
+}
+```
+
+This will prevent the whole component from being blocked by data requests, and the user will be able to interact with the parts of the page that are ready.
+
+### Error Handling
+
+You can use [Solid `<ErrorBoundary>`](https://docs.solidjs.com/reference/components/error-boundary) to show a fallback in case data fetching fails.
+
+```tsx title="src/routes/index.tsx"
+import { ErrorBoundary, For } from "solid-js";
+import { query, createAsync, type RouteDefinition } from "@solidjs/router";
+
+const getPosts = query(async () => {
+  const posts = await fetch("https://my-api.com/blog");
+  return await posts.json();
+}, "posts");
+
+export const route = {
+  preload: () => getPosts(),
+} satisfies RouteDefinition;
+
+export default function Page() {
+  const posts = createAsync(() => getPosts());
+  return (
+    <ul>
+      {/* Show a fallback while the data is fetching. */}
+      <ErrorBoundary fallback={<div>Something went wrong!</div>}>
+        <For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+      </ErrorBoundary>
+    </ul>
+  );
+}
+```
+
+### Client-Side Data Fetching
+
+While `createAsync` is the recommended way to fetch data, sometimes you need client-side only fetching. For these cases, use the [`createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource) primitive:
+
+```tsx title="src/routes/index.tsx"
+import { createResource, ErrorBoundary, Suspense, For } from "solid-js";
+
+export default function Page() {
+  const [posts] = createResource(async () => {
+    const posts = await fetch("https://my-api.com/blog");
+    return await posts.json();
+  });
+
+  return (
+    <ul>
+      {/* Optional: show a fallback while the data is fetching. */}
+      <ErrorBoundary fallback={<div>Something went wrong!</div>}>
+        {/* Optional: Show a fallback while the data is fetching. */}
+        <Suspense fallback={<div>Loading...</div>}>
+          <For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+        </Suspense>
+      </ErrorBoundary>
+    </ul>
+  );
+}
+```
+
+You can use [`<Suspense>`](https://docs.solidjs.com/reference/components/suspense) and [`<ErrorBoundary>`](https://docs.solidjs.com/reference/components/error-boundary) for showing loading UI and handling errors.
+
+Be aware that you should not use `query` with `useResource`.
+
+<Callout type="caution">
+  `query` should not be used with `useResource`.
+</Callout>
+
+
+## Using Tanstack Query
+
+Consider [Tanstack Query](https://tanstack.com/query/latest) if you need advanced features like automatic background refetching or infinite queries. It's particularly appealing if you're already familiar with it from other projects. However, keep in mind that it will increase your bundle size slightly.
+
+Here is a basic example of using Tanstack Query:
+
+```tsx title="src/routes/posts/[id]/index.tsx"
+import { ErrorBoundary, Suspense } from "solid-js";
+import { useParams } from "@solidjs/router";
+import { createQuery } from "@tanstack/solid-query";
+
+export default function Page() {
+  const params = useParams();
+  const postQuery = createQuery(() => ({
+    queryKey: ["posts", params.id],
+    queryFn: async (id: string) => {
+      const post = await fetch(`https://my-api.com/posts/${id}`);
+      return await post.json();
+    },
+    throwOnError: true,
+  }));
+
+  return (
+    <div>
+      {/* Optional: show a fallback while the data is fetching. */}
+      <ErrorBoundary fallback={<div>Something went wrong!</div>}>
+        {/* Optional: Show a fallback while the data is fetching. */}
+        <Suspense fallback={<div>Loading...</div>}>
+          <div>{postQuery.data?.name}</div>
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+}
+```

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -36,7 +36,7 @@ In this example, we created a [`query`](https://docs.solidjs.com/solid-router/re
 - Solid [`<Suspense>`](https://docs.solidjs.com/reference/components/suspense)
 - Solid [`<ErrorBoundary>`](https://docs.solidjs.com/reference/components/error-boundary)
 
-## How to show loading UI
+## Showing loading UI
 
 To show a loading UI while data is loading, you can use [Solid `<Suspense>`](https://docs.solidjs.com/reference/components/suspense):
 
@@ -65,7 +65,7 @@ export default function Page() {
 }
 ```
 
-## How to handle errors
+## Handling errors
 
 To show a fallback UI in case data fetching fails, you can use [Solid `<ErrorBoundary>`](https://docs.solidjs.com/reference/components/error-boundary):
 
@@ -96,7 +96,7 @@ export default function Page() {
 }
 ```
 
-## How to preload data
+## Preloading data
 
 To optimize data fetching during user navigation, you can use [`preload`](https://docs.solidjs.com/solid-router/reference/preload-functions/preload) to preload a query:
 
@@ -129,7 +129,7 @@ export default function Page() {
 }
 ```
 
-## How to create parameterized queries
+## Passing parameters to queries
 
 To create a query that accepts parameters, you can pass any number of arguments to your query function:
 
@@ -166,7 +166,7 @@ export default function Page() {
 
 In this example, we used [`useParams`](https://docs.solidjs.com/solid-router/reference/primitives/use-params) to get the `id` path parameter and passed it to the `getPost` query to get the data for that specific post.
 
-## How to directly use database or an ORM
+## Using database or an ORM
 
 To directly use your database or ORM in a query, you should make the query server-only so your database credentials are not exposed to the client. You can do that by adding [`"use server"`](https://docs.solidjs.com/solid-start/reference/server/use-server) to the first line of your query function:
 
@@ -196,7 +196,7 @@ export default function Page() {
 }
 ```
 
-## How to use `createResource` for client-side fetching
+## Fetching data on the client
 
 To fetch data only on the client side, you can use the [`createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource) primitive:
 
@@ -219,6 +219,8 @@ export default function Page() {
 	);
 }
 ```
+
+Read more in the [`createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource) docs.
 
 <Callout type="info">
     [Tanstack Query](https://tanstack.com/query/latest/docs/framework/solid/overview) can be used for more advanced features such as automatic background re-fetching or infinite queries.

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -131,7 +131,7 @@ export default function Page() {
 
 ## Passing parameters to queries
 
-To create a query that accepts parameters, you can pass any number of arguments to your query function:
+When creating a query that accepts parameters, you can define your query function to take any number of arguments:
 
 ```tsx {9-10} {15} {19-20} title="src/routes/posts/[id]/index.tsx"
 import { ErrorBoundary } from "solid-js";

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -31,9 +31,9 @@ In this example, a [`query`](/solid-router/reference/data-apis/query) is created
 
 To display a loading UI while data is being fetched, you can use [Solid `<Suspense>`](/reference/components/suspense):
 
-1. Import `Suspense` from `solid-js`
-2. Wrap the data rendering in `<Suspense>`
-3. Provide a fallback component that will be displayed while the data is loading using the `fallback` prop
+1. Import `Suspense` from `solid-js`.
+2. Wrap the data rendering in `<Suspense>`.
+3. Provide a fallback component that will be displayed while the data is loading using the `fallback` prop.
 
 ```tsx {13} {15} title="src/routes/index.tsx"
 import { Suspense, For } from "solid-js";
@@ -61,7 +61,7 @@ export default function Page() {
 If the data fetching fails, a fallback UI can be displayed using an [`<ErrorBoundary>`](/reference/components/error-boundary):
 
 1. Import `ErrorBoundary` from `solid-js`.
-2. Wrap the data rendering in `<ErrorBoundary>`
+2. Wrap the data rendering in `<ErrorBoundary>`.
 3. Provide a fallback component that will be displayed if an error occurs using the `fallback` prop.
 
 ```tsx {13} {17} title="src/routes/index.tsx"
@@ -91,9 +91,9 @@ export default function Page() {
 
 Data fetching can be optimized during user navigation by preloading the data with the [`preload`](/solid-router/reference/preload-functions/preload) function:
 
-1. Export a `route` object with a `preload` function
-2. Run your query inside the `preload` function
-3. Use the query as usual in your component
+1. Export a `route` object with a `preload` function.
+2. Run your query inside the `preload` function.
+3. Use the query as usual in your component.
 
 ```tsx {9-11} title="src/routes/index.tsx"
 import { ErrorBoundary } from "solid-js";

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -38,7 +38,7 @@ In this example, a [`query`](/solid-router/reference/data-apis/query) is created
 
 ## Showing loading UI
 
-To show a loading UI while data is loading, you can use [Solid `<Suspense>`](https://docs.solidjs.com/reference/components/suspense):
+To display a loading UI while data is being fetched, you can use [Solid `<Suspense>`](/reference/components/suspense):
 
 1. Import `Suspense` from `solid-js`
 2. Wrap the data rendering in `<Suspense>`

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -25,7 +25,7 @@ export default function Page() {
 }
 ```
 
-In this example, we created a [`query`](https://docs.solidjs.com/solid-router/reference/data-apis/query) and [`createAsync`](https://docs.solidjs.com/solid-router/reference/data-apis/create-async) primitive to access the query data inside our component.
+In this example, we created a [`query`](https://docs.solidjs.com/solid-router/reference/data-apis/query) and used the [`createAsync`](https://docs.solidjs.com/solid-router/reference/data-apis/create-async) primitive to access the query data inside our component.
 
 ## Reference
 

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -222,6 +222,6 @@ export default function Page() {
 
 Read more in the [`createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource) docs.
 
-<Callout type="info">
+<Callout type="info" title="Advanced Data Handling">
     For advanced features like automatic background re-fetching or infinite queries, you can use [Tanstack Query.](https://tanstack.com/query/latest/docs/framework/solid/overview)
 </Callout>

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -89,7 +89,7 @@ export default function Page() {
 
 ## Preloading data
 
-Data fetching can be optimized during user navigation through preloading the data with the [`preload`](/solid-router/reference/preload-functions/preload) function:
+Data fetching can be optimized during user navigation by preloading the data with the [`preload`](/solid-router/reference/preload-functions/preload) function:
 
 1. Export a `route` object with a `preload` function
 2. Run your query inside the `preload` function
@@ -155,7 +155,7 @@ export default function Page() {
 }
 ```
 
-In this example, [`useParams`](/solid-router/reference/primitives/use-params) was used to access the `id` path parameter. You can then pass it to the `getPost` query to get the data for that specific post.
+In this example, [`useParams`](/solid-router/reference/primitives/use-params) was used to get the `id` path parameter. You can then pass it to the `getPost` query to get the data for that specific post.
 
 ## Using a database or an ORM
 

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -11,7 +11,7 @@ import { For } from "solid-js";
 import { query, createAsync } from "@solidjs/router";
 
 const getPosts = query(async () => {
-	const posts = await fetch("https://my-api.com/blog");
+	const posts = await fetch("https://my-api.com/posts");
 	return await posts.json();
 }, "posts");
 
@@ -35,12 +35,12 @@ To display a loading UI while data is being fetched, you can use [Solid `<Suspen
 2. Wrap the data rendering in `<Suspense>`
 3. Provide a fallback component that will be displayed while the data is loading using the `fallback` prop
 
-```tsx {1} {13} {15} title="src/routes/index.tsx"
+```tsx {13} {15} title="src/routes/index.tsx"
 import { Suspense, For } from "solid-js";
 import { query, createAsync } from "@solidjs/router";
 
 const getPosts = query(async () => {
-	const posts = await fetch("https://my-api.com/blog");
+	const posts = await fetch("https://my-api.com/posts");
 	return await posts.json();
 }, "posts");
 
@@ -64,12 +64,12 @@ If the data fetching fails, a fallback UI can be displayed using an [`<ErrorBoun
 2. Wrap the data rendering in `<ErrorBoundary>`
 3. Provide a fallback component that will be displayed if an error occurs using the `fallback` prop.
 
-```tsx {1} {13} {17} title="src/routes/index.tsx"
+```tsx {13} {17} title="src/routes/index.tsx"
 import { ErrorBoundary, Suspense, For } from "solid-js";
 import { query, createAsync } from "@solidjs/router";
 
 const getPosts = query(async () => {
-	const posts = await fetch("https://my-api.com/blog");
+	const posts = await fetch("https://my-api.com/posts");
 	return await posts.json();
 }, "posts");
 
@@ -89,18 +89,18 @@ export default function Page() {
 
 ## Preloading data
 
-Data fetching can be optimized during user navigation through preloading the data with the [`preload`](/solid-router/reference/preload-functions/preload) function: 
+Data fetching can be optimized during user navigation through preloading the data with the [`preload`](/solid-router/reference/preload-functions/preload) function:
 
 1. Export a `route` object with a `preload` function
 2. Run your query inside the `preload` function
 3. Use the query as usual in your component
 
-```tsx {2} {9-11} title="src/routes/index.tsx"
+```tsx {9-11} title="src/routes/index.tsx"
 import { ErrorBoundary } from "solid-js";
 import { query, createAsync, type RouteDefinition } from "@solidjs/router";
 
 const getPosts = query(async () => {
-	const posts = await fetch("https://my-api.com/blog");
+	const posts = await fetch("https://my-api.com/posts");
 	return await posts.json();
 }, "posts");
 
@@ -134,7 +134,7 @@ import {
 } from "@solidjs/router";
 
 const getPost = query(async (id: string) => {
-	const post = await fetch(`https://my-api.com/blog/posts/${id}`);
+	const post = await fetch(`https://my-api.com/posts/${id}`);
 	return await post.json();
 }, "post");
 
@@ -157,11 +157,11 @@ export default function Page() {
 
 In this example, [`useParams`](/solid-router/reference/primitives/use-params) was used to access the `id` path parameter. You can then pass it to the `getPost` query to get the data for that specific post.
 
-## Using database or an ORM
+## Using a database or an ORM
 
 To safely interact with your database or ORM in a query, ensure the query is server-only to prevent exposing your database credentials to the client. You can do this by adding [`"use server"`](/solid-start/reference/server/use-server) as the first line of your query function:
 
-```tsx {3} {6-7} title="src/routes/index.tsx"
+```tsx {6-7} title="src/routes/index.tsx"
 import { For, ErrorBoundary } from "solid-js";
 import { query, createAsync, type RouteDefinition } from "@solidjs/router";
 import { db } from "~/lib/db";
@@ -191,12 +191,12 @@ export default function Page() {
 
 When you only need to fetch data on the client side, you can use the [`createResource`](/reference/basic-reactivity/create-resource) primitive:
 
-```tsx {1} {4-7} title="src/routes/index.tsx"
+```tsx {4-7} title="src/routes/index.tsx"
 import { createResource, ErrorBoundary, Suspense, For } from "solid-js";
 
 export default function Page() {
 	const [posts] = createResource(async () => {
-		const posts = await fetch("https://my-api.com/blog");
+		const posts = await fetch("https://my-api.com/posts");
 		return await posts.json();
 	});
 	return (
@@ -214,5 +214,5 @@ export default function Page() {
 You can [read more about `createResource` here](/reference/basic-reactivity/create-resource).
 
 <Callout type="info" title="Advanced Data Handling">
-    For advanced features like automatic background re-fetching or infinite queries, you can use [Tanstack Query.](https://tanstack.com/query/latest/docs/framework/solid/overview)
+	For advanced features like automatic background re-fetching or infinite queries, you can use [Tanstack Query.](https://tanstack.com/query/latest/docs/framework/solid/overview)
 </Callout>

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -6,6 +6,9 @@ This guide provides practical examples for common data-fetching tasks in SolidSt
 
 Here's a simple example:
 
+<TabsCodeBlocks>
+<div id="TypeScript">
+
 ```tsx title="src/routes/index.tsx"
 import { For } from "solid-js";
 import { query, createAsync } from "@solidjs/router";
@@ -25,6 +28,31 @@ export default function Page() {
 }
 ```
 
+</div>
+<div id="JavaScript">
+
+```jsx title="src/routes/index.jsx"
+import { For } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/posts");
+	return await posts.json();
+}, "posts");
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+		</ul>
+	);
+}
+```
+
+</div>
+</TabsCodeBlocks>
+
 In this example, a [`query`](/solid-router/reference/data-apis/query) is created. In order to access it's data within the component, the [`createAsync`](/solid-router/reference/data-apis/create-async) primitive was used.
 
 ## Showing loading UI
@@ -33,6 +61,9 @@ To show a loading UI during data-fetching:
 
 1. Import [`Suspense`](/reference/components/suspense) from `solid-js`.
 2. Wrap your data rendering in `<Suspense>`, and use the `fallback` prop to show a component during data fetching.
+
+<TabsCodeBlocks>
+<div id="TypeScript">
 
 ```tsx {13} {15} title="src/routes/index.tsx"
 import { Suspense, For } from "solid-js";
@@ -55,12 +86,42 @@ export default function Page() {
 }
 ```
 
+</div>
+<div id="JavaScript">
+
+```jsx {13} {15} title="src/routes/index.jsx"
+import { Suspense, For } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/posts");
+	return await posts.json();
+}, "posts");
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<Suspense fallback={<div>Loading...</div>}>
+				<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+			</Suspense>
+		</ul>
+	);
+}
+```
+
+</div>
+</TabsCodeBlocks>
+
 ## Handling errors
 
 To show a fallback UI if the data-fetching fails:
 
 1. Import [`ErrorBoundary`](/reference/components/error-boundary) from `solid-js`.
 2. Wrap the data rendering in `<ErrorBoundary>`, and use the `fallback` prop to show a component if an error occurs.
+
+<TabsCodeBlocks>
+<div id="TypeScript">
 
 ```tsx {13} {17} title="src/routes/index.tsx"
 import { ErrorBoundary, Suspense, For } from "solid-js";
@@ -85,6 +146,35 @@ export default function Page() {
 }
 ```
 
+</div>
+<div id="JavaScript">
+
+```jsx {13} {17} title="src/routes/index.jsx"
+import { ErrorBoundary, Suspense, For } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/posts");
+	return await posts.json();
+}, "posts");
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<Suspense fallback={<div>Loading...</div>}>
+					<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+				</Suspense>
+			</ErrorBoundary>
+		</ul>
+	);
+}
+```
+
+</div>
+</TabsCodeBlocks>
+
 ## Preloading data
 
 Data fetching can be optimized during user navigation by preloading the data:
@@ -92,6 +182,9 @@ Data fetching can be optimized during user navigation by preloading the data:
 1. Export a `route` object with a [`preload`](/solid-router/reference/preload-functions/preload) function.
 2. Run your query inside the `preload` function.
 3. Use the query as usual in your component.
+
+<TabsCodeBlocks>
+<div id="TypeScript">
 
 ```tsx {9-11} title="src/routes/index.tsx"
 import { ErrorBoundary } from "solid-js";
@@ -118,9 +211,43 @@ export default function Page() {
 }
 ```
 
+</div>
+<div id="JavaScript">
+
+```jsx {9-11} title="src/routes/index.jsx"
+import { ErrorBoundary } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/posts");
+	return await posts.json();
+}, "posts");
+
+export const route = {
+	preload: () => getPosts(),
+};
+
+export default function Page() {
+	const post = createAsync(() => getPosts());
+	return (
+		<div>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<h1>{post().title}</h1>
+			</ErrorBoundary>
+		</div>
+	);
+}
+```
+
+</div>
+</TabsCodeBlocks>
+
 ## Passing parameters to queries
 
 When creating a query that accepts parameters, define your query function to take any number of arguments:
+
+<TabsCodeBlocks>
+<div id="TypeScript">
 
 ```tsx {4} {10} {15} title="src/routes/posts/[id]/index.tsx"
 import { ErrorBoundary } from "solid-js";
@@ -148,9 +275,44 @@ export default function Page() {
 }
 ```
 
+</div>
+<div id="JavaScript">
+
+```jsx {4} {10} {15} title="src/routes/posts/[id]/index.jsx"
+import { ErrorBoundary } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPost = query(async (id) => {
+	const post = await fetch(`https://my-api.com/posts/${id}`);
+	return await post.json();
+}, "post");
+
+export const route = {
+	preload: ({ params }) => getPost(params.id),
+};
+
+export default function Page() {
+	const postId = 1;
+	const post = createAsync(() => getPost(postId));
+	return (
+		<div>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<h1>{post().title}</h1>
+			</ErrorBoundary>
+		</div>
+	);
+}
+```
+
+</div>
+</TabsCodeBlocks>
+
 ## Using a database or an ORM
 
 To safely interact with your database or ORM in a query, ensure it's server-only by adding [`"use server"`](/solid-start/reference/server/use-server) as the first line of your query:
+
+<TabsCodeBlocks>
+<div id="TypeScript">
 
 ```tsx {6-7} title="src/routes/index.tsx"
 import { For, ErrorBoundary } from "solid-js";
@@ -178,9 +340,44 @@ export default function Page() {
 }
 ```
 
+</div>
+<div id="JavaScript">
+
+```jsx {6-7} title="src/routes/index.jsx"
+import { For, ErrorBoundary } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+import { db } from "~/lib/db";
+
+const getPosts = query(async () => {
+	"use server";
+	return await db.from("posts").select();
+}, "posts");
+
+export const route = {
+	preload: () => getPosts(),
+};
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+			</ErrorBoundary>
+		</ul>
+	);
+}
+```
+
+</div>
+</TabsCodeBlocks>
+
 ## Fetching data on the client
 
 To fetch data only on the client, use the [`createResource`](/reference/basic-reactivity/create-resource) primitive:
+
+<TabsCodeBlocks>
+<div id="TypeScript">
 
 ```tsx {4-7} title="src/routes/index.tsx"
 import { createResource, ErrorBoundary, Suspense, For } from "solid-js";
@@ -201,6 +398,32 @@ export default function Page() {
 	);
 }
 ```
+
+</div>
+<div id="JavaScript">
+
+```jsx {4-7} title="src/routes/index.jsx"
+import { createResource, ErrorBoundary, Suspense, For } from "solid-js";
+
+export default function Page() {
+	const [posts] = createResource(async () => {
+		const posts = await fetch("https://my-api.com/posts");
+		return await posts.json();
+	});
+	return (
+		<ul>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<Suspense fallback={<div>Loading...</div>}>
+					<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+				</Suspense>
+			</ErrorBoundary>
+		</ul>
+	);
+}
+```
+
+</div>
+</TabsCodeBlocks>
 
 You can [read more about `createResource` here](/reference/basic-reactivity/create-resource).
 

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -168,7 +168,7 @@ In this example, we used [`useParams`](https://docs.solidjs.com/solid-router/ref
 
 ## Using database or an ORM
 
-To directly use your database or ORM in a query, you should make the query server-only so your database credentials are not exposed to the client. You can do that by adding [`"use server"`](https://docs.solidjs.com/solid-start/reference/server/use-server) to the first line of your query function:
+To safely interact with your database or ORM in a query, ensure the query is server-only to prevent exposing your database credentials to the client. You can do this by adding [`"use server"`](/solid-start/reference/server/use-server) as the first line of your query function:
 
 ```tsx {3} {6-7} title="src/routes/index.tsx"
 import { For, ErrorBoundary } from "solid-js";

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -53,7 +53,8 @@ export default function Page() {
 </div>
 </TabsCodeBlocks>
 
-In this example, a [`query`](/solid-router/reference/data-apis/query) is created. In order to access it's data within the component, the [`createAsync`](/solid-router/reference/data-apis/create-async) primitive was used.
+In this example, a [`query`](/solid-router/reference/data-apis/query) is created.
+In order to access it's data within the component, the [`createAsync`](/solid-router/reference/data-apis/create-async) primitive was used.
 
 ## Showing loading UI
 
@@ -425,7 +426,7 @@ export default function Page() {
 </div>
 </TabsCodeBlocks>
 
-You can [read more about `createResource` here](/reference/basic-reactivity/create-resource).
+See the [`createResource` API reference](/reference/basic-reactivity/create-resource) for more information.
 
 <Callout type="info" title="Advanced Data Handling">
 

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -67,7 +67,7 @@ export default function Page() {
 
 ## Handling errors
 
-To show a fallback UI in case data fetching fails, you can use [Solid `<ErrorBoundary>`](https://docs.solidjs.com/reference/components/error-boundary):
+If the data fetching fails, a fallback UI can be displayed using an [`<ErrorBoundary>`](/reference/components/error-boundary):
 
 1. Import `ErrorBoundary` from `solid-js`.
 2. Wrap the data rendering in `<ErrorBoundary>`

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -223,5 +223,5 @@ export default function Page() {
 Read more in the [`createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource) docs.
 
 <Callout type="info">
-    [Tanstack Query](https://tanstack.com/query/latest/docs/framework/solid/overview) can be used for more advanced features such as automatic background re-fetching or infinite queries.
+    For advanced features like automatic background re-fetching or infinite queries, you can use [Tanstack Query.](https://tanstack.com/query/latest/docs/framework/solid/overview)
 </Callout>

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -220,7 +220,7 @@ export default function Page() {
 }
 ```
 
-Read more in the [`createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource) docs.
+You can [read more about `createResource` here](/reference/basic-reactivity/create-resource) .
 
 <Callout type="info" title="Advanced Data Handling">
     For advanced features like automatic background re-fetching or infinite queries, you can use [Tanstack Query.](https://tanstack.com/query/latest/docs/framework/solid/overview)

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -214,5 +214,7 @@ export default function Page() {
 You can [read more about `createResource` here](/reference/basic-reactivity/create-resource).
 
 <Callout type="info" title="Advanced Data Handling">
-	For advanced features like automatic background re-fetching or infinite queries, you can use [Tanstack Query.](https://tanstack.com/query/latest/docs/framework/solid/overview)
+
+For advanced features like automatic background re-fetching or infinite queries, you can use [Tanstack Query.](https://tanstack.com/query/latest/docs/framework/solid/overview)
+
 </Callout>

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -98,7 +98,7 @@ export default function Page() {
 
 ## Preloading data
 
-To optimize data fetching during user navigation, you can use [`preload`](https://docs.solidjs.com/solid-router/reference/preload-functions/preload) to preload a query:
+Data fetching can be optimized during user navigation through preloading the data with the [`preload`](/solid-router/reference/preload-functions/preload) function: 
 
 1. Export a `route` object with a `preload` function
 2. Run your query inside the `preload` function

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Data Fetching"
+title: "Data fetching"
 ---
 
 SolidStart is built on top of [Solid](/) and uses [Solid Router](/solid-router) by default.

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -164,7 +164,7 @@ export default function Page() {
 }
 ```
 
-In this example, we used [`useParams`](https://docs.solidjs.com/solid-router/reference/primitives/use-params) to get the `id` path parameter and passed it to the `getPost` query to get the data for that specific post.
+In this example, [`useParams`](/solid-router/reference/primitives/use-params) was used to access the `id` path parameter. You can then pass it to the `getPost` query to get the data for that specific post.
 
 ## Using database or an ORM
 

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -25,7 +25,7 @@ export default function Page() {
 }
 ```
 
-In this example, we created a [`query`](https://docs.solidjs.com/solid-router/reference/data-apis/query) and used the [`createAsync`](https://docs.solidjs.com/solid-router/reference/data-apis/create-async) primitive to access the query data inside our component.
+In this example, a [`query`](/solid-router/reference/data-apis/query) is created. In order to access it's data within the component, the [`createAsync`](/solid-router/reference/data-apis/create-async) primitive was used.
 
 ## Reference
 

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -2,7 +2,17 @@
 title: "Data Fetching"
 ---
 
-This guide provides practical examples for common data-fetching tasks in SolidStart.
+SolidStart is built on top of [Solid](/) and uses [Solid Router](/solid-router) by default.
+This means you can leverage their respective data-fetching primitives within SolidStart.
+Since SolidStart itself provides minimal data-fetching APIs, most functionality comes from Solid and Solid Router.
+
+This guide provides practical examples of common data-fetching tasks using these primitives.
+
+<Callout type="info" title="Note">
+
+For detailed API information, refer to the [Solid](/) and [Solid Router](/solid-router) documentation.
+
+</Callout>
 
 Here's a simple example:
 
@@ -426,7 +436,7 @@ export default function Page() {
 </div>
 </TabsCodeBlocks>
 
-See the [`createResource` API reference](/reference/basic-reactivity/create-resource) for more information.
+See the [`createResource`](/reference/basic-reactivity/create-resource) API reference for more information.
 
 <Callout type="info" title="Advanced Data Handling">
 

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -29,11 +29,10 @@ In this example, a [`query`](/solid-router/reference/data-apis/query) is created
 
 ## Showing loading UI
 
-To display a loading UI while data is being fetched, you can use [Solid `<Suspense>`](/reference/components/suspense):
+To show a loading UI during data-fetching:
 
-1. Import `Suspense` from `solid-js`.
-2. Wrap the data rendering in `<Suspense>`.
-3. Provide a fallback component that will be displayed while the data is loading using the `fallback` prop.
+1. Import [`Suspense`](/reference/components/suspense) from `solid-js`.
+2. Wrap your data rendering in `<Suspense>`, and use the `fallback` prop to show a component during data fetching.
 
 ```tsx {13} {15} title="src/routes/index.tsx"
 import { Suspense, For } from "solid-js";
@@ -58,11 +57,10 @@ export default function Page() {
 
 ## Handling errors
 
-If the data fetching fails, a fallback UI can be displayed using an [`<ErrorBoundary>`](/reference/components/error-boundary):
+To show a fallback UI if the data-fetching fails:
 
-1. Import `ErrorBoundary` from `solid-js`.
-2. Wrap the data rendering in `<ErrorBoundary>`.
-3. Provide a fallback component that will be displayed if an error occurs using the `fallback` prop.
+1. Import [`ErrorBoundary`](/reference/components/error-boundary) from `solid-js`.
+2. Wrap the data rendering in `<ErrorBoundary>`, and use the `fallback` prop to show a component if an error occurs.
 
 ```tsx {13} {17} title="src/routes/index.tsx"
 import { ErrorBoundary, Suspense, For } from "solid-js";
@@ -89,9 +87,9 @@ export default function Page() {
 
 ## Preloading data
 
-Data fetching can be optimized during user navigation by preloading the data with the [`preload`](/solid-router/reference/preload-functions/preload) function:
+Data fetching can be optimized during user navigation by preloading the data:
 
-1. Export a `route` object with a `preload` function.
+1. Export a `route` object with a [`preload`](/solid-router/reference/preload-functions/preload) function.
 2. Run your query inside the `preload` function.
 3. Use the query as usual in your component.
 
@@ -122,16 +120,11 @@ export default function Page() {
 
 ## Passing parameters to queries
 
-When creating a query that accepts parameters, you can define your query function to take any number of arguments:
+When creating a query that accepts parameters, define your query function to take any number of arguments:
 
-```tsx {9-10} {15} {19-20} title="src/routes/posts/[id]/index.tsx"
+```tsx {4} {10} {15} title="src/routes/posts/[id]/index.tsx"
 import { ErrorBoundary } from "solid-js";
-import {
-	query,
-	createAsync,
-	useParams,
-	type RouteDefinition,
-} from "@solidjs/router";
+import { query, createAsync, type RouteDefinition } from "@solidjs/router";
 
 const getPost = query(async (id: string) => {
 	const post = await fetch(`https://my-api.com/posts/${id}`);
@@ -143,8 +136,8 @@ export const route = {
 } satisfies RouteDefinition;
 
 export default function Page() {
-	const params = useParams();
-	const post = createAsync(() => getPost(params.id));
+	const postId = 1;
+	const post = createAsync(() => getPost(postId));
 	return (
 		<div>
 			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
@@ -155,11 +148,9 @@ export default function Page() {
 }
 ```
 
-In this example, [`useParams`](/solid-router/reference/primitives/use-params) was used to get the `id` path parameter. You can then pass it to the `getPost` query to get the data for that specific post.
-
 ## Using a database or an ORM
 
-To safely interact with your database or ORM in a query, ensure the query is server-only to prevent exposing your database credentials to the client. You can do this by adding [`"use server"`](/solid-start/reference/server/use-server) as the first line of your query function:
+To safely interact with your database or ORM in a query, ensure it's server-only by adding [`"use server"`](/solid-start/reference/server/use-server) as the first line of your query:
 
 ```tsx {6-7} title="src/routes/index.tsx"
 import { For, ErrorBoundary } from "solid-js";
@@ -189,7 +180,7 @@ export default function Page() {
 
 ## Fetching data on the client
 
-When you only need to fetch data on the client side, you can use the [`createResource`](/reference/basic-reactivity/create-resource) primitive:
+To fetch data only on the client, use the [`createResource`](/reference/basic-reactivity/create-resource) primitive:
 
 ```tsx {4-7} title="src/routes/index.tsx"
 import { createResource, ErrorBoundary, Suspense, For } from "solid-js";
@@ -215,6 +206,6 @@ You can [read more about `createResource` here](/reference/basic-reactivity/crea
 
 <Callout type="info" title="Advanced Data Handling">
 
-For advanced features like automatic background re-fetching or infinite queries, you can use [Tanstack Query.](https://tanstack.com/query/latest/docs/framework/solid/overview)
+For advanced features like automatic background re-fetching or infinite queries, you can use [Tanstack Query](https://tanstack.com/query/latest/docs/framework/solid/overview).
 
 </Callout>

--- a/src/routes/solid-start/guides/data.json
+++ b/src/routes/solid-start/guides/data.json
@@ -1,0 +1,4 @@
+{
+	"title": "Guides",
+	"pages": ["data-fetching.mdx"]
+}


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description

The idea of the Guides section is to provide a resource for developers who don't read Solid.js and Solid Router docs before learning SolidStart, such as React developers who may think of SolidStart as what Next.js is for React and start learning Solid.js from SolidStart. However, I think a Guides section can be useful to a lot of people regardless of whether they come from React.

The goal is to get those users (or anyone really) up and running with SolidStart as quickly as possible, while also guiding them to read more relevant docs if they want to learn more.

This PR adds a Data Fetching page under the Guides section that covers basic data fetching patterns while providing links to relevant documentation for those who want to learn more.

See https://github.com/solidjs/solid-docs/issues/861 for more context. 

### Related issues & labels

#914 https://github.com/solidjs/solid-docs/issues/861
