### PR TITLE
 Improve main content width for short pages

### DIFF
--- a/src/ui/docs-layout.tsx
+++ b/src/ui/docs-layout.tsx
@@ -44,32 +44,30 @@ export const DocsLayout = (props: DocsLayoutProps) => {
 				<Show when={titles()?.title} fallback={<Title>SolidDocs</Title>}>
 					{(title) => <Title>{`${title()} - ${projectTitle()}`}</Title>}
 				</Show>
-				<div id="rr" class="flex relative justify-center">
-					<article class="w-fit overflow-hidden pb-16 lg:px-5 expressive-code-overrides lg:max-w-none">
-						<Show when={titles()?.parent}>
-							{(t) => (
-								<span class="text-sm font-semibold text-blue-700 dark:text-blue-300 my-1">
-									{t()}
-								</span>
-							)}
-						</Show>
-						<Show when={titles()?.title}>
-							{(t) => (
-								<h1 class="prose-headings:text-[2.8rem] text-slate-900 dark:text-white">
-									{t()}
-								</h1>
-							)}
-						</Show>
-						<span class="xl:hidden text-sm -mt-[15px] block">
-							<EditPageLink />
-						</span>
-						<div class="max-w-2xl w-full">{props.children}</div>
-						<span class="xl:hidden text-sm">
-							<PageIssueLink />
-						</span>
-						<Pagination currentIndex={entryIndex()} collection={collection()} />
-					</article>
-				</div>
+				<article class="mx-auto overflow-hidden pb-16 max-w-2xl w-full expressive-code-overrides">
+					<Show when={titles()?.parent}>
+						{(t) => (
+							<span class="text-sm font-semibold text-blue-700 dark:text-blue-300 my-1">
+								{t()}
+							</span>
+						)}
+					</Show>
+					<Show when={titles()?.title}>
+						{(t) => (
+							<h1 class="prose-headings:text-[2.8rem] text-slate-900 dark:text-white">
+								{t()}
+							</h1>
+						)}
+					</Show>
+					<span class="xl:hidden text-sm -mt-[15px] block">
+						<EditPageLink />
+					</span>
+					<div class="w-full">{props.children}</div>
+					<span class="xl:hidden text-sm">
+						<PageIssueLink />
+					</span>
+					<Pagination currentIndex={entryIndex()} collection={collection()} />
+				</article>
 			</>
 		</Show>
 	);


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

This PR addresses a layout inconsistency where pages with very little content appear visually "squeezed" and disproportionately narrow. Currently, the main content area's width adapts to the content size, which is generally fine for longer pages but creates an awkward appearance on shorter ones.

Before:
![image](https://github.com/user-attachments/assets/e6988e04-27fa-4846-8a7d-48350d9675ae)

After:
![image](https://github.com/user-attachments/assets/b6c6d028-4472-4c2d-8bf5-fa666ded4e1a)
