### PR TITLE
Add note about using <A> outside <Router>

### DIFF
--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -19,6 +19,13 @@ By default matching includes locations that are descendants (e.g.: href `/users`
 	useful for links to the root route `/` which would match everything.
 </Callout>
 
+<Callout type="info" title="Note">
+
+`<A>` must be used within a `<Router>` component to access routing context.
+Using it outside this hierarchy will result in a runtime error.
+
+</Callout>
+
 ## Soft Navigation
 
 When JavaScript is present at the runtime, both components behave in a very similar fashion.

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -3,7 +3,7 @@ title: A
 ---
 
 Solid Router exposes an `<A />` component as a wrapper around the native [`<a />`](https://mdn.io/a) tag.
-It relies on the routing context provided by a `<Router>` component.
+It relies on the routing context provided by a [`<Router>`](/solid-router/reference/components/router) component.
 When used outside this context, it triggers a runtime error.
 
 `<A />` supports relative and base paths. `<a />` doesn't. But `<a />` gets augmented

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -4,7 +4,6 @@ title: A
 
 Solid Router exposes the `<A />` component as a wrapper around the [native anchor tag ](https://mdn.io/a).
 It relies on the routing context provided by the [`<Router>` component](/solid-router/reference/components/router) and if used outside, will triggers a runtime error..
-When used outside this context, it triggers a runtime error.
 
 `<A />` supports relative and base paths. `<a />` doesn't. But `<a />` gets augmented
 when JS is present via a top-level listener to the DOM, so you get the

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -2,7 +2,7 @@
 title: A
 ---
 
-Solid Router exposes an `<A />` component as a wrapper around the native [`<a />`](https://mdn.io/a) tag.
+Solid Router exposes the `<A />` component as a wrapper around the [native anchor tag ](https://mdn.io/a).
 It relies on the routing context provided by the [`<Router>` component](/solid-router/reference/components/router) and if used outside, will triggers a runtime error..
 When used outside this context, it triggers a runtime error.
 

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -3,6 +3,8 @@ title: A
 ---
 
 Solid Router exposes an `<A />` component as a wrapper around the native [`<a />`](https://mdn.io/a) tag.
+It relies on the routing context provided by a `<Router>` component.
+When used outside this context, it triggers a runtime error.
 
 `<A />` supports relative and base paths. `<a />` doesn't. But `<a />` gets augmented
 when JS is present via a top-level listener to the DOM, so you get the
@@ -17,13 +19,6 @@ By default matching includes locations that are descendants (e.g.: href `/users`
 <Callout type="tip">
 	Use the boolean `end` prop to prevent matching these. This is particularly
 	useful for links to the root route `/` which would match everything.
-</Callout>
-
-<Callout type="info" title="Note">
-
-`<A>` must be used within a `<Router>` component to access routing context.
-Using it outside this hierarchy will result in a runtime error.
-
 </Callout>
 
 ## Soft Navigation

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -3,7 +3,7 @@ title: A
 ---
 
 Solid Router exposes an `<A />` component as a wrapper around the native [`<a />`](https://mdn.io/a) tag.
-It relies on the routing context provided by a [`<Router>`](/solid-router/reference/components/router) component.
+It relies on the routing context provided by the [`<Router>` component](/solid-router/reference/components/router) and if used outside, will triggers a runtime error..
 When used outside this context, it triggers a runtime error.
 
 `<A />` supports relative and base paths. `<a />` doesn't. But `<a />` gets augmented


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

This PR adds a callout about using `<A>` outside of a `<Router>`.

### Related issues & labels

- Related #1052
