### PR TITLE
Use count() instead of signal() in api children example

### DIFF
--- a/src/routes/reference/component-apis/children.mdx
+++ b/src/routes/reference/component-apis/children.mdx
@@ -33,7 +33,7 @@ If you instead call `resolved()`, you re-use the already resolved children.
 You also guarantee that the children are tracked in the current component, as opposed to another tracking scope such as another component.
 
 In addition, the `children` helper "resolves" children by calling argumentless functions and flattening arrays of arrays into an array. 
-For example, a child specified with JSX like `{signal() * 2}` gets wrapped into a getter function `() => count() * 2` in `props.children`, but gets evaluated to an actual number in resolved, properly depending on a count signal.
+For example, a child specified with JSX like `{count() * 2}` gets wrapped into a getter function `() => count() * 2` in `props.children`, but gets evaluated to an actual number in resolved, properly depending on a count signal.
 
 If the given `props.children` is not an array (which occurs when the JSX tag has a single child), then the `children` helper will not normalize it into an array. 
 This is useful behavior e.g. when the intention is to pass a single function as a child, which can be detected via `typeof resolved() === 'function'`. 


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description

Use `count()` instead of `signal()` in api children example, we talk about `count()` later in the sentence.
