### PR TITLE
Correct title casing inconsistencies

### DIFF
--- a/src/routes/solid-router/concepts/alternative-routers.mdx
+++ b/src/routes/solid-router/concepts/alternative-routers.mdx
@@ -1,5 +1,5 @@
 ---
-title: Alternative Routers
+title: Alternative routers
 ---
 
 While the default router uses the browser's `location.pathname` to determine the current route, you can use alternative routers to change this behavior.

--- a/src/routes/solid-router/concepts/nesting.mdx
+++ b/src/routes/solid-router/concepts/nesting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Nesting Routes
+title: Nesting routes
 ---
 
 Nested routes are a way to create a hierarchy of routes in your application.

--- a/src/routes/solid-start/advanced/websocket.mdx
+++ b/src/routes/solid-start/advanced/websocket.mdx
@@ -1,5 +1,5 @@
 ---
-title: WebSocket Endpoint
+title: WebSocket endpoint
 ---
 
 WebSocket endpoint may be included by passing the ws handler file you specify in your start config.


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

This PR addresses inconsistencies in title casing across the website. Currently, some titles have unnecessary capitalization. This change standardizes all titles to sentence case (only the first word's first letter is capitalized).