### PR TITLE
Correct env type declaration filename in docs

### DIFF
--- a/src/routes/configuration/environment-variables.mdx
+++ b/src/routes/configuration/environment-variables.mdx
@@ -11,7 +11,7 @@ Public variables are considered safe to expose to the client-side code. These va
 In the root directory of the project, create a file called `.env`.
 This file will store environment variables in the `key = value` format.
 
-If working with TypeScript it is possible to make such variables type-safe and enable your TypeScript Language Service Provider (LSP) to autocomplete them by creating a file called `.env.d.ts` in the root directory of the project.
+If working with TypeScript it is possible to make such variables type-safe and enable your TypeScript Language Service Provider (LSP) to autocomplete them by creating a file called `env.d.ts` in the root directory of the project.
 
 ```typescript
 interface ImportMetaEnv {
@@ -79,7 +79,7 @@ For an example, check the pseudo-code below.
 }
 ```
 
-It is also possible to make `process.env` type-safe via the same `.env.d.ts` file.
+It is also possible to make `process.env` type-safe via the same `env.d.ts` file.
 
 ```typescript
 


### PR DESCRIPTION
- [X] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [X] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

The documentation incorrectly suggests using .env.d.ts for typing environment variables. However, based on both [Vite's official docs](https://vite.dev/config/shared-options.html#define) and testing, type safety only works with env.d.ts or vite-env.d.ts—not .env.d.ts