### PR TITLE
Fix line-number alignment in hero

### DIFF
--- a/src/ui/layout/hero.tsx
+++ b/src/ui/layout/hero.tsx
@@ -99,9 +99,7 @@ export const Hero: Component = () => {
 										>
 											<Index each={snippetLines}>
 												{(_, index) => (
-													<pre class="pb-px">
-														{(index + 1).toString().padStart(2, "0")}
-													</pre>
+													<pre>{(index + 1).toString().padStart(2, "0")}</pre>
 												)}
 											</Index>
 										</div>


### PR DESCRIPTION
### Description(required)

Fixed line-number alignment in the example in the hero.

Before:
![image](https://github.com/user-attachments/assets/f3a8ebad-4991-4ec0-8815-44933ad869bb)

After:
![image](https://github.com/user-attachments/assets/cd595d4c-54e3-44c7-9432-c7650cc248da)
