### PR TITLE
Remove beta banner

### DIFF
--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -6,7 +6,6 @@ import { Hero } from "./layout/hero";
 import { cache, createAsync, useMatch } from "@solidjs/router";
 import { DocsLayout } from "./docs-layout";
 import { PageStateProvider } from "~/data/page-state";
-import { Alert } from "@kobalte/core";
 import { SidePanel } from "./layout/side-panel";
 import { SUPPORTED_LOCALES } from "~/i18n/config";
 import { getValidLocaleFromPathname } from "~/i18n/helpers";

--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -142,9 +142,6 @@ export const Layout: ParentComponent<{ isError?: boolean }> = (props) => {
 		<Suspense>
 			<PageStateProvider>
 				<div class="relative dark:bg-slate-900 bg-slate-50">
-					<Alert.Root class="dark:text-slate-900 text-white text-center p-1 font-semibold border-blue-50 dark:border-blue-600 bg-[rgb(14,142,231)] dark:bg-[rgb(162,222,255)]">
-						These docs are currently in Beta!
-					</Alert.Root>
 					<Show when={entries()}>
 						{(data) => <MainHeader tree={data().tree} />}
 					</Show>


### PR DESCRIPTION
This just takes away the beta banner, since it's unclear what it means

Before
<img width="1728" alt="Screenshot 2025-02-10 at 11 54 21" src="https://github.com/user-attachments/assets/a333e2c8-6301-4bbc-adc3-8a8c6bfe283c" />


After
<img width="1554" alt="Screenshot 2025-02-10 at 11 54 07" src="https://github.com/user-attachments/assets/ea4e2955-551a-4a10-beba-d8940bdd5dd5" />
