### PR TITLE
fix: use "primitive" instead of "hook"

### DIFF
--- a/src/routes/solid-router/concepts/dynamic-routes.mdx
+++ b/src/routes/solid-router/concepts/dynamic-routes.mdx
@@ -27,7 +27,7 @@ render(
 
 The colon (`:`) indicates that `id` can be any string.
 Once a URL matches the pattern, the `User` component will be shown.
-When using dynamic segments, the values can be accessed via the [`useParams`](/solid-router/reference/primitives/use-params) hook within the component.
+When using dynamic segments, the values can be accessed via the [`useParams`](/solid-router/reference/primitives/use-params) primitive within the component.
 
 <Callout title="Note on Animation/Transitions">
 Routes that share the same path match will be treated as the same route.

--- a/src/routes/solid-start/building-your-application/routing.mdx
+++ b/src/routes/solid-start/building-your-application/routing.mdx
@@ -174,7 +174,7 @@ For example, `/users/1` and `/users/2` are both valid routes and rather than def
         |-- [id].tsx
 ```
 
-For example, using `solid-router`, you could use the [`useParams`](/solid-router/reference/primitives/use-params) hook to match the dynamic segment:
+For example, using `solid-router`, you could use the [`useParams`](/solid-router/reference/primitives/use-params) primitive to match the dynamic segment:
 
 ```tsx title="routes/users/[id].tsx"
 import { useParams } from "@solidjs/router";


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description
Corrects the discouraged use of "hook" and replaces it with "primitive", based on the guide in [WRITING.md](https://github.com/solidjs/solid-docs/blob/main/WRITING.md)
