### PR TITLE
Update deprecated wrangler command

### DIFF
--- a/src/routes/guides/deployment-options/cloudflare.mdx
+++ b/src/routes/guides/deployment-options/cloudflare.mdx
@@ -75,7 +75,7 @@ build
 4. Deploy using Wrangler:
 
 ```bash
-wrangler pages publish dist
+wrangler pages deploy dist
 ```
 
 After running these commands, your project should be live.


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

This PR fixes the deploy command in wrangler CLI. `wrangler pages publish` is apparently deprecated.

Originally, I wanted to fix this issue as part of a complete rewrite of this page. Since a rewrite might take some time I decided to fix it separately.

### Related issues & labels

- Closes #1138
