### PR TITLE
fix: typo & `redirect` signature

### DIFF
--- a/src/routes/solid-router/reference/response-helpers/redirect.mdx
+++ b/src/routes/solid-router/reference/response-helpers/redirect.mdx
@@ -64,11 +64,11 @@ When returning from a nested method, the parent method will continue to execute,
 ### TypeScript Signature
 
 ```typescript
-interface ResponseOptions & Omit<ResponseInit, "body"> {
+type RouterResponseInit = Omit<ResponseInit, "body"> & {
   revalidate?: string | string[];
-} | number
+};
 
-function redirect(url: string, opts = 302): CustomResponse<never>;
+function redirect(url: string, init?: number | RouterResponseInit): CustomResponse<never>;
 ``` 
 
-The `ResponseOptions` extens the types from the native [`ResponseInit`](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response#options) interface.
+The `ResponseOptions` extends the types from the native [`ResponseInit`](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response#options) interface.


### PR DESCRIPTION
fixed a typo ("extens" became "extends") and corrected the types for the `redirect` function.

<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [ ] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
