### PR TITLE
Fix: theme `system` doesn't switch to dark

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -10,7 +10,7 @@
 		color-scheme: light;
 	}
 
-	html[data-theme="dark"] {
+	html[data-theme*="dark"] {
 		color-scheme: dark;
 	}
 
@@ -23,8 +23,8 @@
 		scrollbar-color: #778292 #e7ecf2;
 		scrollbar-width: thin;
 	}
-	html[data-theme="dark"],
-	html[data-theme="dark"] .custom-scrollbar {
+	html[data-theme*="dark"],
+	html[data-theme*="dark"] .custom-scrollbar {
 		scrollbar-color: #8a99ae #313c50;
 		scrollbar-width: thin;
 	}
@@ -133,6 +133,6 @@ html {
 	--twoslash-cursor: #24292E;
 }
 
-html[data-theme="dark"] {
+html[data-theme*="dark"] {
 	--twoslash-cursor: #BABED8;
 }

--- a/src/styles/expressive-code.css
+++ b/src/styles/expressive-code.css
@@ -50,7 +50,7 @@ html .expressive-code-overrides .expressive-code .copy button div {
 	--tmLineBrdCol: hsl(222.77deg 38.21% 51.76% / 55.57%);
 }
 
-html[data-theme="dark"]
+html[data-theme*="dark"]
 	.expressive-code-overrides
 	.expressive-code
 	.ec-line.mark {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,7 @@ export default {
 		"./src/**/*.{js,jsx,ts,tsx,md,mdx}",
 		"./content/**/*.{js,jsx,ts,tsx,md,mdx}",
 	],
-	darkMode: ["selector", "[data-theme='dark']"],
+	darkMode: ["selector", "[data-theme*='dark']"],
 	theme: {
 		fontSize: {
 			xs: ["0.75rem", { lineHeight: "1rem" }],


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

Despite setting system appearance to dark mode, selecting `System` theme always applies light theme because it changes html[data-theme] to `sdark` which is not valid for applying dark theme.

![image](https://github.com/user-attachments/assets/31851067-189a-46c6-a5e5-9335de7a440f)

[As done in kobaltedev/solidbase](https://github.com/search?q=repo%3Akobaltedev%2Fsolidbase%20data-theme*%3D&type=code), a package which solid-docs lies on, selector should be specified in [`[attr*=value]` style](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#attrvalue_6) to accept both `dark` and `sdark`.



### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
