### PR TITLE
Fix active route CSS issue for Overview link in TOC

### DIFF
--- a/src/ui/layout/main-header.tsx
+++ b/src/ui/layout/main-header.tsx
@@ -62,11 +62,11 @@ export function MainHeader(props: NavProps) {
 	const homePageUrl = createMemo(() => {
 		switch (project()) {
 			case "solid-start":
-				return "/solid-start";
+				return "/solid-start/";
 			case "solid-router":
-				return "/solid-router";
+				return "/solid-router/";
 			case "solid-meta":
-				return "/solid-meta";
+				return "/solid-meta/";
 			default:
 				return "/";
 		}
@@ -107,7 +107,7 @@ export function MainHeader(props: NavProps) {
 					</li>
 					<li>
 						<A
-							href="/solid-router"
+							href="/solid-router/"
 							class="text-slate-900 dark:text-slate-200 px-2"
 							activeClass="border-b-2 border-b-blue-500 dark:bottom-b-blue-500 transition-all duration-250"
 							addLocale
@@ -117,7 +117,7 @@ export function MainHeader(props: NavProps) {
 					</li>
 					<li>
 						<A
-							href="/solid-start"
+							href="/solid-start/"
 							class="text-slate-900 dark:text-slate-200 px-2"
 							activeClass="border-b-2 border-b-blue-500 dark:bottom-b-blue-500 transition-all duration-250"
 							addLocale
@@ -127,7 +127,7 @@ export function MainHeader(props: NavProps) {
 					</li>
 					<li>
 						<A
-							href="/solid-meta"
+							href="/solid-meta/"
 							class="text-slate-900 dark:text-slate-200 px-2"
 							activeClass="border-b-2 border-b-blue-500 dark:bottom-b-blue-500 transition-all duration-250"
 							addLocale


### PR DESCRIPTION
This commit resolves a styling issue where the "Overview" link in the table of contents was not highlighted when navigating to /solid-router or /solid-start. The problem stemmed from a missing trailing slash in the URL, causing the active route matching logic to fail. As a result, users could not easily identify their current section, leading to confusion during navigation.

<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
