### PR TITLE
Add link to useAction reference

### DIFF
--- a/src/routes/solid-router/concepts/actions.mdx
+++ b/src/routes/solid-router/concepts/actions.mdx
@@ -45,7 +45,7 @@ Typically, route actions are used with some sort of solution like fetch or Graph
 
 ### Using actions
 
-To use the action, you can call it from within a component using `useAction`.
+To use the action, you can call it from within a component using [`useAction`](/solid-router/reference/data-apis/use-action).
 This returns a function that can be called with the necessary arguments to trigger the action.
 
 ```tsx del={1} ins={2,9-13}


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
The `useAction` reference page was added recently. In this PR, I added a link to this page in the first appearance of `useAction` in the `action` reference page. There is no other mention of `useAction` in other pages.
