### PR TITLE
Fix <Callout> icon margin

### DIFF
--- a/src/ui/callout.tsx
+++ b/src/ui/callout.tsx
@@ -92,7 +92,7 @@ export function Callout(props: CalloutProps) {
 				styles[mergedProps.type].container
 			}`}
 		>
-			<IconComponent class="h-6 w-8 pt-1 flex-none" />
+			<IconComponent class="h-6 w-8 mt-1 flex-none" />
 			<div class={`m-0 pb-1 px-4 w-full ${styles[mergedProps.type].title}`}>
 				<Show
 					when={props.title}


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

It looks like the `<Callout>` icons are positioned slightly above the title. This PR addresses that issue.

Before:
![image](https://github.com/user-attachments/assets/336bf654-4a42-4d96-a7d5-b6c5cd5c2011)

After:
![image](https://github.com/user-attachments/assets/51d077c3-70e5-4669-947b-62d4186cb6e4)

The calculations of whoever wrote this were correct. However, because of how box-sizing works in CSS, it didn't have the intended effect. Switching from padding to margin resolved the problem.