### PR TITLE
Fix the background color of highlighted lines in dark mode

### DIFF
--- a/src/styles/expressive-code.css
+++ b/src/styles/expressive-code.css
@@ -50,7 +50,7 @@ html .expressive-code-overrides .expressive-code .copy button div {
 	--tmLineBrdCol: hsl(222.77deg 38.21% 51.76% / 55.57%);
 }
 
-html[data-theme="dark"].dark
+html[data-theme="dark"]
 	.expressive-code-overrides
 	.expressive-code
 	.ec-line.mark {


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

This PR fixes the background color of highlighted lines in dark mode. The problems was the CSS selector for dark mode.

Before:
![image](https://github.com/user-attachments/assets/5ce49eb9-d2d9-4262-96f5-e9ceba43f777)

After:
![2025-05-01_08-18](https://github.com/user-attachments/assets/e41a311f-ae27-4a43-93d4-2c46748ded89)

### Related issues & labels

- Closes #1166