### PR TITLE
Addresses Issue #1183

### DIFF
--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -255,7 +255,8 @@ Instead of relying on discovering individual indices, path syntax introduces sev
 
 To append values to an array in a store, use the setter function with the spread operator (`...`) or the path syntax. Both methods add an element to the array but differ in how they modify it and their reactivity behavior.
 
-The spread operator creates a new array by copying existing elements and adding the new element, replacing the entire `store.users` array. This triggers reactivity for all effects tracking the array or its properties.
+The spread operator creates a new array by copying the existing elements and adding the new one, effectively replacing the entire `store.users` array.
+This replacement triggers reactivity for all effects that depend on the array or its properties.
 
 ```jsx
 setStore("users", (otherUsers) => [

--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -270,7 +270,8 @@ setStore("users", (otherUsers) => [
 ])
 ```
 
-The path syntax appends the new element by setting it at the index equal to `store.users.length`, modifying the existing array. This triggers reactivity only for effects tracking the new index or properties like `store.users.length`, making it more efficient for targeted updates.
+The path syntax adds the new element by assigning it to the index equal to `store.users.length`, directly modifying the existing array.
+This triggers reactivity only for effects that depend on the new index or properties like `store.users.length`, making updates more efficient and targeted.
 
 ```jsx
 setStore("users", store.users.length, {

--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -253,8 +253,9 @@ Instead of relying on discovering individual indices, path syntax introduces sev
 
 ### Appending new values
 
-To append new values to an array in a store, use the setter function with the spread operator (`...`) to create a new array that includes the existing items and the new ones.
-For appending a single element, you can instead leverage the "path syntax" by specifying the array’s length as the index to set.
+To append values to an array in a store, use the setter function with the spread operator (`...`) or the path syntax. Both methods add an element to the array but differ in how they modify it and their reactivity behavior.
+
+The spread operator creates a new array by copying existing elements and adding the new element, replacing the entire `store.users` array. This triggers reactivity for all effects tracking the array or its properties.
 
 ```jsx
 setStore("users", (otherUsers) => [
@@ -266,9 +267,11 @@ setStore("users", (otherUsers) => [
 		loggedIn: false,
 	},
 ])
+```
 
-// can become
+The path syntax appends the new element by setting it at the index equal to `store.users.length`, modifying the existing array. This triggers reactivity only for effects tracking the new index or properties like `store.users.length`, making it more efficient for targeted updates.
 
+```jsx
 setStore("users", store.users.length, {
 	id: 3,
 	username: "michael584",


### PR DESCRIPTION
This PR updates the documentation for appending values to store arrays to clearly distinguish the reactivity behavior of the spread operator and path syntax
closes #1183 