### PR TITLE
Removes duplicate search results from search, and fix incorrect URLs

### DIFF
--- a/src/ui/search.tsx
+++ b/src/ui/search.tsx
@@ -64,7 +64,7 @@ export function Search() {
 			});
 			if (!result) return {};
 
-			const seen = {}
+			const seen: Record<string, boolean> = {}
 			result.hits = result.hits.filter(
 				hit => {
 					hit.document.path = hit.document.path.replace("/index#", "#");

--- a/src/ui/search.tsx
+++ b/src/ui/search.tsx
@@ -63,6 +63,18 @@ export function Search() {
 				mode: "fulltext",
 			});
 			if (!result) return {};
+
+			const seen = {}
+			result.hits = result.hits.filter(
+				hit => {
+					hit.document.path = hit.document.path.replace("/index#", "#");
+					if(!seen[hit.document.path]) {
+						seen[hit.document.path] = true;
+						return hit;
+					}
+				}
+			);
+
 			const groupedHits = result.hits.reduce(
 				(groupedHits, hit) => {
 					const section = hit.document.section.replace(

--- a/src/ui/search.tsx
+++ b/src/ui/search.tsx
@@ -64,7 +64,7 @@ export function Search() {
 			});
 			if (!result) return {};
 
-			const seen: Record<string, boolean> = {}
+			const seen: Record<string, boolean> = {};
 			result.hits = result.hits.filter(
 				hit => {
 					hit.document.path = hit.document.path.replace("/index#", "#");


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

Removes duplicated search results and fix incorrect URLs from Orama search results. 

For example "router" gives two duplicated documents 
- `solid-router/index#solid-router` (invalid) 
- `solid-router#solid-router` (valid)

The underlying problem seems to be we use mostly urls that do not contain trailing slashes, but our main sections "Solid Router", "Solid Meta", and "Solid Start" are linked using a trailing slash from the top bar menu.  This probably confuses orama index resulting in a link that includes `/index` as the `path` of the document. Im actually not sure but thats what I suspect. 

 ### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 --> #1315
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
