### PR TITLE
Remove "variables" from createEffect dependency examples

### DIFF
--- a/src/routes/concepts/effects.mdx
+++ b/src/routes/concepts/effects.mdx
@@ -28,7 +28,7 @@ When the value of `count` changes, the effect is triggered, causing it to run ag
 
 Effects can be set to observe any number of dependencies.
 Dependencies are what allow an effect to track changes and respond accordingly.
-These can include signals, variables, props, context, or any other reactive values.
+These can include signals, props, context, or any other reactive values.
 When any of these change, the effect is notified and will run again to update its state.
 
 Upon initialization, an effect will run _once_, regardless of whether it has any dependencies.


### PR DESCRIPTION

<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description
Removed "variables" from the list of the types of things that createEffect tracks changes of. It was [confusing](https://www.reddit.com/r/solidjs/comments/1nex5ei/why_does_solidjs_docs_list_variables_as_a/) and [incorrect](https://playground.solidjs.com/anonymous/086d4c92-c72f-4d9f-bd44-4821080bab61) except for variables that hold reactive values.

