### PR TITLE
Add deno usage info to getting-started.mdx

### DIFF
--- a/src/routes/solid-start/getting-started.mdx
+++ b/src/routes/solid-start/getting-started.mdx
@@ -86,6 +86,12 @@ pnpm i
 bun install
 ```
 </div>
+
+<div id="deno">
+```bash frame="none"
+deno install
+```
+</div>
 </TabsCodeBlocks>
 
 After this command has finished, your new SolidStart application is ready to go!
@@ -116,6 +122,12 @@ pnpm dev
 <div id="bun">
 ```bash frame="none"
 bun dev
+```
+</div>
+
+<div id="deno">
+```bash frame="none"
+deno task dev
 ```
 </div>
 </TabsCodeBlocks>


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

Adds the deno commands for installing and running Solid Start projects to https://docs.solidjs.com/solid-start/getting-started

### Related issues & labels

- Suggested label(s) (optional): `documentation`
