### PR TITLE
Update use-server.mdx Single-flight "actions" s/b "mutations"

### DIFF
--- a/src/routes/solid-start/reference/server/use-server.mdx
+++ b/src/routes/solid-start/reference/server/use-server.mdx
@@ -63,7 +63,7 @@ const updateUser = action(async (id, data) => {
 
 When `getUser` or `updateUser` are invoked on the client, an http request will be made to the server, which calls the corresponding server function.
 
-## Single-flight actions
+## Single-flight mutations
 
 In the above example, when the `updateUser` action is called, a redirect is thrown on the server. 
 Solid Start can handle this redirect on the server instead of propagating it to the client. 


### PR DESCRIPTION
The topic Single-flight "mutations" in response-helpers>redirect.mdx also uses `action` and I haven't heard the term Single-flight "actions" used in doc or videos.

- Replace "actions" with "mutations"

<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
