### PR TITLE
Closes issues #649 and #968 

### DIFF
--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -3,9 +3,7 @@ title: Stores
 order: 6
 ---
 
-Similar to [signals](/concepts/signals), stores are a state management primitive.
-However, while signals manage a single piece of state, stores create a centralized location to reduce code redundancy.
-Within Solid, these stores can spawn a collection of reactive signals, each corresponding to a particular property which can be useful when working with complex state.
+Stores are a state management primitive that provide a centralized location to reduce code redundancy. Unlike [signals](/concepts/signals), which manage a single piece of state and re-render entirely when updated, stores retain fine-grained reactivity by updating only the specific properties that change. They can generate a collection of reactive signals, each tied to a specific property, making them ideal for managing complex state efficiently.
 
 ## Creating a store
 

--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -3,7 +3,9 @@ title: Stores
 order: 6
 ---
 
-Stores are a state management primitive that provide a centralized location to reduce code redundancy. Unlike [signals](/concepts/signals), which manage a single piece of state and re-render entirely when updated, stores retain fine-grained reactivity by updating only the specific properties that change. They can generate a collection of reactive signals, each tied to a specific property, making them ideal for managing complex state efficiently.
+Stores are a state management primitive that provide a centralized way to handle shared data and reduce redundancy.
+Unlike [signals](/concepts/signals), which track a single value and trigger a full re-render when updated, stores maintain fine-grained reactivity by updating only the properties that change.
+They can produce a collection of reactive signals, each linked to an individual property, making them well-suited for managing complex state efficiently.
 
 ## Creating a store
 

--- a/src/routes/solid-start/building-your-application/route-prerendering.mdx
+++ b/src/routes/solid-start/building-your-application/route-prerendering.mdx
@@ -18,7 +18,7 @@ export default defineConfig({
 });
 ```
 
-Or to automatically pre-render all routes, enable the `crawlLinks` option
+Or to pre-render all routes, you can pass `true` to the `crawlLinks` option
 
 ```js { 6 }
 import { defineConfig } from "@solidjs/start/config";

--- a/src/routes/solid-start/building-your-application/route-prerendering.mdx
+++ b/src/routes/solid-start/building-your-application/route-prerendering.mdx
@@ -2,7 +2,9 @@
 title: "Route Pre-rendering"
 ---
 
-Route pre-rendering enables Static Site Generation (SSG) by creating static HTML pages at build time. This delivers faster page loads and improves SEO, making it ideal for content-heavy sites like documentation, blogs, or marketing pages. Static files are served without server-side processing at runtime.
+Route pre-rendering powers Static Site Generation (SSG) by producing static HTML pages during the build process.
+This results in faster load times and better SEO, making it especially useful for content-rich sites such as documentation, blogs, and marketing pages.
+Static files are served without server-side processing at runtime.
 
 Configure prerendering for specific routes using the `routes` option
 

--- a/src/routes/solid-start/building-your-application/route-prerendering.mdx
+++ b/src/routes/solid-start/building-your-application/route-prerendering.mdx
@@ -1,9 +1,10 @@
 ---
-title: "Route pre-rendering"
+title: "Route Pre-rendering"
 ---
 
-SolidStart offers a way to pre-render pages at build time.
-The easiest way to accomplish this is by passing a list of routes to be pre-rendered to the `routes` option.
+Route pre-rendering enables Static Site Generation (SSG) by creating static HTML pages at build time. This delivers faster page loads and improves SEO, making it ideal for content-heavy sites like documentation, blogs, or marketing pages. Static files are served without server-side processing at runtime.
+
+To pre-render specific routes, specify the routes option in your configuration file
 
 ```js { 6 }
 import { defineConfig } from "@solidjs/start/config";
@@ -17,7 +18,7 @@ export default defineConfig({
 });
 ```
 
-When you wish for all your routes to be pre-rendered, you can pass `true` to the `crawlLinks` option:
+Or to automatically pre-render all routes, enable the `crawlLinks` option
 
 ```js { 6 }
 import { defineConfig } from "@solidjs/start/config";
@@ -31,4 +32,6 @@ export default defineConfig({
 });
 ```
 
-For more information on prerender options, check out [Nitro's documentation](https://nitro.build/config#prerender)
+For advanced pre-rendering options, refer to [Nitro's documentation](https://nitro.build/config#prerender).
+
+[SolidBase](https://solidbase.dev) simplifies SSG development with built-in support for fast, pre-rendered Markdown and MDX pages.

--- a/src/routes/solid-start/building-your-application/route-prerendering.mdx
+++ b/src/routes/solid-start/building-your-application/route-prerendering.mdx
@@ -4,7 +4,7 @@ title: "Route Pre-rendering"
 
 Route pre-rendering enables Static Site Generation (SSG) by creating static HTML pages at build time. This delivers faster page loads and improves SEO, making it ideal for content-heavy sites like documentation, blogs, or marketing pages. Static files are served without server-side processing at runtime.
 
-To pre-render specific routes, specify the routes option in your configuration file
+Configure prerendering for specific routes using the `routes` option
 
 ```js { 6 }
 import { defineConfig } from "@solidjs/start/config";


### PR DESCRIPTION
- specified route pre-rendering is for SSG, added solidbase reference, closes #649 

- enhances the explanation of why stores should be used, as discussed in [issue #968](https://github.com/solidjs/solid-docs/issues/968#issuecomment-2558036115), closes #968
