### PR TITLE
Fixed typo in page context.md

### DIFF
--- a/src/routes/concepts/context.mdx
+++ b/src/routes/concepts/context.mdx
@@ -99,7 +99,7 @@ export const App = () => (
 ## Customizing Context Utilities
 
 When an application contains multiple context objects, it can be difficult to keep track of which context object is being used.
-To solve this issue, you can create a custom utilities to create a more readable way to access the context values.
+To solve this issue, you can create a custom utility to create a more readable way to access the context values.
 
 For example, when wrapping a component tree, you may want to create a custom `Provider` component that can be used to wrap the component tree.
 This also provides you with the option of re-using the `Provider` component in other parts of your application, if needed.


### PR DESCRIPTION
Changed a word that is in plural form into the singular form.

<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [ x ] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ x ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
In the section of **Customizing Context Utilities** we have the following sentence:
_To solve this issue, you can create a custom **utilities** to create a more readable way to access the context values._

In this sentence, **utilities** should be singular and called **utility**.

**Suggestion:**
_To solve this issue, you can create a custom **utility** to create a more readable way to access the context values._

### Related issues & labels

- Suggested label(s) (optional): 'documentation'
