### PR TITLE
docs: add missing export on concepts/context

### DIFF
--- a/src/routes/concepts/context.mdx
+++ b/src/routes/concepts/context.mdx
@@ -24,7 +24,7 @@ This function has a `Provider` property that wraps the component tree you want t
 ```jsx tab title="/context/create.js"
 import { createContext } from "solid-js";
 
-const MyContext = createContext();
+export const MyContext = createContext();
 ```
 
 ```jsx tab title="/context/component.jsx"


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->
This PR exports the `MyContext` variable, so it can be used in `/context/component.jsx` as demonstrated in the example.
