### PR TITLE
Fix `createResource` `state` for `errored` (typo)

### DIFF
--- a/src/routes/reference/basic-reactivity/create-resource.mdx
+++ b/src/routes/reference/basic-reactivity/create-resource.mdx
@@ -94,7 +94,7 @@ const [user] = createResource(() => params.id, fetchUser, {
 #### v1.5.0
 
 1. We've added a new state field which covers a more detailed view of the Resource state beyond `loading` and `error`. 
-You can now check whether a Resource is `unresolved`, `pending`, `ready`, `refreshing`, or `error`.
+You can now check whether a Resource is `unresolved`, `pending`, `ready`, `refreshing`, or `errored`.
 
 | State        | Value resolved | Loading | Has error |
 | ------------ | -------------- | ------- | --------- |
@@ -102,7 +102,7 @@ You can now check whether a Resource is `unresolved`, `pending`, `ready`, `refre
 | `pending`    | No             | Yes     | No        |
 | `ready`      | Yes            | No      | No        |
 | `refreshing` | Yes            | Yes     | No        |
-| `error`      | No             | No      | Yes       |
+| `errored`    | No             | No      | Yes       |
 
 2. When server-rendering resources, especially when embedding Solid in other systems that fetch data before rendering, you might want to initialize the resource with this prefetched value instead of fetching again and having the resource serialize it in its own state.
 You can use the new `ssrLoadFrom` option for this. 


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

For `createResource`, the error state was documented as `error`, which is incorrect. Fixed it it to be `errored`.

- Source type: https://github.com/solidjs/solid/blob/41fa6c14b4bf71eed593303cd63b32d53e3515e9/packages/solid/src/server/rendering.ts#L368
- Source implementation: https://github.com/solidjs/solid/blob/41fa6c14b4bf71eed593303cd63b32d53e3515e9/packages/solid/src/reactive/signal.ts#L662

### Related issues & labels

- Suggested label(s) (optional): 'bug', 'documentation'
