### PR TITLE
Add deno info to installation-and-setup docs

### DIFF
--- a/src/routes/solid-meta/getting-started/installation-and-setup.mdx
+++ b/src/routes/solid-meta/getting-started/installation-and-setup.mdx
@@ -30,6 +30,12 @@ yarn add @solidjs/meta
 pnpm add @solidjs/meta
 ```
 </div>
+
+<div id="deno">
+```bash frame="none"
+deno add npm:@solidjs/meta
+```
+</div>
 </TabsCodeBlocks>
 
 ## Setup


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

Adds info on the command to use deno to install the package in the [installation and setup](https://docs.solidjs.com/solid-meta/getting-started/installation-and-setup) documentation page.

### Related issues & labels

- Suggested label(s) (optional): `documentation`
