### PR TITLE
Update refs.mdx

### DIFF
--- a/src/routes/concepts/refs.mdx
+++ b/src/routes/concepts/refs.mdx
@@ -79,7 +79,7 @@ This is useful when you want to access the element directly, but the element may
 ```jsx
 function App() {
 	const [show, setShow] = createSignal(false)
-	const [element, setElement] = createSignal()
+	let element!: HTMLParagraphElement
 
 	return (
 		<div>

--- a/src/routes/concepts/refs.mdx
+++ b/src/routes/concepts/refs.mdx
@@ -86,7 +86,7 @@ function App() {
 			<button onClick={() => setShow((isShown) => !isShown)}>Toggle</button>
 
 			<Show when={show()}>
-				<p ref={setElement}>This is the ref element</p>
+				<p ref={element}>This is the ref element</p>
 			</Show>
 		</div>
 	)


### PR DESCRIPTION
Signal value should be used as red, not the signal setter.

- [ x ] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ x ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
The signals getter should be used as ref, not the signal setter. In the playground it is correct. Just a small mistake in the docs page.

### Related issues & labels
- Suggested label(s) (optional): 'documentation'
