### PR TITLE
Normalize route component names

### DIFF
--- a/src/routes/solid-router/advanced-concepts/lazy-loading.mdx
+++ b/src/routes/solid-router/advanced-concepts/lazy-loading.mdx
@@ -11,18 +11,18 @@ In Solid Router, you can lazy load components using the `lazy` function from Sol
 import { lazy } from "solid-js";
 import { Router, Route } from "@solidjs/router";
 
-const Home = lazy(() => import("./Home"));
+const HomePage = lazy(() => import("./Home"));
 
-const Users = lazy(() => import("./Users"));
+const UsersPage = lazy(() => import("./Users"));
 
 const App = () => (
   <Router>
-    <Route path="/" component={Home} />
-    <Route path="/users" component={Users} />
+    <Route path="/" component={HomePage} />
+    <Route path="/users" component={UsersPage} />
   </Router>
 );
 ```
 
-In the example above, the `Users` component is lazy loaded using the `lazy` function.
+In the example above, the `UsersPage` component is lazy loaded using the `lazy` function.
 The `lazy` function takes a function that returns a promise, which resolves to the component you want to load.
 When the route is matched, the component will be loaded and rendered.

--- a/src/routes/solid-router/concepts/alternative-routers.mdx
+++ b/src/routes/solid-router/concepts/alternative-routers.mdx
@@ -21,7 +21,7 @@ import {
     Route 
     } from "@solidjs/router";
 
-const App = (props) => (
+const Layout = (props) => (
     <>
         <h1>Root header</h1>
         {props.children}
@@ -29,8 +29,8 @@ const App = (props) => (
 );
 
 render(
-    () => <Router root={App}>{/*... routes */}</Router>,
-    () => <HashRouter root={App}>{/*... routes */}</HashRouter>,
+    () => <Router root={Layout}>{/*... routes */}</Router>,
+    () => <HashRouter root={Layout}>{/*... routes */}</HashRouter>,
     document.getElementById("app")
 );
 
@@ -52,7 +52,7 @@ import {
     Route 
     } from "@solidjs/router";
 
-const App = (props) => (
+const Layout = (props) => (
     <>
         <h1>Root header</h1>
         {props.children}
@@ -60,8 +60,8 @@ const App = (props) => (
 );
 
 render(
-    () => <Router root={App}>{/*... routes */}</Router>,
-    () => <MemoryRouter root={App}>{/*... routes */}</MemoryRouter>,
+    () => <Router root={Layout}>{/*... routes */}</Router>,
+    () => <MemoryRouter root={Layout}>{/*... routes */}</MemoryRouter>,
     document.getElementById("app")
 );
 

--- a/src/routes/solid-router/concepts/catch-all.mdx
+++ b/src/routes/solid-router/concepts/catch-all.mdx
@@ -11,17 +11,17 @@ Optionally, you can name the parameter to access the unmatched part of the URL.
 ```jsx
 import { Router, Route } from "@solidjs/router";
 
-import Home from "./Home";
-import About from "./About";
-import NotFound from "./NotFound";
+import HomePage from "./Home";
+import AboutPage from "./About";
+import NotFoundPage from "./NotFound";
 
 const App = () => (
   <Router>
-    <Route path="/home" component={Home} />
-    <Route path="/about" component={About} />
-    <Route path="*404" component={NotFound} />
+    <Route path="/home" component={HomePage} />
+    <Route path="/about" component={AboutPage} />
+    <Route path="*404" component={NotFoundPage} />
   </Router>
 );
 ```
 
-Now, if a user navigates to a URL that does not match `/home` or `/about`, the `NotFound` component will be rendered.
+Now, if a user navigates to a URL that does not match `/home` or `/about`, the `NotFoundPage` component will be rendered.

--- a/src/routes/solid-router/concepts/layouts.mdx
+++ b/src/routes/solid-router/concepts/layouts.mdx
@@ -14,7 +14,7 @@ To define a root-level layout, pass the layout component to the `root` prop of t
 import { render } from "solid-js/web";
 import { Router, Route } from "@solidjs/router";
 
-import Home from "./pages/Home";
+import HomePage from "./pages/Home";
 
 const Layout = (props) => {
     return (
@@ -29,7 +29,7 @@ const Layout = (props) => {
 render(
     () => (
         <Router root={Layout}>
-            <Route path="/" component={Home} />
+            <Route path="/" component={HomePage} />
             <Route path="/hello-world" component={() => <div>Hello world!</div>} />
         </Router>
     ),
@@ -47,7 +47,7 @@ When you want to create a layout that is specific to a group of routes, you can 
 This can be done by passing `props.children` to the component where the nested routes are defined:
 
 ```jsx
-function PageWrapper(props) {
+function UsersLayout(props) {
 	return (
 		<div>
 			<h1> We love our users! </h1>
@@ -59,16 +59,16 @@ function PageWrapper(props) {
 ```
 
 While the routes are still configured the same, the route's elements will appear inside the parent element where the `props.children` was declared.
-For `PageWrapper` to be used as a layout, in this case, you can pass it as a component to the parent route:
+For `UsersLayout` to be used as a layout, in this case, you can pass it as a component to the parent route:
 
 ```jsx
 <Router>
-    <Route path="/users" component={PageWrapper}>
-        <Route path="/" component={Users} />
-        <Route path="/:id" component={User} />
+    <Route path="/users" component={UsersLayout}>
+        <Route path="/" component={UsersPage} />
+        <Route path="/:id" component={UserPage} />
     </Route>
 </Router>
 ```
 
-Now, when the route is `/users`, the content of the `Users` component will be displayed inside the `PageWrapper` component.
-Similarly, when navigating to `/users/1`, the content of the `User` component will be displayed inside the `PageWrapper` component as well.
+Now, when the route is `/users`, the content of the `UsersPage` component will be displayed inside the `UsersLayout` component.
+Similarly, when navigating to `/users/1`, the content of the `UserPage` component will be displayed inside the `UsersLayout` component as well.

--- a/src/routes/solid-router/concepts/navigation.mdx
+++ b/src/routes/solid-router/concepts/navigation.mdx
@@ -5,7 +5,7 @@ title: "Navigation"
 Once your routes have been created within an application, [anchor tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) can be used to help users navigate between different views or pages.
 
 ```jsx {4-5}
-const App = (props) => (
+const HomePage = (props) => (
 	<>
 		<nav>
 			<a href="/users">Users</a>
@@ -23,7 +23,7 @@ While you can use the native HTML anchor tag, Solid Router does provide a [`<A>`
 While similar to an anchor tag, the `<A>` component supports automatically applying the base URL path and relative paths.
 
 ```jsx {4-5}
-const App = (props) => (
+const HomePage = (props) => (
 	<>
     <nav>
         <A href="/">Home</A>

--- a/src/routes/solid-router/concepts/nesting.mdx
+++ b/src/routes/solid-router/concepts/nesting.mdx
@@ -8,16 +8,16 @@ This is useful for creating a [layout](/solid-router/concepts/layouts) that is c
 In Solid Router, the following two route definitions have the same result:
 
 ```jsx
-<Route path="/users/:id" component={User} />
+<Route path="/users/:id" component={UserPage} />
 
 // is equivalent to
 
 <Route path="/users">
-	<Route path="/:id" component={User} />
+	<Route path="/:id" component={UserPage} />
 </Route>
 ```
 
-In both cases, the `User` component will render when the URL is `/users/:id`.
+In both cases, the `UserPage` component will render when the URL is `/users/:id`.
 The difference, however, is that in the first case, `/users/:id` is the only route, and in the second case, `/users` is also a route.
 
 **Note:** visit the [config-based nesting](#config-based-nesting) section for more information on how to nest routes using the configuration-based approach.
@@ -28,28 +28,28 @@ When nesting routes, only the innermost `Route` component will become its own ro
 For example, if you were to nest a route, only the innermost route will become its own route, even if the parent routes are also specified and provided with a component:
 
 ```jsx
-<Route path="/users" component={Users}>
-	<Route path="/:id" component={User} />
+<Route path="/users" component={UsersLayout}>
+	<Route path="/:id" component={UserPage} />
 </Route>
 ```
 
 For a parent route to become its own route, it must be specified separately. This can be done by explicitly defining the parent route as well as the nested route:
 
 ```jsx
-<Route path="/users" component={Users} />
-<Route path="/users/:id" component={User} />
+<Route path="/users" component={UsersPage} />
+<Route path="/users/:id" component={UserPage} />
 ```
 
 Another way to achieve the same result is to nest the routes and explicitly define the parent route through the use of an empty path, and then specify the nested route:
 
 ```jsx
 <Route path="/users">
-  <Route path="/" component={Users} />
-  <Route path="/:id" component={User} />
+  <Route path="/" component={UsersPage} />
+  <Route path="/:id" component={UserPage} />
 </Route>
 ```
 
-In both cases, the `Users` component will render when the URL is `/users`, and the `User` component will render when the URL is `/users/:id`.
+In both cases, the `UsersPage` component will render when the URL is `/users`, and the `UserPage` component will render when the URL is `/users/:id`.
 
 ## Config-based nesting
 
@@ -79,5 +79,5 @@ const routes = {
 render(() => <Router>{routes}</Router>, document.getElementById("app"));
 ```
 
-In this example, when you navigate to `/users/:id`, the `User` component will render.
-Similarly, when you navigate to `/users`, the `Users` component will render.
+In this example, when you navigate to `/users/:id`, the `UserPage` component will render.
+Similarly, when you navigate to `/users`, the `UsersPage` component will render.

--- a/src/routes/solid-router/concepts/path-parameters.mdx
+++ b/src/routes/solid-router/concepts/path-parameters.mdx
@@ -6,13 +6,13 @@ Parameters within a route are used to capture dynamic values from the URL.
 This is useful for creating routes that are more flexible and can handle different values.
 
 ```jsx
-<Route path="/users/:id" component={User} />
+<Route path="/users/:id" component={UserPage} />
 
 ```
 
 In this example, the `:id` parameter will capture any value that comes after `/users/` in the URL.
 The colon `:` is used to denote a parameter, and `id` is the name of the parameter.
-When a URL matches this route, the `User` component will be rendered.
+When a URL matches this route, the `UserPage` component will be rendered.
 
 <Callout title="Animations & Transitions">
 Routes that share the same path match will be treated as the same route.
@@ -34,7 +34,7 @@ You can retrieve the values captured by parameters using [`useParams`](/solid-ro
 ```jsx frame="terminal" title="http://localhost:3000/users/123"
 import { useParams } from "@solidjs/router";
 
-function User() {
+function UserPage() {
     const params = useParams();
     return <div>User ID: {params.id}</div>; {/* Output: User ID: 123 */}
 }
@@ -51,7 +51,7 @@ import { lazy } from "solid-js";
 import { render } from "solid-js/web";
 import { Router, Route } from "@solidjs/router";
 
-const User = import("./pages/User");
+const UserPage = import("./pages/User");
 
 const filters = {
   parent: ["mom", "dad"], // allow enum values
@@ -63,7 +63,7 @@ render(() => (
   <Router>
     <Route
       path="/users/:parent/:id/:withHtmlExtension"
-      component={User}
+      component={UserPage}
       matchFilters={filters}
     />
   </Router>
@@ -86,7 +86,7 @@ In this example, that means:
 Parameters can be made optional by adding a `?` after the parameter name.
 
 ```jsx
-<Route path="/users/:id?" component={User} />
+<Route path="/users/:id?" component={UserPage} />
 
 ```
 
@@ -101,7 +101,7 @@ Wildcard routes can be used to match any number of segments in a path.
 To create a wildcard route, use `*` followed by the parameter name.
 
 ```jsx
-<Route path="/users/*" component={User} />
+<Route path="/users/*" component={UserPage} />
 
 ```
 
@@ -111,7 +111,7 @@ This includes `/users`, `/users/123`, `/users/123/contact`, and so on.
 If you need to expose the wildcard segments of the path, you can name them:
 
 ```jsx
-<Route path="/users/*rest" component={User} />
+<Route path="/users/*rest" component={UserPage} />
 
 ```
 

--- a/src/routes/solid-router/concepts/search-parameters.mdx
+++ b/src/routes/solid-router/concepts/search-parameters.mdx
@@ -11,7 +11,7 @@ This primitive retrieves a tuple that contains a reactive object that reads the 
 ```jsx {4}
 import { useSearchParams } from "@solidjs/router";
 
-export const App = () => {
+export const Page = () => {
 	const [searchParams, setSearchParams] = useSearchParams();
 
 	return (
@@ -55,7 +55,7 @@ If you require accessing the query string directly, you can use the [`useLocatio
 ```jsx
 import { useLocation } from "@solidjs/router";
 
-export const App = () => {
+export const Page = () => {
 	const location = useLocation();
 
 	return (

--- a/src/routes/solid-router/getting-started/component.mdx
+++ b/src/routes/solid-router/getting-started/component.mdx
@@ -11,12 +11,12 @@ To define routes using JSX, the [`Route`](/solid-router/reference/components/rou
 import { render } from "solid-js/web";
 import { Router, Route } from "@solidjs/router";
 
-import Home from "./routes/Home";
+import HomePage from "./routes/Home";
 
 render(
     () => (
         <Router>
-            <Route path="/" component={Home} />
+            <Route path="/" component={HomePage} />
         </Router>
     ),
     document.getElementById("app")
@@ -24,7 +24,7 @@ render(
 ```
 
 The Route component takes a `path` prop, which is the path to match, and a `component` prop, where you pass the component (or element) to render when the path matches.
-In the example above, the `Home` page is rendered when the user navigates to the root path `/`.
+In the example above, the `HomePage` component is rendered when the user navigates to the root path `/`.
 
 To apply multiple routes to the router, add additional `Route` components to the `Router`:
 
@@ -32,19 +32,19 @@ To apply multiple routes to the router, add additional `Route` components to the
 import { render } from "solid-js/web";
 import { Router, Route } from "@solidjs/router";
 
-import Home from "./routes/index.jsx";
-import About from "./routes/about.jsx";
+import HomePage from "./routes/index.jsx";
+import AboutPage from "./routes/about.jsx";
 
 render(
     () => (
         <Router>
-            <Route path="/" component={Home} />
+            <Route path="/" component={HomePage} />
             <Route path="/hello-world" component={() => <h1>Hello World!</h1>} />
-            <Route path="/about" component={About} />
+            <Route path="/about" component={AboutPage} />
         </Router>
     ),
     document.getElementById("app")
 );
 ```
 
-This example defines three routes: the root path (`/`) which renders the `Home` page, the path `/hello-world` which renders an `h1` element, and the path `/about` which renders the `About` component.
+This example defines three routes: the root path (`/`) which renders the `HomePage` component, the path `/hello-world` which renders an `h1` element, and the path `/about` which renders the `AboutPage` component.

--- a/src/routes/solid-router/guides/migration.mdx
+++ b/src/routes/solid-router/guides/migration.mdx
@@ -37,7 +37,7 @@ That being said the old pattern can be reproduced by turning off preloads at the
 import { lazy } from "solid-js";
 import { Router, Route } from "@solidjs/router";
 
-const User = lazy(() => import("./pages/users/[id].js"));
+const UserPage = lazy(() => import("./pages/users/[id].js"));
 
 // preload function
 function preloadUser({ params, location }) {
@@ -47,7 +47,7 @@ function preloadUser({ params, location }) {
 
 // Pass it in the route definition
 <Router preload={false}>
-	<Route path="/users/:id" component={User} preload={preloadUser} />
+	<Route path="/users/:id" component={UserPage} preload={preloadUser} />
 </Router>;
 ```
 
@@ -58,7 +58,7 @@ import { createContext, useContext } from "solid-js";
 
 const UserContext = createContext();
 
-function User(props) {
+function UserPage(props) {
 	<UserContext.Provider value={props.data()}>
 		{/* my component content that includes <UserDetails /> in any depth  */}
 	</UserContext.Provider>;

--- a/src/routes/solid-router/reference/components/hash-router.mdx
+++ b/src/routes/solid-router/reference/components/hash-router.mdx
@@ -16,7 +16,7 @@ The `root` property is used for components that wrap a matched route and require
 import { render } from "solid-js/web";
 import { HashRouter, Route } from "@solidjs/router";
 
-const App = (props) => (
+const Layout = (props) => (
 	<>
 		<h1>Root header</h1>
 		{props.children}
@@ -24,7 +24,7 @@ const App = (props) => (
 );
 
 render(
-	() => <HashRouter root={App}>{/*... routes */}</HashRouter>,
+	() => <HashRouter root={Layout}>{/*... routes */}</HashRouter>,
 	document.getElementById("app")
 );
 ```

--- a/src/routes/solid-router/reference/components/route.mdx
+++ b/src/routes/solid-router/reference/components/route.mdx
@@ -10,10 +10,10 @@ Routes support defining multiple paths using an array.
 This is useful for when you want a route to remain mounted and not re-render when switching between two or more locations that it matches:
 
 ```jsx
-<Route path={["/login", "/register"]} component={Login} />
+<Route path={["/login", "/register"]} component={LoginPage} />
 ```
 
-This would mean navigating from `/login` to `/register` would not cause the `Login` component to re-render.
+This would mean navigating from `/login` to `/register` would not cause the `LoginPage` component to re-render.
 
 </Callout>
 

--- a/src/routes/solid-router/reference/components/router.mdx
+++ b/src/routes/solid-router/reference/components/router.mdx
@@ -9,7 +9,7 @@ There is an optional `root` prop that can be used to wrap the entire application
 import { render } from "solid-js/web";
 import { Router, Route } from "@solidjs/router";
 
-const App = (props) => (
+const Layout = (props) => (
 	<>
 		<h1>Root header</h1>
 		{props.children}
@@ -17,7 +17,7 @@ const App = (props) => (
 );
 
 render(
-	() => <Router root={App}>{/*... routes */}</Router>,
+	() => <Router root={Layout}>{/*... routes */}</Router>,
 	document.getElementById("app")
 );
 ```


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

This PR standardizes the naming of page and layout components by appending `Page` or `Layout` to their names. This naming convention is beneficial when we define a component outside of its context (such as its use in the router) and helps clarify whether the component functions as a page or a layout.

### Related issues & labels

- Related: https://github.com/solidjs/solid-docs/issues/1052
