### PR TITLE
update Modifying values in arrays / Appending new values simplify.

### DIFF
--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -253,8 +253,7 @@ Instead of relying on discovering individual indices, path syntax introduces sev
 
 ### Appending new values
 
-To append a new element to an array within a store, you specify the target array and set the index to the desired position.
-For example, if you wanted to append the new element to the end of the array, you would set the index to `array.length`:
+To append values to an array in a store, use the setter function with the spread operator to return a new array that includes the new elements. For appending a single element, you can instead leverage the "path syntax" by specifying the array’s length as the index to set.
 
 ```jsx
 setStore("users", (otherUsers) => [

--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -253,7 +253,8 @@ Instead of relying on discovering individual indices, path syntax introduces sev
 
 ### Appending new values
 
-To append values to an array in a store, use the setter function with the spread operator to return a new array that includes the new elements. For appending a single element, you can instead leverage the "path syntax" by specifying the array’s length as the index to set.
+To append new values to an array in a store, use the setter function with the spread operator (`...`) to create a new array that includes the existing items and the new ones.
+For appending a single element, you can instead leverage the "path syntax" by specifying the array’s length as the index to set.
 
 ```jsx
 setStore("users", (otherUsers) => [


### PR DESCRIPTION
current 

```Appending new values
To append a new element to an array within a store,
you specify the target array and set the index to the desired position. For example, 
if you wanted to append the new element to the end of the array, 
you would set the index to array.length:
```

this phrasing may be a little ambiguous, the example for appending, using the path syntax, will always use the array.length  to append a value. 

> To **append a new element** to an array within a store,
you specify the target array and set the index to **the desired position**.

may imply to readers that read this section without prior context that the index can be used as insertion point in the array.  not realizing that only works with non existing index such as the length, or higher index

<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x ] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
proposing or revised explanation, that focuses on the usage of array.length as an alternative 
"shortcut"  to using a setter function and a spread for a "**appending of a single value**"


feedback from discord 
![image](https://github.com/user-attachments/assets/9340b529-f67c-4a03-a6a5-845433740642)


### Related issues & labels
Stores
https://docs.solidjs.com/concepts/stores#appending-new-values
