### PR TITLE
Fix inconsistent spelling of 'Solid Router'

### DIFF
--- a/src/i18n/dictionaries/en/ui.ts
+++ b/src/i18n/dictionaries/en/ui.ts
@@ -25,7 +25,7 @@ export default {
 	"main.nav.section.rendering": "Rendering",
 	"main.nav.section.secondary.primitives": "Secondary Primitives",
 	"main.nav.section.stores": "Stores",
-	"main.nav.section.solid.router": "Solid-Router",
+	"main.nav.section.solid.router": "Solid Router",
 	"main.nav.section.solid.router.components": "Components",
 	"main.nav.section.solid.router.data.apis": "Data APIs",
 	"main.nav.section.solid.router.preload.functions": "Preload Functions",

--- a/src/routes/solid-router/index.mdx
+++ b/src/routes/solid-router/index.mdx
@@ -5,11 +5,11 @@ title: Overview
 # Overview
 
 <Callout title="Prerequisites">
-	The docs are based on latest Solid-Router.
+	The docs are based on latest Solid Router.
 	To use this version, you need to have Solid v1.8.4 or later installed.
 </Callout>
 
-Solid-Router is the universal router for Solid which works for rendering on the client or the server.
+Solid Router is the universal router for Solid which works for rendering on the client or the server.
 It was inspired by and combines paradigms of [React Router](https://reactrouter.com/en/main) and the [Ember Router](https://guides.emberjs.com/release/routing/).
 
 A router provides a way to change a user's view based on the URL in the browser.

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -2,7 +2,7 @@
 title: A
 ---
 
-Solid-Router exposes an `<A />` component as a wrapper around the native [`<a />`](https://mdn.io/a) tag.
+Solid Router exposes an `<A />` component as a wrapper around the native [`<a />`](https://mdn.io/a) tag.
 
 `<A />` supports relative and base paths. `<a />` doesn't. But `<a />` gets augmented
 when JS is present via a top-level listener to the DOM, so you get the
@@ -22,7 +22,7 @@ By default matching includes locations that are descendants (e.g.: href `/users`
 ## Soft Navigation
 
 When JavaScript is present at the runtime, both components behave in a very similar fashion.
-This is because Solid-Router adds a listener at the top level of the DOM and will augment the native `<a />` tag to a more performant experience (with soft navigation).
+This is because Solid Router adds a listener at the top level of the DOM and will augment the native `<a />` tag to a more performant experience (with soft navigation).
 
 <Callout type="info">
 

--- a/src/routes/solid-router/reference/data-apis/cache.mdx
+++ b/src/routes/solid-router/reference/data-apis/cache.mdx
@@ -4,7 +4,7 @@ isDeprecated: true
 ---
 
 <Callout type="caution" title="Deprecation Warning">
-This API is deprecated since `v0.15.0` of Solid-Router. Use [query](/solid-router/reference/data-apis/query) instead. It will be removed in an upcoming release.
+This API is deprecated since `v0.15.0` of Solid Router. Use [query](/solid-router/reference/data-apis/query) instead. It will be removed in an upcoming release.
 </Callout>
 
 `cache` is a [higher-order function](https://en.wikipedia.org/wiki/Higher-order_function) designed to create a new function with the same signature as the function passed to it.

--- a/src/routes/solid-start/advanced/auth.mdx
+++ b/src/routes/solid-start/advanced/auth.mdx
@@ -22,7 +22,7 @@ The `getUser` function can be [implemented using sessions](/solid-start/advanced
 ## Protected Routes
 
 Routes can be protected by checking the user or session object during data fetching.
-This example uses [Solid-Router](/solid-router).
+This example uses [Solid Router](/solid-router).
 
 ```tsx
 const getPrivatePosts = query(async function() {


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

This PR replaces all instances of "Solid-Router" with "Solid Router". 

### Related issues & labels

- Closes #1032

