### PR TITLE
Improve Solid quick start

### DIFF
--- a/src/routes/quick-start.mdx
+++ b/src/routes/quick-start.mdx
@@ -18,8 +18,7 @@ Start with the [TypeScript](https://stackblitz.com/github/solidjs/templates/tree
 :::
 
 To create a new Solid application, start by installing the Solid CLI.
-First, ensure you have an up-to-date version of [Node.js](https://nodejs.org/) installed.
-Then, navigate to the directory where you want to create your project and run the following command:
+Navigate to the directory where you want to create your project and run the following command:
 
 ```package-create
 solid
@@ -48,8 +47,34 @@ The CLI will guide you through a series of prompts, allowing you to choose optio
 
 Once the project is created, follow the instructions to install the dependencies and start the development server:
 
-```shell
+```sh title="npm" tab="package-manager"
 │  cd solid-project
 │  npm install
 │  npm run dev
 ```
+
+```sh title="pnpm" tab="package-manager"
+│  cd solid-project
+│  pnpm install
+│  pnpm dev
+```
+
+```sh title="yarn" tab="package-manager"
+│  cd solid-project
+│  yarn install
+│  yarn dev
+```
+
+```sh title="bun" tab="package-manager"
+│  cd solid-project
+│  bun install
+│  bun run dev
+```
+
+```sh title="deno" tab="package-manager"
+│  cd solid-project
+│  deno install
+│  deno run dev
+```
+
+You should now have your Solid project running!

--- a/src/routes/quick-start.mdx
+++ b/src/routes/quick-start.mdx
@@ -4,46 +4,52 @@ title: Quick start
 
 ## Try Solid online
 
-If you want to experiment with Solid in your browser, visit our [interactive playground](https://playground.solidjs.com/).
-
-You can also set up a complete build environment directly in your browser using StackBlitz.
-To get started, try the [TypeScript](https://stackblitz.com/github/solidjs/templates/tree/master/ts) or [JavaScript](https://stackblitz.com/github/solidjs/templates/tree/master/js) templates.
-Solid offers many more templates, which you can explore in the [starter templates](#starter-templates) section.
+To experiment with Solid directly in your browser, head over to our [interactive playground](https://playground.solidjs.com/).
+Prefer a full development setup? You can set up a complete environment using StackBlitz.
+Start with the [TypeScript](https://stackblitz.com/github/solidjs/templates/tree/master/ts) or [JavaScript](https://stackblitz.com/github/solidjs/templates/tree/master/js) templates.
 
 ## Create a Solid project
 
-You can create a new Solid application using the Solid CLI:
+:::info[Prerequisites]
+
+- Familiarity with the command line.
+- An updated [Node.js](https://nodejs.org/en) or [Deno](https://deno.com) installation.
+
+:::
+
+To create a new Solid application, start by installing the Solid CLI.
+First, ensure you have an up-to-date version of [Node.js](https://nodejs.org/) installed.
+Then, navigate to the directory where you want to create your project and run the following command:
 
 ```package-create
 solid
 ```
 
-The CLI will prompt you for a few details about your project:
+This command installs and runs [create-solid](https://github.com/solidjs-community/solid-cli/tree/main/packages/create-solid), the official project scaffolding tool for Solid.
+The CLI will guide you through a series of prompts, allowing you to choose options such as [starter templates](https://github.com/solidjs/templates), TypeScript support, and whether to include [Solid's full-stack framework, SolidStart](/solid-start):
 
-- The name of your project.
-- Whether you want to use [SolidStart](/solid-start).
-  For full-stack projects, we recommend using SolidStart.
-  SolidStart is a meta-framework for Solid that provides features such as file-based routing, nested routing, and multiple rendering modes.
-- The [starter template](#starter-templates) you wish to use.
-- Whether you want to use TypeScript.
+```shell
+◆ Project Name
+|  <solid-project>
 
-If you are uncertain about an option, simply choose the default by pressing enter.
+◆ Is this a SolidStart project?
+|  ● Yes / ○ No
 
-Once the project is created, follow the on-screen instructions to install dependencies and run the development server.
+◆ Which template would you like to use?
+│  ● ts
+│  ○ ts-vitest
+│  ○ ts-uvu
+│  ○ ts-unocss
+│  ○ ts-tailwindcss
 
-## Starter templates
-
-Solid offers a variety of starter templates for popular frameworks and libraries.
-You can see all of them the [templates repository](https://github.com/solidjs/templates).
-
-The best way to kickstart your project with one of the templates is using the Solid CLI.
-
-Additionally, you can try the templates directly in your browser using [StackBlitz](https://stackblitz.com/).
-To do this, replace `<template-name>` in the following URL with the name of the template you want to use, and open it in your browser:
-
-```
-https://stackblitz.com/github/solidjs/templates/tree/master/<template-name>
+◆ Use TypeScript?
+│  ● Yes / ○ No
 ```
 
-For example, the link below opens a complete development environment in your browser for the TypeScript template:
-[https://stackblitz.com/github/solidjs/templates/tree/master/ts](https://stackblitz.com/github/solidjs/templates/tree/master/ts)
+Once the project is created, follow the instructions to install the dependencies and start the development server:
+
+```shell
+│  cd solid-project
+│  npm install
+│  npm run dev
+```

--- a/src/routes/quick-start.mdx
+++ b/src/routes/quick-start.mdx
@@ -2,80 +2,40 @@
 title: Quick start
 ---
 
-## Solid playgrounds
+You can create a new Solid application using the Solid CLI:
 
-Experience Solid in your browser by visiting our [interactive playground](https://playground.solidjs.com/).
+```package-create
+solid
+```
 
-Additionally, we offer a [JavaScript](https://stackblitz.com/github/solidjs/templates/tree/master/js) and [Typescript](https://stackblitz.com/github/solidjs/templates/tree/master/ts) Stackblitz starters, which provide a web-based development environment to get you started.
+The CLI will prompt you for a few details about your project:
 
-## Creating a Solid application
+- The name of your project.
+- Whether you want to use [SolidStart](/solid-start).
+  For full-stack projects, we recommend using SolidStart.
+  SolidStart is a meta-framework for Solid that provides features such as file-based routing, nested routing, and multiple rendering modes.
+- The starter template you wish to use.
+- Whether you want to use TypeScript.
 
-:::info[Prerequisites]
+Then, follow the on-screen instructions to install dependencies and run the development server.
 
-    - Familiarity with the command line
-    - Install [Node.js](https://nodejs.org/en) or [Deno](https://deno.com)
+## Starter templates
 
+Solid offers a variety of starter templates for popular frameworks and libraries.
+You can kickstart your project with one of our templates using the Solid CLI.
+Alternatively, you can clone them directly from our [templates repository](https://github.com/solidjs/templates).
+
+:::tip[StackBlitz]
+You can try our templates directly in your browser using [StackBlitz](https://stackblitz.com/).
+To do this, replace `<template-name>` in the following URL with the name of the template and open it in your browser:
+
+`https://stackblitz.com/github/solidjs/templates/tree/master/<template-name>`
+
+For example, the link below opens a fully-featured development environment in your browser for our TypeScript template:
+
+[https://stackblitz.com/github/solidjs/templates/tree/master/ts](https://stackblitz.com/github/solidjs/templates/tree/master/ts)
 :::
 
-Solid offers convenient project templates that can help kickstart your development.
-To get an application running, follow the steps below based on the language you prefer to use.
+## Solid playground
 
-### For JavaScript projects
-
-1. Run the following command in your terminal to get the JavaScript starter template:
-
-```package-exec
-degit solidjs/templates/js my-app
-```
-
-2. Navigate to your application's directory:
-
-```bash frame="none"
-cd my-app
-```
-
-3. Install the necessary dependencies:
-
-```package-install-local
-```
-4. Run the application:
-
-```package-run
-dev
-```
-
-This will start the development server.
-Now, you can open your browser and navigate to `localhost:3000` to see your application running.
-
-### For TypeScript projects
-
-1. To use a TypeScript template, run the following command in your terminal:
-
-```package-exec
-degit solidjs/templates/ts my-app
-```
-
-2. Navigate to your application's directory:
-
-```bash frame="none"
-cd my-app
-```
-
-3. Install the necessary dependencies:
-
-```package-install-local
-```
-
-4. Run the application:
-
-```package-run
-dev
-```
-
-This will start the development server.
-Now, you can open your browser and navigate to `localhost:3000` to see your application running.
-
-### Explore more templates
-
-Solid offers a variety of Vite templates to streamline your development process.
-These resources are available on [GitHub](https://github.com/solidjs/templates).
+If you want to try Solid in your browser, visit our [interactive playground](https://playground.solidjs.com/).

--- a/src/routes/quick-start.mdx
+++ b/src/routes/quick-start.mdx
@@ -13,12 +13,12 @@ Start with the [TypeScript](https://stackblitz.com/github/solidjs/templates/tree
 :::info[Prerequisites]
 
 - Familiarity with the command line.
-- An updated [Node.js](https://nodejs.org/en) or [Deno](https://deno.com) installation.
+- A recent version of [Node.js](https://nodejs.org/en), [Bun](https://bun.sh/), or [Deno](https://deno.com/).
+  The latest LTS version is recommended.
 
 :::
 
-To create a new Solid application, start by installing the Solid CLI.
-Navigate to the directory where you want to create your project and run the following command:
+To create a new Solid application, navigate to the directory where you want to create your project and run the following command:
 
 ```package-create
 solid

--- a/src/routes/quick-start.mdx
+++ b/src/routes/quick-start.mdx
@@ -2,6 +2,16 @@
 title: Quick start
 ---
 
+## Try Solid online
+
+If you want to experiment with Solid in your browser, visit our [interactive playground](https://playground.solidjs.com/).
+
+You can also set up a complete build environment directly in your browser using StackBlitz.
+To get started, try the [TypeScript](https://stackblitz.com/github/solidjs/templates/tree/master/ts) or [JavaScript](https://stackblitz.com/github/solidjs/templates/tree/master/js) templates.
+Solid offers many more templates, which you can explore in the [starter templates](#starter-templates) section.
+
+## Create a Solid project
+
 You can create a new Solid application using the Solid CLI:
 
 ```package-create
@@ -14,28 +24,26 @@ The CLI will prompt you for a few details about your project:
 - Whether you want to use [SolidStart](/solid-start).
   For full-stack projects, we recommend using SolidStart.
   SolidStart is a meta-framework for Solid that provides features such as file-based routing, nested routing, and multiple rendering modes.
-- The starter template you wish to use.
+- The [starter template](#starter-templates) you wish to use.
 - Whether you want to use TypeScript.
 
-Then, follow the on-screen instructions to install dependencies and run the development server.
+If you are uncertain about an option, simply choose the default by pressing enter.
+
+Once the project is created, follow the on-screen instructions to install dependencies and run the development server.
 
 ## Starter templates
 
 Solid offers a variety of starter templates for popular frameworks and libraries.
-You can kickstart your project with one of our templates using the Solid CLI.
-Alternatively, you can clone them directly from our [templates repository](https://github.com/solidjs/templates).
+You can see all of them the [templates repository](https://github.com/solidjs/templates).
 
-:::tip[StackBlitz]
-You can try our templates directly in your browser using [StackBlitz](https://stackblitz.com/).
-To do this, replace `<template-name>` in the following URL with the name of the template and open it in your browser:
+The best way to kickstart your project with one of the templates is using the Solid CLI.
 
-`https://stackblitz.com/github/solidjs/templates/tree/master/<template-name>`
+Additionally, you can try the templates directly in your browser using [StackBlitz](https://stackblitz.com/).
+To do this, replace `<template-name>` in the following URL with the name of the template you want to use, and open it in your browser:
 
-For example, the link below opens a fully-featured development environment in your browser for our TypeScript template:
+```
+https://stackblitz.com/github/solidjs/templates/tree/master/<template-name>
+```
 
+For example, the link below opens a complete development environment in your browser for the TypeScript template:
 [https://stackblitz.com/github/solidjs/templates/tree/master/ts](https://stackblitz.com/github/solidjs/templates/tree/master/ts)
-:::
-
-## Solid playground
-
-If you want to try Solid in your browser, visit our [interactive playground](https://playground.solidjs.com/).


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

This PR improves the "quick start" page for Solid.js:

1. It recommends using the new Solid CLI instead of the old `degit` command. The new CLI is more beginner-friendly and offers additional features. Plus, the term "degit" might be confusing for new users.
2. It moves the section about the Solid Playground to the end of the page. Since the playground is not typically a way to start a project, I believe most users prefer to start a project locally. However, I'm open to feedback regarding this change.

### Related issues & labels

- Closes #1177
