### PR TITLE
Update Deno project init command

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -126,7 +126,7 @@ export default defineConfig(
 							"install-local": "deno i",
 							run: "deno run :content",
 							exec: "dpx :content",
-							create: "deno run -A npm:create-:content",
+							create: "deno init --npm :content",
 						},
 					},
 				},


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
This PR updates the Deno command for initializing a Solid project. The current command on the website is no longer the preferred way of initializing projects with Deno. `deno init --npm` is equivalent to `npm init`.

### Related issues & labels

- Suggested label(s) (optional): 'documentation'
