### PR TITLE
Solid-Meta: Fix incorrect data URI in emojiSvg() example

### DIFF
--- a/src/routes/solid-meta/reference/meta/link.mdx
+++ b/src/routes/solid-meta/reference/meta/link.mdx
@@ -38,7 +38,7 @@ To use an emoji as a favicon, first create a function that returns a data URI co
 ```jsx
 const emojiSvg = (emoji) => {
 	return (
-		`data:image/svg+xml` +
+		`data:image/svg+xml;utf8,` +
 		`<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>${emoji}</text></svg>`
 	);
 };


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->
The current SVG Emoji icon [example code](https://docs.solidjs.com/solid-meta/reference/meta/link#using-an-emoji-as-a-favicon) does not appear to work at all:

![image](https://github.com/user-attachments/assets/eb1cff28-1c69-4ca4-aa9d-ac9bcec48461)

This PR fixes it by using the correct data URI format in `emojiSvg()`:
```diff
- data:image/svg+xml
+ data:image/svg+xml;utf8,
```
![image](https://github.com/user-attachments/assets/a04e3033-3f2e-42cf-8292-e2206dcf6eda)