### PR TITLE
Remove the deprecated "cloudflare" preset

### DIFF
--- a/src/routes/solid-start/reference/config/define-config.mdx
+++ b/src/routes/solid-start/reference/config/define-config.mdx
@@ -61,7 +61,7 @@ An overview of all available presets is available in the [Deploy section of the 
 - [Netlify Functions and Edge](https://nitro.unjs.io/deploy/providers/netlify) (`netlify`, `netlify-edge`)
 - [Vercel Functions and Edge](https://nitro.unjs.io/deploy/providers/vercel) (`vercel`, `vercel-edge`)
 - [AWS Lambda and Lambda@Edge](https://nitro.unjs.io/deploy/providers/aws) (`aws_lambda`)
-- [Cloudflare Workers and Pages](https://nitro.unjs.io/deploy/providers/cloudflare) (`cloudflare`, `cloudflare_pages`, `cloudflare_module`)
+- [Cloudflare Workers and Pages](https://nitro.unjs.io/deploy/providers/cloudflare) (`cloudflare_pages`, `cloudflare_module`)
 - [Deno Deploy](https://nitro.unjs.io/deploy/providers/deno-deploy) (`deno_deploy`)
 
 **Static site generation**


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

The "cloudflare" preset is deprecated as described [here](https://nitro.build/deploy/providers/cloudflare#cloudflare-service-workers). This pull request removes it.