### PR TITLE
Seed routes for prerendering

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -16,7 +16,7 @@ const allEntries = [
 	solidstartEntries.learn, solidstartEntries.reference,
 	solidrouterEntries.learn, solidrouterEntries.reference,
 	solidMetaEntries.learn, solidMetaEntries.reference,
-].flat(Infinity).map(x => x.path.replace(/\\/g, '/')).sort()
+].flat(Infinity).map(x => x.path.replace(/\\/g, '/'))
 
 function docsData() {
 	const virtualModuleId = "solid:collection";

--- a/app.config.ts
+++ b/app.config.ts
@@ -16,7 +16,10 @@ const allEntries = [
 	solidstartEntries.learn, solidstartEntries.reference,
 	solidrouterEntries.learn, solidrouterEntries.reference,
 	solidMetaEntries.learn, solidMetaEntries.reference,
-].flat(Infinity).map(x => x.path.replace(/\\/g, '/'))
+].flat(Infinity).map(x =>
+	// @ts-expect-error `flat` mess up the type and I have no idea how to fix this
+	x.path.replace(/\\/g, '/')
+)
 
 function docsData() {
 	const virtualModuleId = "solid:collection";

--- a/app.config.ts
+++ b/app.config.ts
@@ -19,7 +19,7 @@ const allEntries = [
 ].flat(Infinity).map(x =>
 	// @ts-expect-error `flat` mess up the type and I have no idea how to fix this
 	x.path.replace(/\\/g, '/')
-)
+);
 
 function docsData() {
 	const virtualModuleId = "solid:collection";

--- a/app.config.ts
+++ b/app.config.ts
@@ -11,6 +11,13 @@ import solidrouterTree from "./.solid/solid-router-tree";
 import solidStartTree from "./.solid/solid-start-tree";
 import solidMetaTree from "./.solid/solid-meta-tree";
 
+const allEntries = [
+	entries.learn, entries.reference,
+	solidstartEntries.learn, solidstartEntries.reference,
+	solidrouterEntries.learn, solidrouterEntries.reference,
+	solidMetaEntries.learn, solidMetaEntries.reference,
+].flat(Infinity).map(x => x.path.replace(/\\/g, '/')).sort()
+
 function docsData() {
 	const virtualModuleId = "solid:collection";
 	const resolveVirtualModuleId = "\0" + virtualModuleId;
@@ -53,6 +60,7 @@ export default defineConfig(
 					crawlLinks: true,
 					autoSubfolderIndex: false,
 					failOnError: true,
+					routes: allEntries,
 					// eslint-disable-next-line no-useless-escape
 					ignore: [/\{\getPath}/, /.*?emojiSvg\(.*/],
 				},

--- a/app.config.ts
+++ b/app.config.ts
@@ -18,7 +18,7 @@ const allEntries = [
 	solidMetaEntries.learn, solidMetaEntries.reference,
 ].flat(Infinity).map(x =>
 	// @ts-expect-error `flat` mess up the type and I have no idea how to fix this
-	x.path.replace(/\\/g, '/')
+	x.path.replace(/\\/g, "/")
 );
 
 function docsData() {


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

Orama search is not working because our routes are not prerendering. This seems to be an issue with Nitro not being able to parse our `data-hk` unquoted attributes. 
Theres a PR to quote our `data-hk` https://github.com/ryansolid/dom-expressions/pull/465 to workaround the problem with Nitro.
Meanwhile this is merged and released, we can pre-seed our routes to prerender known paths and temporaly fix the search. 

This works in local, I am not sure if this works in preview/production. Will see.

### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 --> 
- https://github.com/solidjs/solid-docs/issues/1318 
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
