### PR TITLE
Remove deprecated Auto Minify note from Cloudflare deployment docs

### DIFF
--- a/src/routes/guides/deployment-options/cloudflare.mdx
+++ b/src/routes/guides/deployment-options/cloudflare.mdx
@@ -80,7 +80,3 @@ wrangler pages deploy dist
 
 After running these commands, your project should be live.
 While the terminal may provide a link, it's more reliable to check your Cloudflare Pages dashboard for the deployed URL, which usually follows the format `project-name.pages.dev`.
-
-**Note:**
-Make sure to navigate to the `Speed` -> `Optimization settings` section in your Cloudflare website dashboard and disable the `Auto Minify` option.
-This is important as minification and comment removal can interfere with hydration.


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->
Previously, the same issue mentioned in the note occurred (#185), but now the [Auto Minify option has been deprecated](https://developers.cloudflare.com/fundamentals/api/reference/deprecations/#2024-08-05) and no longer exists. However, the note still remains in the documentation, which causes confusion for users. Since this hasn't been reflected in the documentation yet, I've updated it.
