### PR TITLE
Fix `with` example in `action` Reference

### DIFF
--- a/src/routes/solid-router/reference/data-apis/action.mdx
+++ b/src/routes/solid-router/reference/data-apis/action.mdx
@@ -46,9 +46,8 @@ const deleteTodo = action(async (formData: FormData) => {
 
 Using `with`:
 
-```jsx del={6,7} ins={8}
-const deleteTodo = action(async (formData: FormData) => {
-  const id = Number(formData.get("id"))
+```jsx del={5,6} ins={7}
+const deleteTodo = action(async (id: number) => {
   await api.deleteTodo(id)
 })
 


### PR DESCRIPTION
### Description

I noticed the `with` example in the [`action`](https://docs.solidjs.com/solid-router/reference/data-apis/action) Reference was using FormData. This PR fixes it.