### PR TITLE
Add deno option for installation via package management

### DIFF
--- a/src/routes/solid-router/getting-started/installation-and-setup.mdx
+++ b/src/routes/solid-router/getting-started/installation-and-setup.mdx
@@ -37,6 +37,12 @@ pnpm add @solidjs/router
 bun add @solidjs/router
 ```
 </div>
+
+<div id="deno">
+```bash frame="none"
+deno add npm:@solidjs/router
+```
+</div>
 </TabsCodeBlocks>
 
 ## Configure the routes


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

Adds the instructions for installing the Solid npm package via deno to the [installation and setup](https://docs.solidjs.com/solid-router/getting-started/installation-and-setup) page of the docs

### Related issues & labels

- Suggested label(s) (optional): 'documentation'
