### PR TITLE
docs: add /guides/.../welcome route redirect -> /quick-start

### DIFF
--- a/src/middleware/legacy-routes-redirect.ts
+++ b/src/middleware/legacy-routes-redirect.ts
@@ -180,6 +180,8 @@ const LEGACY_ROUTES = {
 
 	"/solid-router/reference/response-helpers/revalidate":
 		"/solid-router/reference/data-apis/revalidate",
+
+  "/guides/tutorials/getting-started-with-solid/welcome": "/quick-start",
 } as const;
 
 function isLegacyRoute(path: string): path is keyof typeof LEGACY_ROUTES {

--- a/src/routes/guides/tutorials/getting-started-with-solid/welcome.tsx
+++ b/src/routes/guides/tutorials/getting-started-with-solid/welcome.tsx
@@ -1,0 +1,37 @@
+import { onMount } from "solid-js";
+
+/**
+ * Server redirect. Immediate HTTP redirect for requests handled on the server.
+ * 301 for permanent. 301s may be cached by browsers/CDNs.
+ */
+export function GET() {
+  return new Response(null, {
+    status: 302,
+    headers: { Location: "/quick-start" },
+  });
+}
+/**
+ * Client fallback: for environments where GET isn't invoked the client will
+ * execute this and replace the location. Keeps UX smooth when navigating client-side.
+ */
+export default function WelcomeRedirect() {
+  onMount(() => {
+    // use replace so the redirect doesn't add an extra history entry
+    try {
+      window.location.replace("https://docs.solidjs.com/quick-start");
+    } catch (e) {
+      // fallback: set href
+      window.location.href = "https://docs.solidjs.com/quick-start";
+    }
+  });
+
+  return (
+    <main style={{ "font-family": "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif", padding: "2rem" }}>
+      <h1>Redirecting…</h1>
+      <p>
+        You are being redirected to the Quick Start page. If the redirect does not happen automatically,{" "}
+        <a href="https://docs.solidjs.com/quick-start">click here to continue</a>.
+      </p>
+    </main>
+  );
+}

--- a/src/routes/guides/tutorials/getting-started-with-solid/welcome.tsx
+++ b/src/routes/guides/tutorials/getting-started-with-solid/welcome.tsx
@@ -19,7 +19,7 @@ export default function WelcomeRedirect() {
     // use replace so the redirect doesn't add an extra history entry
     try {
       window.location.replace("https://docs.solidjs.com/quick-start");
-    } catch (e) {
+    } catch {
       // fallback: set href
       window.location.href = "https://docs.solidjs.com/quick-start";
     }


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description (required)

Fix a broken link path that leads new users to a 404.

**How I encountered it**
- From Google I landed on https://www.solidjs.com/guides/getting-started
- That page says: “We’re working on new docs. You can check out our new beginner tutorial **here**…”
**- The “here” link points to `https://docs.solidjs.com/guides/tutorials/getting-started-with-solid/welcome`**
- That URL returned **404** on the new docs site.

**What this PR does**
- Adds a route at `src/routes/guides/tutorials/getting-started-with-solid/welcome.tsx`
- Issues an **HTTP redirect** to `/quick-start` (via standard Web `Response` with `Location`)
- Includes a **client-side fallback** (`window.location.replace`) for SPA navigations

**Testing**
- Local dev: `pnpm dev`
- Visiting `/guides/tutorials/getting-started-with-solid/welcome` redirects to `/quick-start`
- Client navigation also redirects via the fallback

### Related issues & labels

- Suggested label(s) (optional): `documentation`, `bug`, `good first issue`
