### PR TITLE
remove random `;` symbol from splitProps docs

### DIFF
--- a/src/routes/reference/reactive-utilities/split-props.mdx
+++ b/src/routes/reference/reactive-utilities/split-props.mdx
@@ -37,7 +37,7 @@ Because `splitProps` takes any number of arrays, we can split a props object as 
 Let's say a component was passed six props:
 
 ```tsx
-;<MyComponent a={1} b={2} c={3} d={4} e={5} foo="bar" />
+<MyComponent a={1} b={2} c={3} d={4} e={5} foo="bar" />
 // ...
 
 function MyComponent(props) {


### PR DESCRIPTION
just fixing a typo here

<img width="711" height="431" alt="image" src="https://github.com/user-attachments/assets/a07387e6-620c-445d-84b3-463e2e6549be" />
