### PR TITLE
Remove style rules from eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,8 +27,6 @@
 	},
 	"plugins": ["@typescript-eslint", "solid"],
 	"rules": {
-		"quotes": ["error", "double"],
-		"semi": "warn",
 		"@typescript-eslint/no-unused-vars": [
 			"error",
 			{


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description
Style guidelines are enforced by Prettier, so there is no need to use ESLint for that purpose. In some cases, ESLint rules can conflict with Prettier. For example, Prettier formats `"\"text\""` to `'"text"'`, which creates an error according to the ESLint rule `"quotes": ["error", "double"]`.