### PR TITLE
Remove colon sign in default <Callout> titles

### DIFF
--- a/src/ui/callout.tsx
+++ b/src/ui/callout.tsx
@@ -98,7 +98,7 @@ export function Callout(props: CalloutProps) {
 					when={props.title}
 					fallback={
 						<span class="capitalize font-semibold text-xl">
-							{props.type || "Info"}:{" "}
+							{props.type || "Info"}
 						</span>
 					}
 				>


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

This PR removes the colon sign in the default `<Callout>` titles for consistency. Read more in #1016.

### Related issues & labels

- Closes #1016
