### PR TITLE
fix callouts

### DIFF
--- a/src/solidbase-theme/mdx-components.tsx
+++ b/src/solidbase-theme/mdx-components.tsx
@@ -38,7 +38,7 @@ export const DirectiveContainer = (
 	return (
 		<Switch
 			fallback={
-				<Callout type={props.type as CalloutType} children={props.children} />
+				<Callout type={props.type as CalloutType} children={_children} />
 			}
 		>
 			<Match when={props.type === "tab"}>{_children}</Match>


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

Hydration errors caused by `props.children` being evaluated twice in `DirectiveContainer` are being surfaced as 404s. This PR just ensures that `props.children` is only evaluated one, using the result of the `children()` for all cases.

### Related issues & labels

- Closes #1146
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
