### PR TITLE
Update use-server.mdx remove "at least"

### DIFF
--- a/src/routes/solid-start/reference/server/use-server.mdx
+++ b/src/routes/solid-start/reference/server/use-server.mdx
@@ -11,7 +11,7 @@ const logHello = async (message: string) => {
 };
 ```
 
-**Note:** `"use server"` functions must be marked async or at least return a promise.
+**Note:** `"use server"` functions must be marked async or return a promise.
 
 ## Basic usage
 


### PR DESCRIPTION
The use of "at least" in "Note: "use server" functions must be marked async or at least return a promise." implies to me that there are other options other than the function:
1. being marked async
2. returning a promise

I'm not sure there are any.
Either way, I don't see 'at least' adding any value to the note/sentence.

<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
