### PR TITLE
Update Nitro documentation links

### DIFF
--- a/src/routes/configuration/environment-variables.mdx
+++ b/src/routes/configuration/environment-variables.mdx
@@ -59,7 +59,7 @@ function MyComponent() {
 
 ## Private Environment Variables
 
-These variables should only be accessed in your backend code, so it's best not to use the `VITE_` prefix for them. Instead, use `process.env` to access them. Depending on the [Nitro preset](https://nitro.unjs.io/deploy) chosen, they'll be made available automatically or they will require an external dependency such as [dotenv](https://www.npmjs.com/package/dotenv).
+These variables should only be accessed in your backend code, so it's best not to use the `VITE_` prefix for them. Instead, use `process.env` to access them. Depending on the [Nitro preset](https://nitro.build/deploy) chosen, they'll be made available automatically or they will require an external dependency such as [dotenv](https://www.npmjs.com/package/dotenv).
 
 ```jsx
 DB_HOST="somedb://192.110.0"

--- a/src/routes/solid-start/advanced/websocket.mdx
+++ b/src/routes/solid-start/advanced/websocket.mdx
@@ -3,7 +3,7 @@ title: WebSocket endpoint
 ---
 
 WebSocket endpoint may be included by passing the ws handler file you specify in your start config.
-Note that this feature is [experimental on the Nitro server](https://nitro.unjs.io/guide/websocket#opt-in-to-the-experimental-feature) and its config may change in future releases of SolidStart. Use it with caution.
+Note that this feature is [experimental on the Nitro server](https://nitro.build/guide/websocket#opt-in-to-the-experimental-feature) and its config may change in future releases of SolidStart. Use it with caution.
 
 ```ts title="./app.config.ts"
 import { defineConfig } from "@solidjs/start/config";

--- a/src/routes/solid-start/building-your-application/route-prerendering.mdx
+++ b/src/routes/solid-start/building-your-application/route-prerendering.mdx
@@ -31,4 +31,4 @@ export default defineConfig({
 });
 ```
 
-For more information on prerender options, check out [Nitro's documentation](https://nitro.unjs.io/config#prerender)
+For more information on prerender options, check out [Nitro's documentation](https://nitro.build/config#prerender)

--- a/src/routes/solid-start/getting-started.mdx
+++ b/src/routes/solid-start/getting-started.mdx
@@ -137,7 +137,7 @@ Your application should now be running locally on port 3000.
 You can view it by navigating to [http://localhost:3000](http://localhost:3000).
 
 :::info
-    SolidStart uses [Vinxi](https://vinxi.vercel.app/) both for starting a development server with [Vite](https://vitejs.dev/) and for building and starting a production server with [Nitro](https://nitro.unjs.io/).
+    SolidStart uses [Vinxi](https://vinxi.vercel.app/) both for starting a development server with [Vite](https://vitejs.dev/) and for building and starting a production server with [Nitro](https://nitro.build/).
 
     When you run your application, you are actually running `vinxi dev` under the hood.
     You can read more about the Vinxi CLI, and how it can be configured [here](https://vinxi.vercel.app/api/cli.html).

--- a/src/routes/solid-start/index.mdx
+++ b/src/routes/solid-start/index.mdx
@@ -5,7 +5,7 @@ title: Overview
 # Overview
 
 SolidStart is an open source meta-framework designed to unify components that make up a web application.
-It is built on top of [Solid](/) and uses [Vinxi](https://vinxi.vercel.app/), an agnostic Framework Bundler that combines the power of [Vite](https://vitejs.dev) and [Nitro](https://nitro.unjs.io/).
+It is built on top of [Solid](/) and uses [Vinxi](https://vinxi.vercel.app/), an agnostic Framework Bundler that combines the power of [Vite](https://vitejs.dev) and [Nitro](https://nitro.build/).
 
 Start avoids being opinionated by only providing the fewest pieces to get you started.
 While templates are available that include many of the expected tools, SolidStart itself does not ship with a Router or Metadata library.

--- a/src/routes/solid-start/reference/config/define-config.mdx
+++ b/src/routes/solid-start/reference/config/define-config.mdx
@@ -44,25 +44,25 @@ export default defineConfig({
 
 ## Configuring Nitro
 
-SolidStart uses [Nitro](https://nitro.unjs.io/) to run on a number of platforms. 
+SolidStart uses [Nitro](https://nitro.build/) to run on a number of platforms. 
 The `server` option exposes some Nitro options including the build and deployment presets. 
-An overview of all available presets is available in the [Deploy section of the Nitro documentation](https://nitro.unjs.io/deploy).
+An overview of all available presets is available in the [Deploy section of the Nitro documentation](https://nitro.build/deploy).
 
  Some common ones include:
 
 **Servers**
 
-- [Node.js Server](https://nitro.unjs.io/deploy/runtimes/node#handler-advanced) (`node`) (Default)
-- [Deno Server](https://nitro.unjs.io/deploy/runtimes/deno) (`deno_server`)
+- [Node.js Server](https://nitro.build/deploy/runtimes/node#handler-advanced) (`node`) (Default)
+- [Deno Server](https://nitro.build/deploy/runtimes/deno) (`deno_server`)
 - [Bun Server](https://nitro.build/deploy/runtimes/bun) (`bun`)
 
 **Providers**
 
-- [Netlify Functions and Edge](https://nitro.unjs.io/deploy/providers/netlify) (`netlify`, `netlify-edge`)
-- [Vercel Functions and Edge](https://nitro.unjs.io/deploy/providers/vercel) (`vercel`, `vercel-edge`)
-- [AWS Lambda and Lambda@Edge](https://nitro.unjs.io/deploy/providers/aws) (`aws_lambda`)
-- [Cloudflare Workers and Pages](https://nitro.unjs.io/deploy/providers/cloudflare) (`cloudflare`, `cloudflare_pages`, `cloudflare_module`)
-- [Deno Deploy](https://nitro.unjs.io/deploy/providers/deno-deploy) (`deno_deploy`)
+- [Netlify Functions and Edge](https://nitro.build/deploy/providers/netlify) (`netlify`, `netlify-edge`)
+- [Vercel Functions and Edge](https://nitro.build/deploy/providers/vercel) (`vercel`, `vercel-edge`)
+- [AWS Lambda and Lambda@Edge](https://nitro.build/deploy/providers/aws) (`aws_lambda`)
+- [Cloudflare Workers and Pages](https://nitro.build/deploy/providers/cloudflare) (`cloudflare`, `cloudflare_pages`, `cloudflare_module`)
+- [Deno Deploy](https://nitro.build/deploy/providers/deno-deploy) (`deno_deploy`)
 
 **Static site generation**
 

--- a/src/routes/solid-start/reference/entrypoints/app-config.mdx
+++ b/src/routes/solid-start/reference/entrypoints/app-config.mdx
@@ -3,7 +3,7 @@ title: app.config.ts
 ---
 
 The `app.config.ts` is the root of every SolidStart app and the main point of configuration.
-This file exports a configuration for SolidStart, [Vinxi](https://vinxi.vercel.app/), [Vite](https://vitejs.dev) and [Nitro](https://nitro.unjs.io).
+This file exports a configuration for SolidStart, [Vinxi](https://vinxi.vercel.app/), [Vite](https://vitejs.dev) and [Nitro](https://nitro.build/).
 The easiest way to generate a configuration is to use the [`defineConfig`](/solid-start/reference/config/define-config) helper.
 
 Here [`defineConfig`](/solid-start/reference/config/define-config) is used to create a minimal configuration with default settings.


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

Nitro documentation is now hosted under `nitro.build` instead of `nitro.unjs.io`. Fortunately, this change does not affect our documentation, as the links are automatically redirected to the new site. However, I believe it's important to update them for consistency.

In this pull request, I opened each link in my browser and replaced it with the redirected URL.
