### PR TITLE
Add useAction reference

### DIFF
--- a/src/routes/solid-router/reference/data-apis/action.mdx
+++ b/src/routes/solid-router/reference/data-apis/action.mdx
@@ -68,23 +68,6 @@ The solution is to provide a unique name.
 const myAction = action(async (args) => {}, "my-action");
 ```
 
-## `useAction`
-
-Instead of forms, actions can directly be wrapped in a `useAction` primitive.
-This is how router context is created.
-
-```jsx
-// in component
-const submit = useAction(myAction);
-submit(...args);
-
-```
-
-The outside of a form context can use custom data instead of `formData`.
-These helpers preserve types.
-
-However, even when used with server functions, such as with [SolidStart](https://start.solidjs.com/getting-started/what-is-solidstart), this requires client-side JavaScript and is not progressively enhanceable like forms are.
-
 ## `useSubmission`/`useSubmissions`
 
 These functions are used when incorporating optimistic updates during ongoing actions.

--- a/src/routes/solid-router/reference/data-apis/action.mdx
+++ b/src/routes/solid-router/reference/data-apis/action.mdx
@@ -68,6 +68,23 @@ The solution is to provide a unique name.
 const myAction = action(async (args) => {}, "my-action");
 ```
 
+## `useAction`
+
+Instead of forms, actions can directly be wrapped in a `useAction` primitive.
+This is how router context is created.
+
+```jsx
+// in component
+const submit = useAction(myAction);
+submit(...args);
+
+```
+
+The outside of a form context can use custom data instead of `formData`.
+These helpers preserve types.
+
+However, even when used with server functions, such as with [SolidStart](https://start.solidjs.com/getting-started/what-is-solidstart), this requires client-side JavaScript and is not progressively enhanceable like forms are.
+
 ## `useSubmission`/`useSubmissions`
 
 These functions are used when incorporating optimistic updates during ongoing actions.

--- a/src/routes/solid-router/reference/data-apis/data.json
+++ b/src/routes/solid-router/reference/data-apis/data.json
@@ -6,6 +6,7 @@
 		"create-async.mdx",
 		"create-async-store.mdx",
 		"query.mdx",
+		"use-action.mdx",
 		"use-submission.mdx",
 		"use-submissions.mdx"
 	]

--- a/src/routes/solid-router/reference/data-apis/use-action.mdx
+++ b/src/routes/solid-router/reference/data-apis/use-action.mdx
@@ -24,4 +24,5 @@ const result = updateName("John Wick");
 
 ## Returns
 
-`useAction` returns a function that lets you invoke the action. It has the same signature as the action itself.
+`useAction` returns a function that lets you invoke the action. 
+It has the same signature as the action itself.

--- a/src/routes/solid-router/reference/data-apis/use-action.mdx
+++ b/src/routes/solid-router/reference/data-apis/use-action.mdx
@@ -1,0 +1,27 @@
+---
+title: useAction
+---
+
+`useAction` allows you to programmatically invoke an [`action`](/solid-router/reference/data-apis/action).
+
+```tsx
+import { useAction } from "@solidjs/router";
+import { updateNameAction } from "./actions";
+
+const updateName = useAction(updateNameAction);
+
+const result = updateName("John Wick");
+```
+
+<Callout type="info" title="Note">
+	`useAction` requires client-side JavaScript and is not progressively
+	enhanceable.
+</Callout>
+
+## Parameters
+
+- `action`: the action you want to invoke.
+
+## Returns
+
+`useAction` returns a function that lets you invoke the action. It has the same signature as the action itself.

--- a/src/routes/solid-router/reference/data-apis/use-action.mdx
+++ b/src/routes/solid-router/reference/data-apis/use-action.mdx
@@ -2,7 +2,7 @@
 title: useAction
 ---
 
-`useAction` allows you to programmatically invoke an [`action`](/solid-router/reference/data-apis/action).
+`useAction` allows an [`action`](/solid-router/reference/data-apis/action) to be invoked programmatically.
 
 ```tsx
 import { useAction } from "@solidjs/router";
@@ -20,9 +20,9 @@ const result = updateName("John Wick");
 
 ## Parameters
 
-- `action`: the action you want to invoke.
+- `action`: The action to be invoked.
 
 ## Returns
 
-`useAction` returns a function that lets you invoke the action. 
-It has the same signature as the action itself.
+`useAction` returns a function that invokes the action.
+It shares the same signature as the action itself.


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

This PR adds a dedicated reference page for the `useAction` primitive. It also removes the `useAction` section in the [action reference](https://docs.solidjs.com/solid-router/reference/data-apis/action) as it's not needed anymore.

### Related issues & labels

- Closes #1002
- Suggested label(s) (optional): documentation