### PR TITLE
Replace cache with query - Update return-responses.mdx

### DIFF
--- a/src/routes/solid-start/advanced/return-responses.mdx
+++ b/src/routes/solid-start/advanced/return-responses.mdx
@@ -3,7 +3,7 @@ title: Returning responses
 ---
 
 In SolidStart, it is possible to return a Response object from a server function. 
-[`solid-router`](/solid-router) knows how to handle certain responses with its [`cache`](/solid-router/reference/data-apis/cache) and [`action`](/solid-router/reference/data-apis/action) APIs. 
+[`solid-router`](/solid-router) knows how to handle certain responses with its [`query`](/solid-router/reference/data-apis/query) and [`action`](/solid-router/reference/data-apis/action) APIs. 
 For Typescript, when returning a response using `solid-router`'s `redirect`, `reload`, or `json` helpers, they will not impact the return value of the server function.
 
 While we suggest depending on the type of the function to handle errors differently, you can always return or throw a response.


### PR DESCRIPTION
Replace on instance of `cache` with `query`.

<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

Page had old reference to `cache` which was replaced by `query`.

### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
