### PR TITLE
Improve wording on delegated events propagation

### DIFF
--- a/src/routes/concepts/components/event-handlers.mdx
+++ b/src/routes/concepts/components/event-handlers.mdx
@@ -10,8 +10,8 @@ Solid provides two ways to add event listeners to the browser:
 - [`on:__`](/reference/jsx-attributes/on): adds an event listener to the `element`. This is also known as a _native event_.
 - [`on__`](/reference/jsx-attributes/on_): adds an event listener to the `document` and dispatches it to the `element`. This can be referred to as a _delegated event_.
 
-Delegated events save some resources by sharing a handler, performing better on commonly used events.
-Native events, however, provide more control over the behavior of the event.
+Delegated events conserve resources and improve performance for commonly used events by sharing a single handler.
+Native events, conversely, offer greater control over event behavior.
 
 ## Using events
 

--- a/src/routes/concepts/components/event-handlers.mdx
+++ b/src/routes/concepts/components/event-handlers.mdx
@@ -10,8 +10,8 @@ Solid provides two ways to add event listeners to the browser:
 - [`on:__`](/reference/jsx-attributes/on): adds an event listener to the `element`. This is also known as a _native event_.
 - [`on__`](/reference/jsx-attributes/on_): adds an event listener to the `document` and dispatches it to the `element`. This can be referred to as a _delegated event_.
 
-Delegated events flow through the [_component tree_](/concepts/components/basics#component-trees), and save some resources by performing better on commonly used events.
-Native events, however, flow through the _DOM tree_, and provide more control over the behavior of the event.
+Delegated events save some resources by sharing a handler, performing better on commonly used events.
+Native events, however, provide more control over the behavior of the event.
 
 ## Using events
 
@@ -95,7 +95,7 @@ If you need to attach an event listener to an element that is not supported by S
 
 While delegated events provide some performance enhancements, there are tradeoffs.
 
-Event delegation is designed for event propagation through the JSX Tree, rather than the DOM Tree.
+Delegated events flow through native element parents but can be overriden by components like Portal.
 This can differ from the previous expectations of how events work and flow.
 
 Some things to keep in mind include:
@@ -171,8 +171,8 @@ button
 
 [See how this solution differs in the Solid Playground](https://playground.solidjs.com/anonymous/9e2deddc-2e83-4ac2-8ee0-49c7c3a45d11).
 
-- [Portals](/concepts/control-flow/portal) propagate events following the _component tree_ and not the _DOM tree_, making them easier to use.
-  This means when a `Portal` gets attached to the `body`, any events will propagate up to the `container`.
+- [Portals](/concepts/control-flow/portal) propagate events to the parent on where it was created, and not to the parent on where it was mounted, making them easier to use.
+  This means when a `Portal` gets attached to the `body`, any events will propagate up to the `container` instead of to the `body`.
 
 ```tsx
 <div class="container" onInput={() => console.log("portal key press")}>

--- a/src/routes/concepts/components/event-handlers.mdx
+++ b/src/routes/concepts/components/event-handlers.mdx
@@ -171,8 +171,8 @@ button
 
 [See how this solution differs in the Solid Playground](https://playground.solidjs.com/anonymous/9e2deddc-2e83-4ac2-8ee0-49c7c3a45d11).
 
-- [Portals](/concepts/control-flow/portal) propagate events to the parent on where it was created, and not to the parent on where it was mounted, making them easier to use.
-  This means when a `Portal` gets attached to the `body`, any events will propagate up to the `container` instead of to the `body`.
+- [Portals](/concepts/control-flow/portal) propagate events following the _component tree_ and not the _DOM tree_, making them easier to use.
+  This means when a `Portal` gets attached to the `body`, any events will propagate up to the `container`.
 
 ```tsx
 <div class="container" onInput={() => console.log("portal key press")}>


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

Milo raised the issue that our wording of "delegated events propagate through the component tree" is slightly incorrect/confusing. This PR aims to clarify that. 

Delegated events flow the dom tree, but components like Portal make these jump to a different element, so while a component changed the flow of the event, is not like events exclusively follow the component tree.

Discord thread in #docs channel https://discord.com/channels/722131463138705510/861229287868858379/1399549944179982438
Invitation if you need: https://discord.gg/solidjs

### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
