### PR TITLE
Fix bugs and inconsistencies in markdown metadata

### DIFF
--- a/src/routes/solid-meta/reference/meta/base.mdx
+++ b/src/routes/solid-meta/reference/meta/base.mdx
@@ -6,7 +6,7 @@ order: 5
 `Base` is a component that specifies the base URL for all relative URLs in the document.
 This provides a way to define the [`base`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) element of your document's `head`.
 
-```tsx twoslash
+```tsx
 import { Base } from "@solidjs/meta";
 
 <Base target="_blank" href="https://docs.solidjs.com/" />;
@@ -16,7 +16,7 @@ import { Base } from "@solidjs/meta";
 
 ### Adding `base` tag
 
-```tsx twoslash
+```tsx
 import { MetaProvider, Base } from "@solidjs/meta";
 
 export default function Root() {

--- a/src/routes/solid-meta/reference/meta/link.mdx
+++ b/src/routes/solid-meta/reference/meta/link.mdx
@@ -8,7 +8,7 @@ Commonly, this is used for linking stylesheets and other associations.
 
 This component renders a [`link`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link) element within the document's `<head>`.
 
-```tsx twoslash
+```tsx
 import { Link } from "@solidjs/meta";
 <Link rel="icon" href="/favicon.ico" />;
 ```
@@ -19,7 +19,7 @@ import { Link } from "@solidjs/meta";
 
 To add a favicon in an app, `<Link>` can be used to point to the asset:
 
-```tsx twoslash
+```tsx
 import { MetaProvider, Link } from "@solidjs/meta";
 
 export default function Root() {

--- a/src/routes/solid-meta/reference/meta/meta.mdx
+++ b/src/routes/solid-meta/reference/meta/meta.mdx
@@ -6,7 +6,7 @@ order: 3
 The `<Meta>` component represents metadata that cannot be represented by other HTML elements.
 It is a wrapper for the native [`meta`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta) element and has the same properties.
 
-```tsx twoslash
+```tsx
 import { Meta } from "@solidjs/meta";
 
 <Meta name="description" content="My site description" />;
@@ -19,7 +19,7 @@ import { Meta } from "@solidjs/meta";
 
 ### Adding `meta` tag
 
-```tsx twoslash {6-8}
+```tsx {6-8}
 import { MetaProvider, Meta } from "@solidjs/meta";
 
 export default function Root() {

--- a/src/routes/solid-meta/reference/meta/metaprovider.mdx
+++ b/src/routes/solid-meta/reference/meta/metaprovider.mdx
@@ -6,7 +6,7 @@ order: 6
 `MetaProvider` is a parent component responsible for wrapping all the metadata components.
 All components that are contained within this will be added to the application `<head/>`
 
-```tsx twoslash
+```tsx
 import { MetaProvider } from "@solidjs/meta";
 
 <MetaProvider>// add meta components</MetaProvider>;

--- a/src/routes/solid-meta/reference/meta/style.mdx
+++ b/src/routes/solid-meta/reference/meta/style.mdx
@@ -5,7 +5,7 @@ order: 4
 
 `Style` is a component that adds the [`style`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style) element to your document's `head`.
 
-```tsx twoslash
+```tsx
 import { Style } from "@solidjs/meta";
 
 <Style>
@@ -28,7 +28,7 @@ It is recommended to add styles in an external stylesheet and use a `Link` inste
 	Styles within the `Style` component are not scoped.
 </Callout>
 
-```tsx twoslash
+```tsx
 import { MetaProvider, Style } from "@solidjs/meta";
 
 export default function Root() {

--- a/src/routes/solid-meta/reference/meta/title.mdx
+++ b/src/routes/solid-meta/reference/meta/title.mdx
@@ -6,7 +6,7 @@ order: 1
 `Title` is a component that renders the [`title`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title) element.
 This will render the title of the page in the browser tab.
 
-```tsx twoslash
+```tsx
 import { Title } from "@solidjs/meta";
 <Title>My Site</Title>;
 ```
@@ -15,7 +15,7 @@ import { Title } from "@solidjs/meta";
 
 ### Setting the title for your site
 
-```tsx twoslash filename="root.tsx" {5}
+```tsx title="root.tsx" {5}
 import { MetaProvider, Title } from "@solidjs/meta";
 export default function Root() {
 	return (

--- a/src/routes/solid-router/reference/data-apis/use-submission.mdx
+++ b/src/routes/solid-router/reference/data-apis/use-submission.mdx
@@ -104,7 +104,7 @@ function Component() {
 ```
 </div>
 <div id="js">
-```tsx title="component.jsx" {5,9-11}
+```jsx title="component.jsx" {5,9-11}
 import { Show } from "solid-js";
 import { useSubmission } from "@solidjs/router";
 

--- a/src/routes/solid-router/reference/data-apis/use-submissions.mdx
+++ b/src/routes/solid-router/reference/data-apis/use-submissions.mdx
@@ -136,7 +136,7 @@ function Component() {
 ```
 </div>
 <div id="js">
-```tsx title="component.jsx" {5,12-19}
+```jsx title="component.jsx" {5,12-19}
 import { Show } from "solid-js";
 import { useSubmissions } from "@solidjs/router";
 

--- a/src/routes/solid-start/building-your-application/data-loading.mdx
+++ b/src/routes/solid-start/building-your-application/data-loading.mdx
@@ -30,7 +30,7 @@ export default function Page() {
 ```
 </div>
 <div id="js">
-```tsx {4-7} title="/src/routes/users.jsx"
+```jsx {4-7} title="/src/routes/users.jsx"
 import { For, createResource } from "solid-js";
 
 export default function Page() {
@@ -77,7 +77,7 @@ export default function Page() {
 </div>
 
 <div id="js">
-```tsx title="/routes/users.jsx" {4, 7, 10}
+```jsx title="/routes/users.jsx" {4, 7, 10}
 import { For } from "solid-js";
 import { createAsync, query } from "@solidjs/router";
 
@@ -146,7 +146,7 @@ export default function Page() {
 
 
 <div id="js">
-```tsx title="/routes/users.jsx" {5}
+```jsx title="/routes/users.jsx" {5}
 import { For } from "solid-js";
 import { createAsync, query } from "@solidjs/router";
 

--- a/src/routes/solid-start/building-your-application/routing.mdx
+++ b/src/routes/solid-start/building-your-application/routing.mdx
@@ -42,7 +42,7 @@ You will want to make sure `props.children` is wrapped in `<Suspense />` because
 `<FileRoutes />` will generate a route for each file in the `routes` directory and its subdirectories. For a route to be rendered as a page, it must default export a component.
 This component represents the content that will be rendered when users visit the page:
 
-```tsx filename="routes/index.tsx"
+```tsx title="routes/index.tsx"
 export default function Index() {
 	return <div>Welcome to my site!</div>;
 }
@@ -89,7 +89,7 @@ by using `props.children` in the layout.
 
 <TabsCodeBlocks>
   <div id="ts">
-```tsx filename="routes/blog.tsx" title="blog.tsx"
+```tsx title="routes/blog.tsx"
 import { RouteSectionProps } from "@solidjs/router";
 
 export default function BlogLayout(props: RouteSectionProps) {
@@ -98,7 +98,7 @@ export default function BlogLayout(props: RouteSectionProps) {
 ```
    </div>
    <div id="js">
- ```jsx filename="routes/blog.jsx" title="blog.tsx"
+ ```jsx title="routes/blog.jsx"
 export default function BlogLayout(props) {
 	return <div>{props.children}</div>;
 }
@@ -250,7 +250,7 @@ Since SolidStart supports the use of other routers, you can use the `route` expo
 
 <TabsCodeBlocks>
   <div id="ts">
-```jsx {3-7}
+```tsx {3-7}
 import type { RouteSectionProps, RouteDefinition } from "@solidjs/router";
 
 export const route = {


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

This PR addresses several inconsistencies and bugs in the metadata of fenced code blocks:

1. The `twoslash` metadata is specific to a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-twoslash) and is only utilized in the Solid-Meta documentation; therefore, I have removed it.
2. The `filename` metadata has no effect. It seems it was renamed to `title` at some point, but the corresponding updates were not made.
3. Some code blocks contained incorrect language or filenames.
