### PR TITLE
Update the structure of props and options reference

### DIFF
--- a/src/routes/reference/basic-reactivity/create-memo.mdx
+++ b/src/routes/reference/basic-reactivity/create-memo.mdx
@@ -2,7 +2,7 @@
 title: createMemo
 ---
 
-Memos let you efficiently use a derived value in many reactive computations. 
+Memos let you efficiently use a derived value in many reactive computations.
 `createMemo` creates a readonly reactive value equal to the return value of the given function and makes sure that function only gets executed when its dependencies change.
 
 ```tsx
@@ -25,9 +25,9 @@ const value = createMemo(() => computeExpensiveValue(a(), b()))
 value()
 ```
 
-In Solid, you often don't need to wrap functions in memos; you can alternatively just define and call a regular function to get similar reactive behavior. 
-The main difference is when you call the function in multiple reactive settings. 
-In this case, when the function's dependencies update, the function will get called multiple times unless it is wrapped in createMemo. 
+In Solid, you often don't need to wrap functions in memos; you can alternatively just define and call a regular function to get similar reactive behavior.
+The main difference is when you call the function in multiple reactive settings.
+In this case, when the function's dependencies update, the function will get called multiple times unless it is wrapped in createMemo.
 For example:
 
 ```tsx
@@ -43,16 +43,16 @@ return (
 )
 ```
 
-When the username signal updates, searchForUser will get called just once. 
+When the username signal updates, searchForUser will get called just once.
 If the returned user actually changed, the user memo updates, and then both list items will update automatically.
 
 If we had instead defined user as a plain function `() => searchForUser(username())`, then `searchForUser` would have been called twice, once when updating each list item.
 
-Another key difference is that a memo can shield dependents from updating when the memo's dependencies change but the resulting memo value doesn't. 
-Like [createSignal](/reference/basic-reactivity/create-signal), the derived signal made by `createMemo` updates (and triggers dependents to rerun) only when the value returned by the memo function actually changes from the previous value, according to JavaScript's `===` operator. 
+Another key difference is that a memo can shield dependents from updating when the memo's dependencies change but the resulting memo value doesn't.
+Like [createSignal](/reference/basic-reactivity/create-signal), the derived signal made by `createMemo` updates (and triggers dependents to rerun) only when the value returned by the memo function actually changes from the previous value, according to JavaScript's `===` operator.
 Alternatively, you can pass an options object with `equals` set to false to always update the memo when its dependencies change, or you can pass your own `equals` function for testing equality.
 
-The memo function is called with an argument equal to the value returned from the previous execution of the memo function, or, on the first call, equal to the optional second argument to `createMemo`. 
+The memo function is called with an argument equal to the value returned from the previous execution of the memo function, or, on the first call, equal to the optional second argument to `createMemo`.
 This is useful for reducing computations, such as:
 
 ```tsx
@@ -60,13 +60,25 @@ This is useful for reducing computations, such as:
 const sum = createMemo((prev) => input() + prev, 0)
 ```
 
-The memo function should not change other signals by calling setters (it should be "pure"). 
+The memo function should not change other signals by calling setters (it should be "pure").
 This enables Solid to optimize the execution order of memo updates according to their dependency graph, so that all memos can update at most once in response to a dependency change.
 
-## Options and arguments
+## Parameters
 
-| Name    | Type                                                    | Description                                                    |
-| :------ | :------------------------------------------------------ | :------------------------------------------------------------- |
-| fn      | `(v: T) => T`                                           | The function to memoize.                                       |
-| value   | `T`                                                     | The initial value of the memo.                                 |
-| options | `{ equals?: false \| ((prev: T, next: T) => boolean) }` | An optional object with an `equals` function to test equality. |
+### `fn`
+
+**Type**: `(v: T) => T`
+
+The function to memoize.
+
+### `value`
+
+**Type**: `T`
+
+The initial value of the memo.
+
+### `options`
+
+**Type**: `{ equals?: false | ((prev: T, next: T) => boolean) }`
+
+An optional object with an `equals` function to test equality.

--- a/src/routes/reference/basic-reactivity/create-resource.mdx
+++ b/src/routes/reference/basic-reactivity/create-resource.mdx
@@ -4,7 +4,7 @@ title: createResource
 
 `createResource` takes an asynchronous fetcher function and returns a signal that is updated with the resulting data when the fetcher completes.
 
-There are two ways to use `createResource`: you can pass the fetcher function as the sole argument, or you can additionally pass a source signal as the first argument. 
+There are two ways to use `createResource`: you can pass the fetcher function as the sole argument, or you can additionally pass a source signal as the first argument.
 The source signal will retrigger the fetcher whenever it changes, and its value will be passed to the fetcher.
 
 ```tsx
@@ -15,15 +15,15 @@ const [data, { mutate, refetch }] = createResource(fetchData)
 const [data, { mutate, refetch }] = createResource(source, fetchData)
 ```
 
-In these snippets, the fetcher is the function `fetchData`, and `data()` is undefined until `fetchData` finishes resolving. 
-In the first case, `fetchData` will be called immediately. 
-In the second, `fetchData` will be called as soon as `source` has any value other than false, null, or undefined. 
+In these snippets, the fetcher is the function `fetchData`, and `data()` is undefined until `fetchData` finishes resolving.
+In the first case, `fetchData` will be called immediately.
+In the second, `fetchData` will be called as soon as `source` has any value other than false, null, or undefined.
 It will be called again whenever the value of `source` changes, and that value will always be passed to `fetchData` as its first argument.
 
-You can call `mutate` to directly update the `data` signal (it works like any other signal setter). 
+You can call `mutate` to directly update the `data` signal (it works like any other signal setter).
 You can also call refetch to rerun the fetcher directly, and pass an optional argument to provide additional info to the fetcher e.g `refetch(info)`.
 
-`data` works like a normal signal getter: use `data()` to read the last returned value of `fetchData`. 
+`data` works like a normal signal getter: use `data()` to read the last returned value of `fetchData`.
 But it also has extra reactive properties:
 
 - `data.loading`: whether the fetcher has been called but not returned.
@@ -33,8 +33,8 @@ But it also has extra reactive properties:
   - Fetcher throws an `Error` instance, `data.error` will be that instance.
   - If the fetcher throws a string, `data.error.message` will contain that string.
   - When the fetcher throws a value that is neither an `Error` nor a string, that value will be available as `data.error.cause`.
-  
-- As of **v1.4.0**, `data.latest` returns the last value received and will not trigger [Suspense](/reference/components/suspense) or [transitions](#TODO); if no value has been returned yet, `data.latest` will act the same as `data()`. 
+
+- As of **v1.4.0**, `data.latest` returns the last value received and will not trigger [Suspense](/reference/components/suspense) or [transitions](#TODO); if no value has been returned yet, `data.latest` will act the same as `data()`.
   This can be useful if you want to show the out-of-date data while the new data is loading.
 
 `loading`, `error`, and `latest` are reactive getters and can be tracked.
@@ -42,9 +42,9 @@ But it also has extra reactive properties:
 ## The fetcher
 
 The `fetcher` is the async function that you provide to `createResource` to actually fetch the data.
-It is passed two arguments: the value of the source signal (if provided), and an info object with two properties: `value` and `refetching`. 
-The `value` property tells you the previously fetched value. 
-The `refetching` property is true if the `fetcher` was triggered using the refetch function and false otherwise. 
+It is passed two arguments: the value of the source signal (if provided), and an info object with two properties: `value` and `refetching`.
+The `value` property tells you the previously fetched value.
+The `refetching` property is true if the `fetcher` was triggered using the refetch function and false otherwise.
 If the `refetch` function was called with an argument (`refetch(info)`), refetching is set to that argument.
 
 ```tsx
@@ -93,7 +93,7 @@ const [user] = createResource(() => params.id, fetchUser, {
 
 #### v1.5.0
 
-1. We've added a new state field which covers a more detailed view of the Resource state beyond `loading` and `error`. 
+1. We've added a new state field which covers a more detailed view of the Resource state beyond `loading` and `error`.
 You can now check whether a Resource is `unresolved`, `pending`, `ready`, `refreshing`, or `errored`.
 
 | State        | Value resolved | Loading | Has error |
@@ -105,7 +105,7 @@ You can now check whether a Resource is `unresolved`, `pending`, `ready`, `refre
 | `errored`    | No             | No      | Yes       |
 
 2. When server-rendering resources, especially when embedding Solid in other systems that fetch data before rendering, you might want to initialize the resource with this prefetched value instead of fetching again and having the resource serialize it in its own state.
-You can use the new `ssrLoadFrom` option for this. 
+You can use the new `ssrLoadFrom` option for this.
 Instead of using the default `server` value, you can pass `initial` and the resource will use `initialValue` as if it were the result of the first fetch for both SSR and hydration.
 
 ```tsx
@@ -115,7 +115,7 @@ const [data, { mutate, refetch }] = createResource(() => params.id, fetchUser, {
 })
 ```
 
-3. Resources can be set with custom defined storage with the same signature as a Signal by using the storage option. 
+3. Resources can be set with custom defined storage with the same signature as a Signal by using the storage option.
 For example using a custom reconciling store could be done this way:
 
 ```tsx
@@ -145,14 +145,50 @@ This option is still experimental and may change in the future.
 
 The `createResource` function takes an optional third argument, an options object. The options are:
 
-| Name         | Type                    | Default        | Description                                                                                                                                                   |
-| ------------ | ----------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name         | `string`                | `undefined`    | A name for the resource. This is used for debugging purposes.                                                                                                 |
-| deferStream  | `boolean`               | `false`        | If true, Solid will wait for the resource to resolve before flushing the stream.                                                                              |
-| initialValue | `any`                   | `undefined`    | The initial value of the resource.                                                                                                                            |
-| onHydrated   | `function`              | `undefined`    | A callback that is called when the resource is hydrated.                                                                                                      |
-| ssrLoadFrom  | `"server" \| "initial"` | `"server"`     | The source of the initial value for SSR. If set to `"initial"`, the resource will use the `initialValue` option instead of the value returned by the fetcher. |
-| storage      | `function`              | `createSignal` | A function that returns a signal. This can be used to create a custom storage for the resource. This is still experimental                                    |
+### `name`
+
+**Type**: `string`
+
+A name for the resource.
+This is used for debugging purposes.
+
+### `deferStream`
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+If true, Solid will wait for the resource to resolve before flushing the stream.
+
+### `initialValue`
+
+**Type**: `any`
+
+The initial value of the resource.
+
+### `onHydrated`
+
+**Type**: `function`
+
+A callback that is called when the resource is hydrated.
+
+### `ssrLoadFrom`
+
+**Type**: `"server" | "initial"`
+
+**Default**: `"server"`
+
+The source of the initial value for SSR.
+If set to `"initial"`, the resource will use the `initialValue` option instead of the value returned by the fetcher.
+
+### `storage`
+
+**Type**: `function`
+
+**Default**: `createSignal`
+
+A function that returns a signal.
+This can be used to create a custom storage for the resource. This is still experimental
 
 ## Note for TypeScript users
 

--- a/src/routes/reference/basic-reactivity/create-signal.mdx
+++ b/src/routes/reference/basic-reactivity/create-signal.mdx
@@ -2,7 +2,7 @@
 title: createSignal
 ---
 
-Signals are the most basic reactive primitive. 
+Signals are the most basic reactive primitive.
 They track a single value (which can be a value of any type) that changes over time.
 
 ```tsx
@@ -38,8 +38,8 @@ Calling the getter (e.g., `count()` or `ready()`) returns the current value of t
 
 Crucial to automatic dependency tracking, calling the getter within a tracking scope causes the calling function to depend on this Signal, so that function will rerun if the Signal gets updated.
 
-Calling the setter (e.g., `setCount(nextCount)` or `setReady(nextReady)`) sets the Signal's value and updates the Signal (triggering dependents to rerun) if the value actually changed (see details below). 
-The setter takes either the new value for the signal or a function that maps the previous value of the signal to a new value as its only argument. 
+Calling the setter (e.g., `setCount(nextCount)` or `setReady(nextReady)`) sets the Signal's value and updates the Signal (triggering dependents to rerun) if the value actually changed (see details below).
+The setter takes either the new value for the signal or a function that maps the previous value of the signal to a new value as its only argument.
 The updated value is also returned by the setter. As an example:
 
 ```tsx
@@ -81,11 +81,30 @@ const newCount = setCount((prev) => prev + 1)
 
 ## Options
 
-| Name       | Type                                       | Default | Description                                                                                                                                                                                                                                                         |
-| ---------- | ------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `equals`   | `false \| ((prev: T, next: T) => boolean)` | `===`   | A function that determines whether the Signal's value has changed. If the function returns true, the Signal's value will not be updated and dependents will not rerun. If the function returns false, the Signal's value will be updated and dependents will rerun. |
-| `name`     | `string`                                   |         | A name for the Signal. This is useful for debugging.                                                                                                                                                                                                                |
-| `internal` | `boolean`                                  | `false` | If true, the Signal will not be accessible in the devtools.                                                                                                                                                                                                         |
+### `equals`
+
+**Type**: `false | ((prev: T, next: T) => boolean)`
+
+**Default**: `===`
+
+A function that determines whether the Signal's value has changed.
+If the function returns true, the Signal's value will not be updated and dependents will not rerun.
+If the function returns false, the Signal's value will be updated and dependents will rerun.
+
+### `name`
+
+**Type**: `string`
+
+A name for the Signal.
+This is useful for debugging.
+
+### `internal`
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+If true, the Signal will not be accessible in the devtools.
 
 ### `equals`
 

--- a/src/routes/reference/components/dynamic.mdx
+++ b/src/routes/reference/components/dynamic.mdx
@@ -25,8 +25,12 @@ Here's an example of how you can use it:
 
 ## Props
 
-| Name        | Type                                                        | Description                               |
-| :---------- | :---------------------------------------------------------- | :---------------------------------------- |
-| `component` | `Component<T>` \| `string` \| `keyof JSX.IntrinsicElements` | The component to render.                  |
-| `children`  | `any`                                                       | The children to pass to the component.    |
-| `...`       | `T`                                                         | Any other props to pass to the component. |
+### `component`
+
+**Type**: `Component<T> | string | keyof JSX.IntrinsicElements`
+
+The component to render.
+
+### `children`
+
+Any other props to pass to the component.

--- a/src/routes/reference/components/for.mdx
+++ b/src/routes/reference/components/for.mdx
@@ -44,8 +44,20 @@ The optional second argument is an index signal:
 
 ## Props
 
-| Name       | Type                                  | Description                                                      |
-| :--------- | :------------------------------------ | :--------------------------------------------------------------- |
-| `each`     | `readonly T[]`                        | The list of items to render.                                     |
-| `fallback` | `JSX.Element`                         | A fallback element to render while the list is loading.          |
-| `children` | `(item: T, index: () => number) => U` | A callback that returns a JSX element for each item in the list. |
+### `each`
+
+**Type**: `readonly T[]`
+
+The list of items to render.
+
+### `fallback`
+
+**Type**: `JSX.Element`
+
+A fallback element to render while the list is loading.
+
+### `children`
+
+**Type**: `(item: T, index: () => number) => U`
+
+A callback that returns a JSX element for each item in the list.

--- a/src/routes/reference/components/index-component.mdx
+++ b/src/routes/reference/components/index-component.mdx
@@ -54,8 +54,20 @@ Optional second argument is an index number:
 
 ## Props
 
-| Name     | Type                                  | Description                                                     |
-| :------- | :------------------------------------ | :-------------------------------------------------------------- |
-| each     | `readonly T[]`                        | The array to iterate over.                                      |
-| fallback | `JSX.Element`                         | Optional fallback element to render while the array is loading. |
-| children | `(item: () => T, index: number) => U` | The function that renders the children.                         |
+### `each`
+
+**Type**: `readonly T[]`
+
+The array to iterate over.
+
+### `fallback`
+
+**Type**: `JSX.Element`
+
+Optional fallback element to render while the array is loading.
+
+### `children`
+
+**Type**: `(item: () => T, index: number) => U`
+
+The function that renders the children.

--- a/src/routes/reference/components/portal.mdx
+++ b/src/routes/reference/components/portal.mdx
@@ -18,11 +18,11 @@ function Portal(props: {
 }): Text
 ```
 
-This inserts the element in the mount node. 
-Useful for inserting Modals outside of the page layout. 
+This inserts the element in the mount node.
+Useful for inserting Modals outside of the page layout.
 Events still propagate through the component hierarchy, however `<Portal>` will only run on the client and has hydration _disabled_.
 
-The portal is mounted in a `<div>` unless the target is the document head. 
+The portal is mounted in a `<div>` unless the target is the document head.
 `useShadow` places the element in a Shadow Root for style isolation, and `isSVG` is required if inserting into an SVG element so that the `<div>` is not inserted.
 
 ```tsx
@@ -33,8 +33,26 @@ The portal is mounted in a `<div>` unless the target is the document head.
 
 ## Props
 
-| Name        | Type      | Default       | Description                                       |
-| :---------- | :-------- | :------------ | :------------------------------------------------ |
-| `mount`     | `Node`    | document.body | The DOM node to mount the portal in.              |
-| `useShadow` | `boolean` | false         | Whether to use a Shadow Root for style isolation. |
-| `isSVG`     | `boolean` | false         | Whether the mount node is an SVG element.         |
+### `mount`
+
+**Type**:`Node`
+
+**Default**: `document.body`
+
+The DOM node to mount the portal in.
+
+### `useShadow`
+
+**Type**:`boolean`
+
+**Default**: `false`
+
+Whether to use a Shadow Root for style isolation.
+
+### `isSVG`
+
+**Type**:`boolean`
+
+**Default**: `false
+
+Whether the mount node is an SVG element.

--- a/src/routes/reference/components/show.mdx
+++ b/src/routes/reference/components/show.mdx
@@ -43,8 +43,20 @@ If the `keyed` property is not used, the argument of the child function will be 
 
 ## Props
 
-| Name       | Type                              | Description                                   |
-| :--------- | :-------------------------------- | :-------------------------------------------- |
-| `when`     | `T \| undefined \| null \| false` | The value to test for truthiness              |
-| `keyed`    | `boolean`                         | Whether to key the block to the value of when |
-| `fallback` | `JSX.Element`                     | The fallback to render when the `when` is falsy     |
+### `when`
+
+**Type**: `T | undefined | null | false`
+
+The value to test for truthiness.
+
+### `keyed`
+
+**Type**: `boolean`
+
+Whether to key the block to the value of when.
+
+### `fallback`
+
+**Type**: `JSX.Element`
+
+The fallback to render when the `when` is falsy.

--- a/src/routes/reference/components/suspense-list.mdx
+++ b/src/routes/reference/components/suspense-list.mdx
@@ -34,14 +34,13 @@ Here's an example of how to use SuspenseList:
 
 ## Props
 
-| Name          | Type                                      | Default      | Description                                                                 |
-| ------------- | ----------------------------------------- | ------------ | --------------------------------------------------------------------------- |
-| `revealOrder` | `"forwards" \| "backwards" \| "together"` | `"forwards"` | Determines the order in which the SuspenseList children should be revealed. |
-| `tail`        | `"collapsed" \| "hidden"`                 | `undefined`  | TODO                                                                        |
-
 ### `revealOrder`
 
-`"forwards" | "backwards" | "together"`
+**Type**: `"forwards" | "backwards" | "together"`
+
+**Default**: `"forwards"`
+
+Determines the order in which the SuspenseList children should be revealed.
 
 - `"forwards"`: Reveals each item in the list once the previous item has finished rendering. This is the default.
 - `"backwards"`: Reveals each item in the list once the next item has finished rendering.
@@ -49,4 +48,4 @@ Here's an example of how to use SuspenseList:
 
 ### `tail`
 
-`"collapsed" | "hidden"`
+**Type**: `"collapsed" | "hidden"`

--- a/src/routes/reference/components/suspense.mdx
+++ b/src/routes/reference/components/suspense.mdx
@@ -143,6 +143,8 @@ In this code, we don't create _any_ DOM nodes inside {"<Suspense>"} before the r
 
 ## Props
 
-| Name       | Type          | Description                                                      |
-| :--------- | :------------ | :--------------------------------------------------------------- |
-| `fallback` | `JSX.Element` | The fallback component to render while the children are loading. |
+### `fallback`
+
+**Type**: `JSX.Element`
+
+The fallback component to render while the children are loading.

--- a/src/routes/reference/components/switch-and-match.mdx
+++ b/src/routes/reference/components/switch-and-match.mdx
@@ -53,16 +53,19 @@ For example, it can be used to perform basic routing:
 
 Match also supports function children to serve as keyed flow.
 
-## Props
+## Switch props
 
-### Switch
+### `fallback`
 
-| Name       | Type          | Default     | Description                                                                      |
-| ---------- | ------------- | ----------- | -------------------------------------------------------------------------------- |
-| `fallback` | `JSX.Element` | `undefined` | The fallback element to render if no `Match` component has a truthy `when` prop. |
+**Type**: `JSX.Element`
 
-### Match
+The fallback element to render if no `Match` component has a truthy `when` prop.
 
-| Name   | Type                              | Default     | Description                                                               |
-| ------ | --------------------------------- | ----------- | ------------------------------------------------------------------------- |
-| `when` | `T \| undefined \| null \| false` | `undefined` | The condition to check. If it is truthy, the `children` will be rendered. |
+## Match props
+
+### `when`
+
+**Type**: `T | undefined | null | false`
+
+The condition to check.
+If it is truthy, the `children` will be rendered.

--- a/src/routes/reference/reactive-utilities/from.mdx
+++ b/src/routes/reference/reactive-utilities/from.mdx
@@ -17,7 +17,7 @@ function from<T>(
 
 ```
 
-A helper to make it easier to interop with external producers like RxJS observables or with Svelte Stores. 
+A helper to make it easier to interop with external producers like RxJS observables or with Svelte Stores.
 This basically turns any subscribable (object with a subscribe method) into a Signal and manages subscription and disposal.
 
 ```tsx
@@ -36,8 +36,10 @@ const clock = from((set) => {
 })
 ```
 
-## Arguments
+## Parameters
 
-| Name     | Type                                                                                                                           | Description                                  |
-| :------- | :----------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------- |
-| producer | `((setter: (v: T) => T) => () => void) \| { subscribe: (fn: (v: T) => void) => (() => void) \| { unsubscribe: () => void }; }` | The producer function or subscribable object |
+### `producer`
+
+**Type**: `((setter: (v: T) => T) => () => void) | { subscribe: (fn: (v: T) => void) => (() => void) | { unsubscribe: () => void }; }`
+
+The producer function or subscribable object.

--- a/src/routes/reference/reactive-utilities/index-array.mdx
+++ b/src/routes/reference/reactive-utilities/index-array.mdx
@@ -12,7 +12,7 @@ function indexArray<T, U>(
 
 ```
 
-Similar to `mapArray` except it maps by index. 
+Similar to `mapArray` except it maps by index.
 The item is a signal and the index is now the constant.
 
 Underlying helper for the `<Index>` control flow.
@@ -33,9 +33,16 @@ const mapped = indexArray(source, (model) => {
 });
 ```
 
-## Arguments
+## Parameters
 
-| Name  | Type                           | Description           |
-| :---- | :----------------------------- | :-------------------- |
-| list  | `() => readonly T[]`           | The list to map.      |
-| mapFn | `(v: () => T, i: number) => U` | The mapping function. |
+### `list`
+
+**Type**: `() => readonly T[]`
+
+The list to map.
+
+### `mapFn`
+
+**Type**: `(v: () => T, i: number) => U`
+
+The mapping function.

--- a/src/routes/reference/reactive-utilities/map-array.mdx
+++ b/src/routes/reference/reactive-utilities/map-array.mdx
@@ -12,8 +12,8 @@ function mapArray<T, U>(
 
 ```
 
-Reactive map helper that caches each item by reference to reduce unnecessary mapping on updates. 
-It only runs the mapping function once per value and then moves or removes it as needed. 
+Reactive map helper that caches each item by reference to reduce unnecessary mapping on updates.
+It only runs the mapping function once per value and then moves or removes it as needed.
 The index argument is a signal. The map function itself is not tracking.
 
 Underlying helper for the `<For>` control flow.
@@ -37,9 +37,16 @@ const mapped = mapArray(source, (model) => {
 })
 ```
 
-## Arguments
+## Parameters
 
-| Name  | Type                           | Description              |
-| :---- | :----------------------------- | :----------------------- |
-| list  | `() => readonly T[]`           | The source array to map. |
-| mapFn | `(v: T, i: () => number) => U` | The mapping function.    |
+### `list`
+
+**Type**: `() => readonly T[]`
+
+The source array to map.
+
+### `mapFn`
+
+**Type**: `(v: T, i: () => number) => U`
+
+The mapping function.

--- a/src/routes/reference/reactive-utilities/on-util.mdx
+++ b/src/routes/reference/reactive-utilities/on-util.mdx
@@ -61,10 +61,22 @@ createEffect(
 setState({ a: 4 }); // logs 4
 ```
 
-## Arguments and options
+## Parameters
 
-| Argument | Type                                           | Description                                       |
-| :------- | :--------------------------------------------- | :------------------------------------------------ |
-| deps     | `T`                                            | The dependencies to watch.                        |
-| fn       | `(input: T, prevInput: T, prevValue?: U) => U` | The function to run when the dependencies change. |
-| options  | `{ defer?: boolean }`                          | Options to configure the effect.                  |
+### `deps`
+
+**Type**: `T`
+
+The dependencies to watch.
+
+### `fn`
+
+**Type**: `(input: T, prevInput: T, prevValue?: U) => U`
+
+The function to run when the dependencies change.
+
+### `options`
+
+**Type**: `{ defer?: boolean }`
+
+Options to configure the effect.

--- a/src/routes/reference/rendering/hydrate.mdx
+++ b/src/routes/reference/rendering/hydrate.mdx
@@ -24,9 +24,22 @@ const dispose = hydrate(App, document.getElementById("app"))
 
 ## Parameters
 
-| Prop                 | type               | description                                     |
-| -------------------- | ------------------ | ----------------------------------------------- |
-| fn                   | `() => JSX.Element`| Function that returns the application code.     |
-| node                 | MountableElement   | DOM Element to mount the application to         |
-| options.renderId     | string             |                                                 |
-| options.owner        | unknown            |                                                 |
+### `fn`
+
+**Type**: `() => JSX.Element`
+
+Function that returns the application code.
+
+### `node`
+
+**Type**: `MountableElement`
+
+DOM Element to mount the application to.
+
+### `options.renderId`
+
+**Type**: `string`
+
+### `options.owner`
+
+**Type**: `unknown`

--- a/src/routes/reference/rendering/render-to-stream.mdx
+++ b/src/routes/reference/rendering/render-to-stream.mdx
@@ -43,9 +43,26 @@ renderToStream(App).pipeTo(writable)
 
 ## Options
 
-| Name            | Type       | Description                                                      |
-| --------------- | ---------- | ---------------------------------------------------------------- |
-| nonce           | string     | The nonce to use for inline scripts.                             |
-| renderId        | string     | The id to use for this render.                                   |
-| onCompleteShell | () => void | A callback that fires when the shell is complete.                |
-| onCompleteAll   | () => void | A callback that fires when all Suspense boundaries have settled. |
+### `nonce`
+
+**Type**: `string`
+
+The nonce to use for inline scripts.
+
+### `renderId`
+
+**Type**: `string`
+
+The id to use for this render.
+
+### `onCompleteShell`
+
+**Type**: `() => void`
+
+A callback that fires when the shell is complete.
+
+### `onCompleteAll`
+
+**Type**: `() => void`
+
+A callback that fires when all Suspense boundaries have settled.

--- a/src/routes/reference/rendering/render-to-string-async.mdx
+++ b/src/routes/reference/rendering/render-to-string-async.mdx
@@ -16,7 +16,7 @@ function renderToStringAsync<T>(
 
 ```
 
-Same as `renderToString` except that it will wait for all `<Suspense>` boundaries to resolve before returning the results. 
+Same as `renderToString` except that it will wait for all `<Suspense>` boundaries to resolve before returning the results.
 Resource data is automatically serialized into the script tag and will be hydrated on client load.
 
 `renderId` is used to namespace renders when having multiple top level roots.
@@ -27,8 +27,20 @@ const html = await renderToStringAsync(App)
 
 ## Options
 
-| Name        | Type     | Description                                                                                  |
-| ----------- | -------- | -------------------------------------------------------------------------------------------- |
-| `timeoutMs` | `number` | The number of milliseconds to wait for a `<Suspense>` boundary to resolve before timing out. |
-| `renderId`  | `string` | The id to use for the render.                                                                |
-| `nonce`     | `string` | The nonce to use for the script tag.                                                         |
+### `timeoutMs`
+
+**Type**: `number`
+
+The number of milliseconds to wait for a `<Suspense>` boundary to resolve before timing out.
+
+### `renderId`
+
+**Type**: `string`
+
+The id to use for the render.
+
+### `nonce`
+
+**Type**: `string`
+
+The nonce to use for the script tag.

--- a/src/routes/reference/rendering/render-to-string.mdx
+++ b/src/routes/reference/rendering/render-to-string.mdx
@@ -15,8 +15,8 @@ function renderToString<T>(
 
 ```
 
-Renders to a string synchronously. 
-The function also generates a script tag for progressive hydration. 
+Renders to a string synchronously.
+The function also generates a script tag for progressive hydration.
 Options include eventNames to listen to before the page loads and play back on hydration, and nonce to put on the script tag.
 
 `renderId` is used to namespace renders when having multiple top level roots.
@@ -27,7 +27,14 @@ const html = renderToString(App)
 
 ## Options
 
-| Name       | Type     | Description                          |
-| ---------- | -------- | ------------------------------------ |
-| `nonce`    | `string` | The nonce to use for the script tag. |
-| `renderId` | `string` | The id to use for the script tag.    |
+### `nonce`
+
+**Type**: `string`
+
+The nonce to use for the script tag.
+
+### `renderId`
+
+**Type**: `string`
+
+The id to use for the script tag.

--- a/src/routes/reference/rendering/render.mdx
+++ b/src/routes/reference/rendering/render.mdx
@@ -28,7 +28,14 @@ It's important that the first argument is a function: do not pass JSX directly (
 
 ## Parameters
 
-| Argument             | Type                | Description                                     |
-| -------------------- | ------------------- | ----------------------------------------------- |
-| code                 | `() => JSX.Element` | Function that returns the application code.     |
-| element              | MountableElement    | DOM Element to mount the application to         |
+### `code`
+
+**Type**: `() => JSX.Element`
+
+Function that returns the application code.
+
+### `element`
+
+**Type**: `MountableElement`
+
+DOM Element to mount the application to.

--- a/src/routes/reference/secondary-primitives/create-computed.mdx
+++ b/src/routes/reference/secondary-primitives/create-computed.mdx
@@ -9,23 +9,30 @@ function createComputed<T>(fn: (v: T) => T, value?: T): void
 
 ```
 
-`createComputed` creates a new computation that immediately runs the given function in a tracking scope, thus automatically tracking its dependencies, and automatically reruns the function whenever the dependencies changes. 
-The function gets called with an argument equal to the value returned from the function's last execution, or on the first call, equal to the optional second argument to `createComputed`. 
+`createComputed` creates a new computation that immediately runs the given function in a tracking scope, thus automatically tracking its dependencies, and automatically reruns the function whenever the dependencies changes.
+The function gets called with an argument equal to the value returned from the function's last execution, or on the first call, equal to the optional second argument to `createComputed`.
 Note that the return value of the function is not otherwise exposed; in particular, createComputed has no return value.
 
-`createComputed` is the most immediate form of reactivity in Solid, and is most useful for building other reactive primitives. 
-For example, some other Solid primitives are built from `createComputed`. 
-However, it should be used with care, as `createComputed` can easily cause more unnecessary updates than other reactive primitives. 
+`createComputed` is the most immediate form of reactivity in Solid, and is most useful for building other reactive primitives.
+For example, some other Solid primitives are built from `createComputed`.
+However, it should be used with care, as `createComputed` can easily cause more unnecessary updates than other reactive primitives.
 Before using it, consider the closely related primitives [`createMemo`](/reference/basic-reactivity/create-memo) and [`createRenderEffect`](/reference/secondary-primitives/create-render-effect).
 
-Like `createMemo`, `createComputed` calls its function immediately on updates (unless you're in a [batch](/reference/reactive-utilities/batch), [effect](/reference/basic-reactivity/create-effect), or [transition](/reference/reactive-utilities/use-transition)). 
-However, while `createMemo` functions should be pure (not set any signals), `createComputed` functions can set signals. 
-Related, `createMemo` offers a readonly signal for the return value of the function, whereas to do the same with `createComputed` you would need to set a signal within the function. 
+Like `createMemo`, `createComputed` calls its function immediately on updates (unless you're in a [batch](/reference/reactive-utilities/batch), [effect](/reference/basic-reactivity/create-effect), or [transition](/reference/reactive-utilities/use-transition)).
+However, while `createMemo` functions should be pure (not set any signals), `createComputed` functions can set signals.
+Related, `createMemo` offers a readonly signal for the return value of the function, whereas to do the same with `createComputed` you would need to set a signal within the function.
 If it is possible to use pure functions and `createMemo`, this is likely more efficient, as Solid optimizes the execution order of memo updates, whereas updating a signal within `createComputed` will immediately trigger reactive updates some of which may turn out to be unnecessary.
 
-## Arguments
+## Parameters
 
-| Name    | Type          | Description                                |
-| :------ | :------------ | :----------------------------------------- |
-| `fn`    | `(v: T) => T` | The function to run in a tracking scope.   |
-| `value` | `T`           | The initial value to pass to the function. |
+### `fn`
+
+**Type**: `(v: T) => T`
+
+The function to run in a tracking scope.
+
+### `value`
+
+**Type**: `T`
+
+The initial value to pass to the function.

--- a/src/routes/reference/secondary-primitives/create-deferred.mdx
+++ b/src/routes/reference/secondary-primitives/create-deferred.mdx
@@ -21,9 +21,21 @@ Creates a readonly that only notifies downstream changes when the browser is idl
 
 ## Options
 
-| Name      | Type                                       | Description                                            |
-| --------- | ------------------------------------------ | ------------------------------------------------------ |
-| timeoutMs | `number`                                   | The maximum time to wait before forcing the update.    |
-| equals    | `false or ((prev: T, next: T) => boolean)` | A function that returns true if the value has changed. |
-| name      | `string`                                   | The name of the readonly.                              |
+### `timeoutMs`
+
+**Type**: `number`
+
+The maximum time to wait before forcing the update.    
+
+### `equals`
+
+**Type**: `false | ((prev: T, next: T) => boolean)`
+
+A function that returns true if the value has changed. 
+
+### `name`
+
+**Type**: `string`
+
+The name of the readonly.                              
 

--- a/src/routes/reference/secondary-primitives/create-render-effect.mdx
+++ b/src/routes/reference/secondary-primitives/create-render-effect.mdx
@@ -9,13 +9,13 @@ function createRenderEffect<T>(fn: (v: T) => T, value?: T): void
 
 ```
 
-A render effect is a computation similar to a regular effect (as created by [`createEffect`](/reference/basic-reactivity/create-effect)), but differs in when Solid schedules the first execution of the effect function. 
-While `createEffect` waits for the current rendering phase to be complete, `createRenderEffect` immediately calls the function. 
-Thus the effect runs as DOM elements are being created and updated, but possibly before specific elements of interest have been created, and probably before those elements have been connected to the document. 
-In particular, **refs** will not be set before the initial effect call. 
+A render effect is a computation similar to a regular effect (as created by [`createEffect`](/reference/basic-reactivity/create-effect)), but differs in when Solid schedules the first execution of the effect function.
+While `createEffect` waits for the current rendering phase to be complete, `createRenderEffect` immediately calls the function.
+Thus the effect runs as DOM elements are being created and updated, but possibly before specific elements of interest have been created, and probably before those elements have been connected to the document.
+In particular, **refs** will not be set before the initial effect call.
 Indeed, Solid uses `createRenderEffect` to implement the rendering phase itself, including setting of **refs**.
 
-Reactive updates to render effects are identical to effects: they queue up in response to a reactive change (e.g., a single signal update, or a batch of changes, or collective changes during an entire render phase) and run in a single [`batch`](/reference/reactive-utilities/batch) afterward (together with effects). 
+Reactive updates to render effects are identical to effects: they queue up in response to a reactive change (e.g., a single signal update, or a batch of changes, or collective changes during an entire render phase) and run in a single [`batch`](/reference/reactive-utilities/batch) afterward (together with effects).
 In particular, all signal updates within a render effect are batched.
 
 Here is an example of the behavior. (Compare with the example in [`createEffect`](/reference/basic-reactivity/create-effect).)
@@ -49,9 +49,16 @@ queueMicrotask(() => {
 
 Just like `createEffect`, the effect function gets called with an argument equal to the value returned from the effect function's last execution, or on the first call, equal to the optional second argument of `createRenderEffect`.
 
-## Arguments
+## Parameters
 
-| Name    | Type          | Description                                            |
-| :------ | :------------ | :----------------------------------------------------- |
-| `fn`    | `(v: T) => T` | The effect function to be called.                      |
-| `value` | `T`           | The initial value to be passed to the effect function. |
+### `fn`
+
+**Type**: `(v: T) => T`
+
+The effect function to be called.
+
+### `value`
+
+**Type**: `T`
+
+The initial value to be passed to the effect function.

--- a/src/routes/reference/secondary-primitives/create-selector.mdx
+++ b/src/routes/reference/secondary-primitives/create-selector.mdx
@@ -39,7 +39,7 @@ const isSelected = createSelector(selectedId)
 In the code above, each `li` element receives an `active` class
 exactly when the corresponding `item.id` is equal to `selectedId()`.
 When the `selectedId` signal changes, the `li` element(s) that previously
-had previously matching `id` get the `active` class removed, and the 
+had previously matching `id` get the `active` class removed, and the
 `li` element(s) that now have a matching `id` get the `active` class added.
 All other `li` elements get skipped, so if `id`s are distinct,
 only 2 DOM operations get performed.
@@ -55,9 +55,18 @@ const [selectedId, setSelectedId] = createSignal()
 </For>
 ```
 
-## Arguments
+## Parameters
 
-| Name     | Type                      | Description                                  |
-| :------- | :------------------------ | :------------------------------------------- |
-| `source` | `() => T`                 | The source signal to get the value from and compare with keys. |
-| `fn`     | `(a: U, b: T) => boolean` | A function to compare the key and the value, returning whether they should be treated as equal. Default: `===` |
+### `source`
+
+**Type**: `() => T`
+
+The source signal to get the value from and compare with keys.
+
+### `fn`
+
+**Type**: `(a: U, b: T) => boolean`
+
+**Default**: `===`
+
+A function to compare the key and the value, returning whether they should be treated as equal.

--- a/src/routes/reference/store-utilities/reconcile.mdx
+++ b/src/routes/reference/store-utilities/reconcile.mdx
@@ -37,9 +37,21 @@ onCleanup(() => unsubscribe());
 
 ```
 
-##### Options
+## Options
 
-| Option | Type    | Default | Description                        |
-| ------ | ------- | ------- | ---------------------------------- |
-| key    | string  | "id"    |  Specifies the key to be used for matching items during reconciliation |
-| merge  | boolean | false   | When merge is false, referential checks are performed where possible to determine equality, and items that are not referentially equal are replaced. When merge is true, all diffing is pushed to the leaves, effectively morphing the previous data to the new value. |
+### `key`
+
+**Type**: `string`
+
+**Default**: `"id"`
+
+Specifies the key to be used for matching items during reconciliation.
+
+### `merge`
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+When merge is false, referential checks are performed where possible to determine equality, and items that are not referentially equal are replaced.
+When merge is true, all diffing is pushed to the leaves, effectively morphing the previous data to the new value. 

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -33,12 +33,46 @@ To prevent, both `<A />` and `<a />` tags from soft navigating when JavaScript i
 
 ## Props Reference
 
-| prop          | type    | description                                                                                                                                                                              |
-| ------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| href          | string  | The path of the route to navigate to. This will be resolved relative to the route that the link is in, but you can preface it with `/` to refer back to the root.                        |
-| noScroll      | boolean | If true, turn off the default behavior of scrolling to the top of the new page                                                                                                           |
-| replace       | boolean | If true, don't add a new entry to the browser history. (By default, the new page will be added to the browser history, so pressing the back button will take you to the previous route.) |
-| state         | unknown | [Push this value](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) to the history stack when navigating                                                               |
-| inactiveClass | string  | The class to show when the link is inactive (when the current location doesn't match the link)                                                                                           |
-| activeClass   | string  | The class to show when the link is active                                                                                                                                                |
-| end           | boolean | If `true`, only considers the link to be active when the current location matches the `href` exactly; if `false`, check if the current location _starts with_ `href`                     |
+### `href`
+
+**Type**: `string`
+
+The path of the route to navigate to.
+This will be resolved relative to the route that the link is in, but you can preface it with `/` to refer back to the root.
+
+### `noScroll`
+
+**Type**: `boolean`
+
+If true, turn off the default behavior of scrolling to the top of the new page.
+
+### `replace`
+
+**Type**: `boolean`
+
+If true, don't add a new entry to the browser history.
+(By default, the new page will be added to the browser history, so pressing the back button will take you to the previous route.)
+
+### `state`
+
+**Type**: `unknown`
+
+[Push this value](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) to the history stack when navigating.
+
+### `inactiveClass`
+
+**Type**: `string`
+
+The class to show when the link is inactive (when the current location doesn't match the link.)
+
+### `activeClass`
+
+**Type**: `string`
+
+The class to show when the link is active.
+
+### `end`
+
+**Type**: `boolean`
+
+If `true`, only considers the link to be active when the current location matches the `href` exactly; if `false`, check if the current location _starts with_ `href`.

--- a/src/routes/solid-router/reference/components/hash-router.mdx
+++ b/src/routes/solid-router/reference/components/hash-router.mdx
@@ -29,11 +29,44 @@ render(
 );
 ```
 
-| prop          | type                                                     | description                                                                         |
-| ------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| children      | `JSX.Element`, `RouteDefinition`, or `RouteDefinition[]` | The route definitions                                                               |
-| root          | Component                                                | Top level layout component                                                          |
-| base          | string                                                   | Base url to use for matching routes                                                 |
-| actionBase    | string                                                   | Root url for server actions, default: `/_server`                                    |
-| preload       | boolean                                                  | Enables/disables preloads globally, default: `true`                                 |
-| explicitLinks | boolean                                                  | Disables all anchors being intercepted and instead requires [`<A>`](/solid-router/reference/components/a). default: `false` |
+### `children`
+
+**Type**: `JSX.Element | RouteDefinition | RouteDefinition[]`
+
+The route definitions.
+
+### `root`
+
+**Type**: `Component`
+
+Top level layout component.
+
+### `base`
+
+**Type**: `string`
+
+Base url to use for matching routes.
+
+### `actionBase`
+
+**Type**: `string`
+
+**Default**: `"/_server"`
+
+Root url for server actions.
+
+### `preload`
+
+**Type**: `boolean`
+
+**Default**: `true`
+
+Enables/disables preloads globally.
+
+### `explicitLinks`
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+Disables all anchors being intercepted and instead requires [`<A>`](/solid-router/reference/components/a).

--- a/src/routes/solid-router/reference/components/memory-router.mdx
+++ b/src/routes/solid-router/reference/components/memory-router.mdx
@@ -48,29 +48,100 @@ The `MemoryHistory` object contains the following methods, which you can use to 
 - The `back` and `forward` methods mimic the browser's back and forward buttons, respectively, and the `go` method navigates a specific number of steps in the history, either backward or forward.
 - The `listen` method registers a callback to be called on navigation change.
 
+## `MemoryHistory` props
 
+### `get`
 
-## Properties
+**Type**: `get(): string`
 
-### `MemoryHistory`
+Returns the current route.
 
-| Method    | Signature                                                     | Description                                                                                                                                                                     |
-| --------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `get`     | `get(): string`                                               | Returns the current route.                                                                                                                                                      |
-| `set`     | `set({ value: string, scroll?: boolean, replace?: boolean })` | Navigates to a new route. `value`: URL to navigate to. `scroll`: Scrolls to element by ID (default: `false`). `replace`: Replaces the current history entry (default: `false`). |
-| `back`    | `back(): void`                                                | Navigates 1 step back in the history. Corresponds to `go(-1)`.                                                                                                                  |
-| `forward` | `forward(): void`                                             | Navigates 1 step forward in the history. Corresponds to `go(1)`.                                                                                                                |
-| `go`      | `go(n: number): void`                                         | Navigates n steps in the history. Negative for back, positive for forward. Clamped to history length.                                                                           |
-| `listen`  | `listen(listener: (value: string) => void): () => void`       | Registers a listener that will be called on navigation.                                                                                                                         |
+### `set`
 
-### `MemoryRouter`
+**Type**: `set({ value: string, scroll?: boolean, replace?: boolean })`
 
-| Property      | Type                                                     | Description                                                                                |
-| ------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| children      | `JSX.Element`, `RouteDefinition`, or `RouteDefinition[]` | The route definitions                                                                      |
-| root          | Component                                                | Top level layout component                                                                 |
-| base          | string                                                   | Base url to use for matching routes                                                        |
-| actionBase    | string                                                   | Root url for server actions, default: `/_server`                                           |
-| preload       | boolean                                                  | Enables/disables preloads globally, default: `true`                                        |
-| explicitLinks | boolean                                                  | Disables all anchors being intercepted and instead requires `<A>`. default: `false`        |
-| history       | MemoryHistory                                            | An optionally pre-filled and mutable history object which will store any navigation events |
+**Default**: `false`
+
+Navigates to a new route.
+
+- `value`: URL to navigate to.
+- `scroll`: Scrolls to element by ID (default: `false`).
+- `replace`: Replaces the current history entry (default: `false`).
+
+### `back`
+
+**Type**: `back(): void`
+
+Navigates 1 step back in the history.
+Corresponds to `go(-1)`.
+
+### `forward`
+
+**Type**: `forward(): void`
+
+Navigates 1 step forward in the history.
+Corresponds to `go(1)`.
+
+### `go`
+
+**Type**: `go(n: number): void`
+
+Navigates n steps in the history.
+Negative for back, positive for forward.
+Clamped to history length.
+
+### `listen`
+
+**Type**: `listen(listener: (value: string) => void): () => void`
+
+Registers a listener that will be called on navigation.
+
+## MemoryRouter props
+
+### `children`
+
+**Type**: `JSX.Element | RouteDefinition | RouteDefinition[]`
+
+The route definitions.
+
+### `root`
+
+**Type**: Component
+
+Top level layout component.
+
+### `base`
+
+**Type**: `string`
+
+Base url to use for matching routes.
+
+### `actionBase`
+
+**Type**: `string`
+
+**Default**: `"/_server"`
+
+Root url for server actions.
+
+### `preload`
+
+**Type**: `boolean`
+
+**Default**: `true`
+
+Enables/disables preloads globally.
+
+### `explicitLinks`
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+truebles all anchors being intercepted and instead requires `<A>`.
+
+### `history`
+
+**Type**: `MemoryHistory`
+
+An optionally pre-filled and mutable history object which will store any navigation events.

--- a/src/routes/solid-router/reference/components/route.mdx
+++ b/src/routes/solid-router/reference/components/route.mdx
@@ -17,10 +17,32 @@ This would mean navigating from `/login` to `/register` would not cause the `Log
 
 :::
 
-| prop         | type                 | description                                                       |
-| ------------ | -------------------- | ----------------------------------------------------------------- |
-| path         | `string \| string[]` | Path partial for defining the route segment                       |
-| component    | `Component`          | Component that will be rendered for the matched segment           |
-| matchFilters | `MatchFilters`       | Additional constraints for matching against the route             |
-| children     | `JSX.Element`        | Nested `<Route>` definitions                                      |
-| preload      | `RoutePreloadFunc`   | Function called during preload or when the route is navigated to. |
+### `path `
+
+**Type**: `string | string[]`
+
+Path partial for defining the route segment.
+
+### `component`
+
+**Type**: `Component`
+
+Component that will be rendered for the matched segment.
+
+### `matchFilters `
+
+**Type**: `MatchFilters`
+
+Additional constraints for matching against the route.
+
+### `children `
+
+**Type**: `JSX.Element`
+
+Nested `<Route>` definitions.
+
+### `preload`
+
+**Type**: `RoutePreloadFunc`
+
+Function called during preload or when the route is navigated to.

--- a/src/routes/solid-router/reference/components/router.mdx
+++ b/src/routes/solid-router/reference/components/router.mdx
@@ -22,12 +22,51 @@ render(
 );
 ```
 
-| prop          | type                                                     | description                                                                                                                                                                               |
-| ------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| children      | `JSX.Element`, `RouteDefinition`, or `RouteDefinition[]` | The route definitions                                                                                                                                                                     |
-| root          | Component                                                | Top level layout component                                                                                                                                                                |
-| base          | string                                                   | Base url to use for matching routes                                                                                                                                                       |
-| actionBase    | string                                                   | Root url for server actions, default: `/_server`                                                                                                                                          |
-| preload       | boolean                                                  | Enables/disables preloads globally, default: `true`                                                                                                                                       |
-| explicitLinks | boolean                                                  | Disables all anchors being intercepted and instead requires `<A>`. default: `false`. (To disable interception for a specific link, set `target` to any value, e.g. `<a target="_self">`.) |
-| url           | string                                                   | The initial route to render                                                                                                                                                               |
+### `children`
+
+**Type**: `JSX.Element | RouteDefinition | RouteDefinition[]`
+
+The route definitions.
+
+### `root`
+
+**Type**: `Component`
+
+Top level layout component.
+
+### `base`
+
+**Type**: `string`
+
+Base url to use for matching routes.
+
+### `actionBase`
+
+**Type**: `string`
+
+**Default**: `"/_server"`
+
+Root url for server actions.
+
+### `preload`
+
+**Type**: `boolean`
+
+**Default**: `true`
+
+Enables/disables preloads globally.
+
+### `explicitLinks`
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+Disables all anchors being intercepted and instead requires `<A>`.
+(To disable interception for a specific link, set `target` to any value, e.g. `<a target="_self">`.)
+
+### `url`
+
+**Type**: `string`
+
+The initial route to render.

--- a/src/routes/solid-router/reference/data-apis/cache.mdx
+++ b/src/routes/solid-router/reference/data-apis/cache.mdx
@@ -94,14 +94,21 @@ The return value is a `CachedFunction`, a function that has the same signature a
 This cached function stores the return value using the cache key.
 Under most circumstances, this temporarily prevents the passed function from running with the same arguments, even if the created function is called repeatedly.
 
-## Arguments
+## Parameters
 
-| argument | type                    | description                                                               |
-| -------- | ----------------------- | ------------------------------------------------------------------------- |
-| `fn`     | `(...args: any) => any` | A function whose return value you'd like to be cached.                    |
-| `name`\* | string                  | Any arbitrary string that you'd like to use as the rest of the cache key. |
+### `fn`
 
-\*Since the internal cache is shared by all the functions using `cache`, the string should be unique for each function passed to `cache`.
+**Type**: `(...args: any) => any`
+
+A function whose return value you'd like to be cached.
+
+### `name`
+
+**Type**: string
+
+Any arbitrary string that you'd like to use as the rest of the cache key.
+
+Since the internal cache is shared by all the functions using `cache`, the string should be unique for each function passed to `cache`.
 If the same key is used with multiple functions, one function might return the cached result of the other.
 
 ## Methods

--- a/src/routes/solid-router/reference/data-apis/create-async.mdx
+++ b/src/routes/solid-router/reference/data-apis/create-async.mdx
@@ -33,11 +33,48 @@ export function Component () => {
 
 ## Options
 
-| Name         | Type                    | Default        | Description                                                                                                                                                   |
-| ------------ | ----------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name         | `string`                | `undefined`    | A name for the resource. This is used for debugging purposes.                                                                                                 |
-| deferStream  | `boolean`               | `false`        | If true, Solid will wait for the resource to resolve before flushing the stream.                                                                              |
+### `name`
+
+**Type**: `string`
+
+A name for the resource.
+This is used for debugging purposes.
+
+### `deferStream`
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+If true, Solid will wait for the resource to resolve before flushing the stream.
+
 | initialValue | `any`                   | `undefined`    | The initial value of the resource.                                                                                                                            |
-| onHydrated   | `function`              | `undefined`    | A callback that is called when the resource is hydrated.                                                                                                      |
-| ssrLoadFrom  | `"server" \| "initial"` | `"server"`     | The source of the initial value for SSR. If set to `"initial"`, the resource will use the `initialValue` option instead of the value returned by the fetcher. |
-| storage      | `function`              | `createSignal` | A function that returns a signal. This can be used to create a custom storage for the resource. This is still experimental
+
+### `initialValue`
+
+The initial value of the resource.
+
+### `onHydrated`
+
+**Type**: `function`
+
+A callback that is called when the resource is hydrated.
+
+### `ssrLoadFrom`
+
+**Type**: `"server" | "initial"`
+
+**Default**: `"server"`
+
+The source of the initial value for SSR.
+If set to `"initial"`, the resource will use the `initialValue` option instead of the value returned by the fetcher.
+
+### `storage`
+
+**Type**: `function`
+
+**Default**: `createSignal`
+
+A function that returns a signal.
+This can be used to create a custom storage for the resource.
+This is still experimental.

--- a/src/routes/solid-router/reference/data-apis/create-async.mdx
+++ b/src/routes/solid-router/reference/data-apis/create-async.mdx
@@ -48,8 +48,6 @@ This is used for debugging purposes.
 
 If true, Solid will wait for the resource to resolve before flushing the stream.
 
-| initialValue | `any`                   | `undefined`    | The initial value of the resource.                                                                                                                            |
-
 ### `initialValue`
 
 The initial value of the resource.

--- a/src/routes/solid-router/reference/data-apis/query.mdx
+++ b/src/routes/solid-router/reference/data-apis/query.mdx
@@ -89,14 +89,21 @@ The return value is a `CachedFunction`, a function that has the same signature a
 This cached function stores the return value using the cache key.
 Under most circumstances, this temporarily prevents the passed function from running with the same arguments, even if the created function is called repeatedly.
 
-## Arguments
+## Parameters
 
-| argument | type                    | description                                                               |
-| -------- | ----------------------- | ------------------------------------------------------------------------- |
-| `fn`     | `(...args: any) => any` | A function whose return value you'd like to be cached.                    |
-| `name`\* | string                  | Any arbitrary string that you'd like to use as the rest of the cache key. |
+### `fn`
 
-\*Since the internal cache is shared by all the functions using `query`, the string should be unique for each function passed to `query`.
+**Type**: `(...args: any) => any`
+
+A function whose return value you'd like to be cached.
+
+### `name`
+
+**Type**: `string`
+
+Any arbitrary string that you'd like to use as the rest of the cache key.
+
+Since the internal cache is shared by all the functions using `query`, the string should be unique for each function passed to `query`.
 If the same key is used with multiple functions, one function might return the cached result of the other.
 
 ## Methods

--- a/src/routes/solid-router/reference/data-apis/use-action.mdx
+++ b/src/routes/solid-router/reference/data-apis/use-action.mdx
@@ -19,7 +19,9 @@ const result = updateName("John Wick");
 
 ## Parameters
 
-- `action`: The action to be invoked.
+### `action`
+
+The action to be invoked.
 
 ## Returns
 

--- a/src/routes/solid-router/reference/primitives/use-location.mdx
+++ b/src/routes/solid-router/reference/primitives/use-location.mdx
@@ -10,10 +10,14 @@ const location = useLocation();
 const pathname = createMemo(() => parsePath(location.pathname));
 ```
 
-| attribute  | type   | description                                                                               |
-| ---------- | ------ | ----------------------------------------------------------------------------------------- |
-| `pathname` | string | The pathname part of the URL, without the query string.                                   |
-| `search`   | string | The query string part of the URL.                                                         |
-| `hash`     | string | The hash part of the URL, including the `#`.                                              |
-| `state`    | any    | Custom state passed from [`useNavigate`](/solid-router/reference/primitives/use-navigate) |
-| `query`    | object | Returns a store-like object containing all the query parameters of the URL.               |
+## Returns
+
+`useLocation` returns an object with the following attributes:
+
+| attribute  | type     | description                                                                               |
+| ---------- | -------- | ----------------------------------------------------------------------------------------- |
+| `pathname` | `string` | The pathname part of the URL, without the query string.                                   |
+| `search`   | `string` | The query string part of the URL.                                                         |
+| `hash`     | `string` | The hash part of the URL, including the `#`.                                              |
+| `state`    | `any`    | Custom state passed from [`useNavigate`](/solid-router/reference/primitives/use-navigate) |
+| `query`    | `object` | Returns a store-like object containing all the query parameters of the URL.               |

--- a/src/routes/solid-start/reference/client/client-only.mdx
+++ b/src/routes/solid-start/reference/client/client-only.mdx
@@ -2,7 +2,7 @@
 title: clientOnly
 ---
 
-Wrapping components in `clientOnly` will cause them render _only_ in the client. 
+Wrapping components in `clientOnly` will cause them render _only_ in the client.
 This can useful for components that interact directly with the DOM, such as jQuery, since they can not render on the server.
 It works similar to [`lazy`](/reference/component-apis/lazy) but will only render _after hydration_ and will never load on the server.
 
@@ -32,6 +32,8 @@ function IsomorphicComp() {
 
 ## Parameters
 
-| Argument | Type            | Description                          |
-| -------- | --------------- | ------------------------------------ |
-| fn       | `() => Promise` | Function to be run client-side only. |
+### `fn`
+
+**Type**: `() => Promise`
+
+Function to be run client-side only.

--- a/src/routes/solid-start/reference/client/mount.mdx
+++ b/src/routes/solid-start/reference/client/mount.mdx
@@ -2,7 +2,7 @@
 title: mount
 ---
 
-`mount` is a method that calls either [`hydrate`](/reference/rendering/hydrate) (server rendering) or [`render`](/reference/rendering/render) (client rendering) depending on the configuration. 
+`mount` is a method that calls either [`hydrate`](/reference/rendering/hydrate) (server rendering) or [`render`](/reference/rendering/render) (client rendering) depending on the configuration.
 It is used in [`entry-client.tsx`](/solid-start/reference/entrypoints/entry-client) to bootstrap an application.
 
 ```tsx
@@ -15,7 +15,14 @@ If you set `{ ssr: false }` in the [`defineConfig`](/solid-start/reference/confi
 
 ## Parameters
 
-| Prop | type              | description                                 |
-| ---- | ----------------- | ------------------------------------------- |
-| fn   | () => JSX.Element | Function that returns the application code. |
-| el   | MountableElement  | DOM Element to mount the application to     |
+### `fn`
+
+**Type**: `() => JSX.Element`
+
+Function that returns the application code.
+
+### `el`
+
+**Type**: `MountableElement`
+
+DOM Element to mount the application to.

--- a/src/routes/solid-start/reference/config/define-config.mdx
+++ b/src/routes/solid-start/reference/config/define-config.mdx
@@ -21,7 +21,7 @@ export default defineConfig({
 });
 ```
 
-The `vite` option can also be a function that can be customized for each Vinxi router. 
+The `vite` option can also be a function that can be customized for each Vinxi router.
 
 In SolidStart, 3 routers are used:
 - `server` - server-side routing
@@ -44,8 +44,8 @@ export default defineConfig({
 
 ## Configuring Nitro
 
-SolidStart uses [Nitro](https://nitro.build/) to run on a number of platforms. 
-The `server` option exposes some Nitro options including the build and deployment presets. 
+SolidStart uses [Nitro](https://nitro.build/) to run on a number of platforms.
+The `server` option exposes some Nitro options including the build and deployment presets.
 An overview of all available presets is available in the [Deploy section of the Nitro documentation](https://nitro.build/deploy).
 
  Some common ones include:
@@ -85,7 +85,7 @@ export default defineConfig({
 
 #### Special note
 
-SolidStart uses async local storage. 
+SolidStart uses async local storage.
 Netlify, Vercel, and Deno support this out of the box but if you're using Cloudflare you will need to specify the following:
 
 ```js
@@ -110,15 +110,75 @@ compatibility_flags = [ "nodejs_compat" ]
 
 ## Parameters
 
-| Property             | Type                                       | Default                    | Description                                                                                                                                                                  |
-| -------------------- | ------------------------------------------ | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ssr                  | boolean                                    | true                       | Toggle between client and server rendering.                                                                                                                                  |
-| solid                | object                                     |                            | Configuration object for [vite-plugin-solid](https://github.com/solidjs/vite-plugin-solid)                                                                                   |
-| extensions           | string[]                                   | ["js", "jsx", "ts", "tsx"] | Array of file extensions to be treated as routes.                                                                                                                            |
-| server               | object                                     |                            | Nitro server config options                                                                                                                                                  |
-| appRoot              | string                                     | "./src"                    | The path to the root of the application.                                                                                                                                     |
-| routeDir             | string                                     | "./routes"                 | The path to where the routes are located.                                                                                                                                    |
-| middleware           | string                                     |                            | The path to an optional [middleware](/solid-start/advanced/middleware) file.                                                                                                 |
-| devOverlay           | boolean                                    | true                       | Toggle the dev overlay.                                                                                                                                                      |
-| experimental.islands | boolean                                    | false                      | Enable "islands" mode.                                                                                                                                                       |
-| vite                 | `ViteConfig` or `({ router })=>ViteConfig` |                            | [Vite config object](https://vitejs.dev/config/shared-options.html). Can be configured for each `router` which has the string value "server", "client" or "server-function"` |
+### `ssr`
+
+**Type**: `boolean`
+
+**Default**: `true`
+
+Toggle between client and server rendering.
+
+### `solid`
+
+**Type**: `object`
+
+Configuration object for [vite-plugin-solid](https://github.com/solidjs/vite-plugin-solid).
+
+### `extensions`
+
+**Type**: `string[]`
+
+**Default**:  `["js", "jsx", "ts", "tsx"]`
+
+Array of file extensions to be treated as routes.
+
+### `server`
+
+**Type**: `object`
+
+Nitro server config options.
+
+### `appRoot`
+
+**Type**: `string`
+
+**Default**: `"./src"`
+
+The path to the root of the application.
+
+### `routeDir`
+
+**Type**: `string`
+
+**Default**: `"./routes"`
+
+The path to where the routes are located.
+
+### `middleware`
+
+**Type**: `string`
+
+The path to an optional [middleware](/solid-start/advanced/middleware) file.
+
+### `devOverlay`
+
+**Type**: `boolean`
+
+**Default**: `true`
+
+Toggle the dev overlay.
+
+### `experimental.islands`
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+Enable "islands" mode.
+
+### `vite`
+
+**Type**: `ViteConfig | ({ router }) => ViteConfig`
+
+[Vite config object](https://vitejs.dev/config/shared-options.html).
+Can be configured for each `router` which has the string value "server", "client" or "server-function"`.

--- a/src/routes/solid-start/reference/server/create-handler.mdx
+++ b/src/routes/solid-start/reference/server/create-handler.mdx
@@ -24,7 +24,16 @@ export default createHandler(() => (
 
 ## Parameters
 
-| Argument     | Type                     | Default  | Description                                                       |
-| ------------ | ------------------------ | -------- | ----------------------------------------------------------------- |
-| fn           | fn: (context: PageEvent) |          | A function that returns the static document for your application. |
-| options.mode | string                   | "stream" | The SSR mode. Options are 'sync', 'async' and 'stream'.           |
+### `fn`
+
+**Type**: `fn: (context: PageEvent)`
+
+A function that returns the static document for your application.
+
+### `options.mode`
+
+**Type**: `"sync" | "async" | "stream"`
+
+**Default**: `"stream"`
+
+The SSR mode.

--- a/src/routes/solid-start/reference/server/http-header.mdx
+++ b/src/routes/solid-start/reference/server/http-header.mdx
@@ -25,7 +25,7 @@ export default function NotFound() {
 }
 ```
 
-As a page is rendered, you may want to add additional HTTP headers to the response and the `HttpHeader` component will do that for you. 
+As a page is rendered, you may want to add additional HTTP headers to the response and the `HttpHeader` component will do that for you.
 By passing it a `name` and `value`, they will get added to the `Response` headers sent back to the browser.
 
 When streaming responses with [`renderToStream`](/reference/rendering/render-to-stream), HTTP headers can only be added before the stream is first flushed.
@@ -33,7 +33,14 @@ This requires adding `deferStream` to any resources that need to be loaded befor
 
 ## Parameters
 
-| Property | Type   | Description                    |
-| -------- | ------ | ------------------------------ |
-| name     | string | The name of the header to set  |
-| value    | string | The value of the header to set |
+### `name`
+
+**Type**: `string`
+
+The name of the header to set.
+
+### `value`
+
+**Type**: `string`
+
+The value of the header to set.

--- a/src/routes/solid-start/reference/server/http-status-code.mdx
+++ b/src/routes/solid-start/reference/server/http-status-code.mdx
@@ -15,7 +15,7 @@ import { HttpStatusCode } from "@solidjs/start";
 As a page is rendered, you may want to set the status code to the `Response` depending on what happens.
 The `HttpStatusCode` component does this for you by taking the `code`  passed in and setting it to the `Response` status in the browser.
 
-Since `HttpStatusCode` is just a component, it can be used with [`ErrorBoundary`](/reference/components/error-boundary), [`Show`](/reference/components/show), [`Switch`](/reference/components/switch-and-match) or any of the other JSX control-flow components. 
+Since `HttpStatusCode` is just a component, it can be used with [`ErrorBoundary`](/reference/components/error-boundary), [`Show`](/reference/components/show), [`Switch`](/reference/components/switch-and-match) or any of the other JSX control-flow components.
 This means the same logic used when deciding what to render can inform what status code you are setting, allowing that logic to sit together.
 
 Status codes are important tools for things like caching and SEO, so it is a good practice to send meaningful status codes.
@@ -36,11 +36,11 @@ export default function NotFound() {
 
 ## Setting a 404 status code for missing pages for dynamic routes
 
-When using dynamic params in routes, setting a 404 status code if the given parameter for a segment points to a missing resource is important. 
-Usually, the param is discovered to be missing when doing an async request with that parameter. 
+When using dynamic params in routes, setting a 404 status code if the given parameter for a segment points to a missing resource is important.
+Usually, the param is discovered to be missing when doing an async request with that parameter.
 
 Errors can be thrown from inside these fetchers and caught by the nearest [`<ErrorBoundary>`](/reference/components/error-boundary) component from where the data is accessed.
-`<HttpStatusCode>` pairs very well with error boundaries because you can inspect the error in the ErrorBoundary's fallback. 
+`<HttpStatusCode>` pairs very well with error boundaries because you can inspect the error in the ErrorBoundary's fallback.
 If the fetcher throws an error indicating the data was not found, you can render `<HttpStatusCode code={404} />`.
 
 Note that when streaming responses [`renderStream`](/reference/rendering/render-to-stream), the HTTP Status can only be included if added _before_ the stream first flushed.
@@ -76,6 +76,8 @@ export default function House(props: { name: string }) {
 
 ## Parameters
 
-| Property | Type   | Description          |
-| -------- | ------ | -------------------- |
-| code     | number | The HTTP status code |
+### `code`
+
+**Type**: `number`
+
+The HTTP status code.

--- a/src/routes/solid-start/reference/server/start-server.mdx
+++ b/src/routes/solid-start/reference/server/start-server.mdx
@@ -10,6 +10,8 @@ import { StartServer } from "@solidjs/start/server";
 
 ## Parameters
 
-| Property | Type     | Description                                                       |
-| -------- | -------- | ----------------------------------------------------------------- |
-| document | Function | A function that returns the static document for your application. |
+### `document`
+
+**Type**: `Function`
+
+A function that returns the static document for your application.


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

This PR changes the structure of how we document props, parameters, and options. Instead of using a table format, we will now present the documentation as follows:

```
## Options

### `deferStream`

**Type:** `boolean`

**Default:** `false`

Description...
```

This new format allows for several benefits:

1. Improved indexing of content by search engines and Orama.
2. The ability to add additional information about a prop or option, such as examples that could not be accommodated in a table format.
3. The ability to link directly to the documentation of a specific prop, as links are automatically generated for headings.

### Related issues & labels

- Closes #987
