### PR TITLE
Documentation metadata via Frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Solid Docs
+<p>
+  <img src="https://assets.solidjs.com/banner?project=Solid%20Documentation&type=core" alt="Solid Documentation" />
+</p>
+
 
 Welcome to Solid's documentation!
 

--- a/src/routes/advanced-concepts/fine-grained-reactivity.mdx
+++ b/src/routes/advanced-concepts/fine-grained-reactivity.mdx
@@ -1,5 +1,16 @@
 ---
 title: Fine-grained reactivity
+use_cases: >-
+  understanding core reactivity, performance optimization, building reactive
+  systems from scratch, learning framework internals
+tags:
+  - reactivity
+  - signals
+  - effects
+  - performance
+  - fundamentals
+  - reactive-primitives
+version: '1.0'
 ---
 
 Reactivity ensures automatic responses to data changes, eliminating the need for manual updates to the user interface (UI).

--- a/src/routes/concepts/components/basics.mdx
+++ b/src/routes/concepts/components/basics.mdx
@@ -1,6 +1,17 @@
 ---
 title: Basics
 order: 4
+use_cases: >-
+  always, first component creation, learning component structure, understanding
+  lifecycle, component organization
+tags:
+  - components
+  - jsx
+  - lifecycle
+  - fundamentals
+  - always
+  - component-tree
+version: '1.0'
 ---
 
 Components are the building blocks of Solid applications.

--- a/src/routes/concepts/components/class-style.mdx
+++ b/src/routes/concepts/components/class-style.mdx
@@ -1,6 +1,17 @@
 ---
 title: Class and style
 order: 2
+use_cases: >-
+  styling components, dynamic styling, theming, conditional css classes, inline
+  styles
+tags:
+  - styling
+  - css
+  - classes
+  - dynamic-styling
+  - theming
+  - conditional-rendering
+version: '1.0'
 ---
 
 Similar to HTML, Solid uses `class` and `style` attributes to style elements via [CSS (Cascading Style Sheets)](https://developer.mozilla.org/en-US/docs/Glossary/CSS).

--- a/src/routes/concepts/components/event-handlers.mdx
+++ b/src/routes/concepts/components/event-handlers.mdx
@@ -1,6 +1,17 @@
 ---
 title: Event handlers
 order: 3
+use_cases: >-
+  user interactions, click handlers, form events, custom events, event
+  delegation optimization
+tags:
+  - events
+  - user-interaction
+  - forms
+  - event-delegation
+  - performance
+  - handlers
+version: '1.0'
 ---
 
 Event handlers are functions that are called in response to specific events occurring in the browser, such as when a user clicks or taps on an element.

--- a/src/routes/concepts/components/props.mdx
+++ b/src/routes/concepts/components/props.mdx
@@ -1,5 +1,16 @@
 ---
 title: Props
+use_cases: >-
+  passing data between components, component communication, reusable components,
+  parent-child data flow
+tags:
+  - props
+  - component-communication
+  - data-flow
+  - reusability
+  - merge-props
+  - split-props
+version: '1.0'
 ---
 
 Props are a way to pass state from a parent component to a child component.

--- a/src/routes/concepts/context.mdx
+++ b/src/routes/concepts/context.mdx
@@ -1,6 +1,17 @@
 ---
-title: "Context"
+title: Context
 order: 5
+use_cases: >-
+  avoiding prop drilling, global state, theme management, authentication state,
+  deeply nested components
+tags:
+  - context
+  - global-state
+  - prop-drilling
+  - state-management
+  - provider-pattern
+  - theming
+version: '1.0'
 ---
 
 Context provides a way to pass data through the component tree without having to pass props down manually at every level.

--- a/src/routes/concepts/control-flow/conditional-rendering.mdx
+++ b/src/routes/concepts/control-flow/conditional-rendering.mdx
@@ -1,6 +1,17 @@
 ---
-title: "Conditional rendering"
+title: Conditional rendering
 order: 1
+use_cases: >-
+  showing hiding content, loading states, error states, user permissions,
+  dynamic ui
+tags:
+  - conditional-rendering
+  - loading-states
+  - error-handling
+  - dynamic-ui
+  - show
+  - switch-match
+version: '1.0'
 ---
 
 Conditional rendering is the process of displaying different UI elements based on certain conditions.

--- a/src/routes/concepts/control-flow/dynamic.mdx
+++ b/src/routes/concepts/control-flow/dynamic.mdx
@@ -1,6 +1,16 @@
 ---
-title: "Dynamic"
+title: Dynamic
 order: 2
+use_cases: >-
+  dynamic component rendering, component switching, plugin systems, cms content,
+  configurable ui
+tags:
+  - dynamic-components
+  - component-switching
+  - configurable-ui
+  - cms
+  - plugin-systems
+version: '1.0'
 ---
 
 `<Dynamic>` is a Solid component that allows you to render components dynamically based on data.

--- a/src/routes/concepts/control-flow/error-boundary.mdx
+++ b/src/routes/concepts/control-flow/error-boundary.mdx
@@ -1,6 +1,16 @@
 ---
-title: "Error boundary"
+title: Error boundary
 order: 5
+use_cases: >-
+  error handling, preventing app crashes, user experience, graceful degradation,
+  error recovery
+tags:
+  - error-handling
+  - error-boundary
+  - crash-prevention
+  - user-experience
+  - error-recovery
+version: '1.0'
 ---
 
 By default, if part of an application throws an error during rendering, the entire application can crash, resulting in Solid removing its UI from the screen.

--- a/src/routes/concepts/control-flow/list-rendering.mdx
+++ b/src/routes/concepts/control-flow/list-rendering.mdx
@@ -1,6 +1,18 @@
 ---
-title: "List rendering"
+title: List rendering
 order: 3
+use_cases: >-
+  displaying arrays, dynamic lists, table data, todo lists, data visualization,
+  performance optimization
+tags:
+  - lists
+  - arrays
+  - iteration
+  - performance
+  - for-component
+  - index-component
+  - dynamic-data
+version: '1.0'
 ---
 
 List rendering allows you to generate multiple elements from a collection of data, such as an array or object, where each element corresponds to an item in the collection.

--- a/src/routes/concepts/control-flow/portal.mdx
+++ b/src/routes/concepts/control-flow/portal.mdx
@@ -1,6 +1,19 @@
 ---
-title: "Portal"
+title: Portal
 order: 3
+use_cases: >-
+  modals, tooltips, dropdowns, popups, overlays, z-index issues, clipped
+  content, accessibility improvements
+tags:
+  - modals
+  - tooltips
+  - dropdowns
+  - popups
+  - overlays
+  - accessibility
+  - dom
+  - positioning
+version: '1.0'
 ---
 
 When an element requires rendering outside of the usual document flow, challenges related to stacking contents and z-index can interfere with the desired intention or look of an application.

--- a/src/routes/concepts/derived-values/derived-signals.mdx
+++ b/src/routes/concepts/derived-values/derived-signals.mdx
@@ -1,6 +1,17 @@
 ---
 title: Derived signals
 order: 1
+use_cases: >-
+  computed values, reactive calculations, dependent state, always, any solid
+  project, data transformations
+tags:
+  - reactivity
+  - computed
+  - derived
+  - calculations
+  - dependencies
+  - always
+version: '1.0'
 ---
 
 Derived signals are functions that rely on one or more [signals](/concepts/signals) to produce a value.

--- a/src/routes/concepts/derived-values/memos.mdx
+++ b/src/routes/concepts/derived-values/memos.mdx
@@ -1,6 +1,17 @@
 ---
 title: Memos
 order: 2
+use_cases: >-
+  expensive computations, caching, performance optimization, derived state,
+  preventing unnecessary recalculations
+tags:
+  - performance
+  - optimization
+  - caching
+  - expensive-computations
+  - derived
+  - reactivity
+version: '1.0'
 ---
 
 Memos are a type of reactive value that can be used to memoize derived state or expensive computations.

--- a/src/routes/concepts/effects.mdx
+++ b/src/routes/concepts/effects.mdx
@@ -1,6 +1,17 @@
 ---
 title: Effects
 order: 4
+use_cases: >-
+  side effects, dom manipulation, data fetching, subscriptions, cleanup,
+  lifecycle management, logging
+tags:
+  - side-effects
+  - lifecycle
+  - data-fetching
+  - dom-manipulation
+  - cleanup
+  - subscriptions
+version: '1.0'
 ---
 
 Effects are functions that are triggered when the signals they depend on change.

--- a/src/routes/concepts/intro-to-reactivity.mdx
+++ b/src/routes/concepts/intro-to-reactivity.mdx
@@ -1,6 +1,17 @@
 ---
-title: "Intro to reactivity"
+title: Intro to reactivity
 order: 1
+use_cases: >-
+  always, learning solid, understanding reactivity, new developers, core
+  concepts
+tags:
+  - always
+  - learning
+  - fundamentals
+  - reactivity
+  - beginner
+  - core-concepts
+version: '1.0'
 ---
 
 **Note**: While this guide is useful for understanding reactive systems, it does use some Solid-specific terminology.

--- a/src/routes/concepts/refs.mdx
+++ b/src/routes/concepts/refs.mdx
@@ -1,5 +1,15 @@
 ---
 title: Refs
+use_cases: >-
+  dom access, element manipulation, focus management, animations, third party
+  libraries, imperative operations
+tags:
+  - dom-access
+  - animations
+  - focus-management
+  - third-party-integration
+  - imperative
+version: '1.0'
 ---
 
 Refs, or references, are a special attribute that can be attached to any element, and are used to reference a DOM element or a component instance.

--- a/src/routes/concepts/signals.mdx
+++ b/src/routes/concepts/signals.mdx
@@ -1,6 +1,14 @@
 ---
 title: Signals
 order: 2
+use_cases: 'always, any solid project, state management, reactive data, core functionality'
+tags:
+  - always
+  - state-management
+  - reactivity
+  - fundamentals
+  - core
+version: '1.0'
 ---
 
 Signals are the primary means of [managing state](/concepts/intro-to-reactivity#state-management) in your Solid application.

--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -1,6 +1,17 @@
 ---
 title: Stores
 order: 6
+use_cases: >-
+  complex state, nested data, objects, arrays, shared state, performance
+  optimization, large applications
+tags:
+  - complex-state
+  - nested-data
+  - objects
+  - arrays
+  - performance
+  - large-applications
+version: '1.0'
 ---
 
 Stores are a state management primitive that provide a centralized way to handle shared data and reduce redundancy.

--- a/src/routes/concepts/understanding-jsx.mdx
+++ b/src/routes/concepts/understanding-jsx.mdx
@@ -1,6 +1,18 @@
 ---
 title: Understanding JSX
 order: 2
+use_cases: >-
+  always, learning solid, templating, ui rendering, new developers, component
+  creation
+tags:
+  - always
+  - jsx
+  - templating
+  - ui
+  - components
+  - fundamentals
+  - beginner
+version: '1.0'
 ---
 
 JSX is an extension for JavaScript.

--- a/src/routes/configuration/environment-variables.mdx
+++ b/src/routes/configuration/environment-variables.mdx
@@ -1,5 +1,16 @@
 ---
 title: Environment variables
+use_cases: >-
+  configuration, api keys, deployment, environment-specific settings, build
+  configuration
+tags:
+  - configuration
+  - deployment
+  - api-keys
+  - build
+  - environment
+  - settings
+version: '1.0'
 ---
 
 Solid is built on top of [Vite](https://vitejs.dev/), which offers a convenient way to handle environment variables.

--- a/src/routes/configuration/typescript.mdx
+++ b/src/routes/configuration/typescript.mdx
@@ -1,5 +1,19 @@
 ---
 title: TypeScript
+use_cases: >-
+  type safety, large projects, team development, code documentation, catching
+  errors at compile time
+tags:
+  - typescript
+  - types
+  - configuration
+  - jsx
+  - components
+  - events
+  - signals
+  - context
+  - refs
+version: '1.0'
 ---
 
 [TypeScript](https://www.typescriptlang.org/) is a superset of JavaScript that enhances code reliability and predictability through the introduction of [static types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html).

--- a/src/routes/guides/complex-state-management.mdx
+++ b/src/routes/guides/complex-state-management.mdx
@@ -1,6 +1,18 @@
 ---
 title: Complex state management
 order: 5
+use_cases: >-
+  large applications, multiple components, complex user interactions, avoiding
+  prop drilling, shared state
+tags:
+  - stores
+  - state management
+  - complex apps
+  - context
+  - produce
+  - shared state
+  - scalability
+version: '1.0'
 ---
 
 As applications grow and start to involve many components, more intricate user interactions, and possibly communication with backend services, you may find that staying organized with more [basic state management methods](/guides/state-management) can become difficult to maintain.

--- a/src/routes/guides/deploying-your-app.mdx
+++ b/src/routes/guides/deploying-your-app.mdx
@@ -1,6 +1,16 @@
 ---
 title: Deploy your app
 order: 9
+use_cases: >-
+  production deployment, going live, hosting selection, deployment platform
+  comparison
+tags:
+  - deployment
+  - hosting
+  - production
+  - platforms
+  - links
+version: '1.0'
 ---
 
 Are you ready to deploy your Solid application? Follow our guides for different deployment services.

--- a/src/routes/guides/deployment-options/aws-via-flightcontrol.mdx
+++ b/src/routes/guides/deployment-options/aws-via-flightcontrol.mdx
@@ -2,6 +2,18 @@
 title: AWS via Flightcontrol
 order: 1
 mainNavExclude: true
+use_cases: >-
+  aws deployment, automated deployments, github integration, enterprise hosting,
+  cloud infrastructure
+tags:
+  - deployment
+  - aws
+  - flightcontrol
+  - github
+  - automation
+  - cloud
+  - configuration
+version: '1.0'
 ---
 
 [Flightcontrol](https://www.flightcontrol.dev/) is a platform that fully automates deployments to Amazon Web Services (AWS).

--- a/src/routes/guides/deployment-options/aws-via-sst.mdx
+++ b/src/routes/guides/deployment-options/aws-via-sst.mdx
@@ -2,6 +2,18 @@
 title: AWS via SST
 order: 1
 mainNavExclude: true
+use_cases: >-
+  aws lambda deployment, serverless hosting, cloud infrastructure, container
+  deployment
+tags:
+  - deployment
+  - aws
+  - lambda
+  - serverless
+  - containers
+  - sst
+  - cloud
+version: '1.0'
 ---
 
 [SST](https://sst.dev/) is a framework for deploying applications to any cloud provider. It has a built-in way to deploy SolidStart apps to AWS Lambda. For additional details, you can [visit their docs](https://sst.dev/docs/).

--- a/src/routes/guides/deployment-options/cloudflare.mdx
+++ b/src/routes/guides/deployment-options/cloudflare.mdx
@@ -2,6 +2,18 @@
 title: Cloudflare
 order: 2
 mainNavExclude: true
+use_cases: >-
+  jamstack deployment, cloudflare pages hosting, cdn deployment, edge computing,
+  web interface deployment
+tags:
+  - deployment
+  - cloudflare
+  - pages
+  - jamstack
+  - cli
+  - wrangler
+  - cdn
+version: '1.0'
 ---
 
 [Cloudflare Pages](https://pages.cloudflare.com/) is a JAMstack platform for frontend developers, where JAMstack stands for JavaScript, APIs, and Markup.

--- a/src/routes/guides/deployment-options/firebase.mdx
+++ b/src/routes/guides/deployment-options/firebase.mdx
@@ -2,6 +2,17 @@
 title: Firebase
 order: 3
 mainNavExclude: true
+use_cases: >-
+  google cloud deployment, firebase hosting, backend services integration, rapid
+  prototyping
+tags:
+  - deployment
+  - firebase
+  - google
+  - hosting
+  - cli
+  - backend
+version: '1.0'
 ---
 
 [Firebase](https://firebase.google.com/) is an all-in-one app development platform by Google, offering a range of services from real-time databases to user authentication.

--- a/src/routes/guides/deployment-options/netlify.mdx
+++ b/src/routes/guides/deployment-options/netlify.mdx
@@ -2,6 +2,17 @@
 title: Netlify
 order: 4
 mainNavExclude: true
+use_cases: >-
+  jamstack deployment, netlify hosting, continuous deployment, git integration,
+  static site hosting
+tags:
+  - deployment
+  - netlify
+  - jamstack
+  - git
+  - cli
+  - continuous deployment
+version: '1.0'
 ---
 
 [Netlify](https://www.netlify.com/) is a widely-used hosting platform suitable for various types of projects.

--- a/src/routes/guides/deployment-options/railway.mdx
+++ b/src/routes/guides/deployment-options/railway.mdx
@@ -2,6 +2,17 @@
 title: Railway
 order: 5
 mainNavExclude: true
+use_cases: >-
+  railway deployment, cloud hosting, github integration, domain management,
+  container deployment
+tags:
+  - deployment
+  - railway
+  - cloud
+  - github
+  - cli
+  - domains
+version: '1.0'
 ---
 
 [Railway](https://railway.app/) is a well-known platform for deploying a variety of web and cloud-based projects.

--- a/src/routes/guides/deployment-options/stormkit.mdx
+++ b/src/routes/guides/deployment-options/stormkit.mdx
@@ -2,6 +2,17 @@
 title: Stormkit
 order: 7
 mainNavExclude: true
+use_cases: >-
+  static site deployment, spa hosting, serverless functions, git provider
+  integration
+tags:
+  - deployment
+  - stormkit
+  - static
+  - spa
+  - serverless
+  - git
+version: '1.0'
 ---
 
 [Stormkit](https://www.stormkit.io) is a deployment platform for static websites, single-page applications (SPAs), and serverless functions.

--- a/src/routes/guides/deployment-options/vercel.mdx
+++ b/src/routes/guides/deployment-options/vercel.mdx
@@ -2,6 +2,18 @@
 title: Vercel
 order: 6
 mainNavExclude: true
+use_cases: >-
+  deploying to production, hosting frontend projects, continuous deployment, web
+  interface deployment, cli deployment
+tags:
+  - deployment
+  - hosting
+  - production
+  - vercel
+  - cli
+  - frontend
+  - git
+version: '1.0'
 ---
 
 [Vercel](https://vercel.com/) is a widely-used platform specialized in hosting frontend projects.

--- a/src/routes/guides/deployment-options/zerops.mdx
+++ b/src/routes/guides/deployment-options/zerops.mdx
@@ -2,6 +2,18 @@
 title: Zerops
 order: 7
 mainNavExclude: true
+use_cases: >-
+  deploying to cloud platform, ssr deployment, static deployment, dev-first
+  hosting, node.js deployment
+tags:
+  - deployment
+  - hosting
+  - cloud
+  - ssr
+  - static
+  - nodejs
+  - production
+version: '1.0'
 ---
 
 [Zerops](https://zerops.io) is a dev-first cloud platform that can be used to deploy both Static and SSR Solid Node.js Apps.

--- a/src/routes/guides/fetching-data.mdx
+++ b/src/routes/guides/fetching-data.mdx
@@ -1,6 +1,18 @@
 ---
 title: Fetching data
 order: 3
+use_cases: >-
+  data fetching, api calls, async operations, loading states, error handling,
+  real-time data, optimistic updates
+tags:
+  - data
+  - async
+  - api
+  - loading
+  - error
+  - fetching
+  - resource
+version: '1.0'
 ---
 
 For most modern web applications, data fetching is a common task.

--- a/src/routes/guides/routing-and-navigation.mdx
+++ b/src/routes/guides/routing-and-navigation.mdx
@@ -1,6 +1,18 @@
 ---
 title: Routing & navigation
 order: 4
+use_cases: >-
+  navigation between pages, url routing, dynamic routes, nested routes, route
+  parameters, spa routing, preloading data
+tags:
+  - routing
+  - navigation
+  - spa
+  - pages
+  - dynamic
+  - nested
+  - preload
+version: '1.0'
 ---
 
 [Solid Router](/solid-router) simplifies routing in Solid applications to help developers manage navigation and rendering by defining routes using JSX or objects passed via props.

--- a/src/routes/guides/state-management.mdx
+++ b/src/routes/guides/state-management.mdx
@@ -1,6 +1,18 @@
 ---
 title: State management
 order: 2
+use_cases: >-
+  managing component state, reactivity, derived values, sharing state, lifting
+  state, complex applications, interactive ui
+tags:
+  - state
+  - reactivity
+  - signals
+  - derived
+  - effects
+  - memos
+  - components
+version: '1.0'
 ---
 
 State management is the process of handling and manipulating data that affects the behavior and presentation of a web application.

--- a/src/routes/guides/styling-components/css-modules.mdx
+++ b/src/routes/guides/styling-components/css-modules.mdx
@@ -2,6 +2,17 @@
 title: CSS modules
 order: 3
 mainNavExclude: true
+use_cases: >-
+  scoped styling, avoiding css conflicts, component-specific styles, modular
+  css, style encapsulation
+tags:
+  - css
+  - modules
+  - styling
+  - scoped
+  - components
+  - encapsulation
+version: '1.0'
 ---
 
 CSS Modules are CSS files where class names, animations, and media queries are scoped locally by default.

--- a/src/routes/guides/styling-components/less.mdx
+++ b/src/routes/guides/styling-components/less.mdx
@@ -2,6 +2,17 @@
 title: LESS
 order: 2
 mainNavExclude: true
+use_cases: >-
+  advanced css features, css preprocessing, variables in styles, mixins,
+  programmatic styling
+tags:
+  - css
+  - preprocessing
+  - less
+  - variables
+  - mixins
+  - styling
+version: '1.0'
 ---
 
 [LESS](https://lesscss.org/) is a preprocessor based on JavaScript.

--- a/src/routes/guides/styling-components/macaron.mdx
+++ b/src/routes/guides/styling-components/macaron.mdx
@@ -2,6 +2,17 @@
 title: Macaron
 order: 4
 mainNavExclude: true
+use_cases: >-
+  type-safe styling, compile-time css, css-in-js, styled components, variant
+  styling, design systems
+tags:
+  - css-in-js
+  - styling
+  - typescript
+  - variants
+  - compile-time
+  - styled
+version: '1.0'
 ---
 
 [Macaron](https://macaron.js.org/) is compile-time CSS-in-JS library that offers type safety.

--- a/src/routes/guides/styling-components/sass.mdx
+++ b/src/routes/guides/styling-components/sass.mdx
@@ -2,6 +2,17 @@
 title: SASS
 order: 1
 mainNavExclude: true
+use_cases: >-
+  advanced css features, css preprocessing, nested styles, scss syntax, sass
+  syntax, modular styling
+tags:
+  - css
+  - preprocessing
+  - sass
+  - scss
+  - nested
+  - styling
+version: '1.0'
 ---
 
 [SASS](https://sass-lang.com/) is a popular CSS preprocessor that makes authoring CSS easier.

--- a/src/routes/guides/styling-components/tailwind-v3.mdx
+++ b/src/routes/guides/styling-components/tailwind-v3.mdx
@@ -2,6 +2,17 @@
 title: Tailwind CSS v3
 order: 7
 mainNavExclude: true
+use_cases: >-
+  utility-first styling, rapid ui development, responsive design, design
+  systems, utility classes
+tags:
+  - css
+  - utility
+  - tailwind
+  - responsive
+  - design
+  - classes
+version: '1.0'
 ---
 
 [Tailwind CSS v3](https://v3.tailwindcss.com/) is an on-demand utility CSS library that integrates seamlessly with Solid as a built-in PostCSS plugin.

--- a/src/routes/guides/styling-components/tailwind.mdx
+++ b/src/routes/guides/styling-components/tailwind.mdx
@@ -2,6 +2,15 @@
 title: Tailwind CSS
 order: 5
 mainNavExclude: true
+use_cases: 'styling projects, utility-first css, responsive design, component styling'
+tags:
+  - tailwind
+  - css
+  - styling
+  - utilities
+  - postcss
+  - design
+version: '1.0'
 ---
 
 :::note

--- a/src/routes/guides/styling-components/uno.mdx
+++ b/src/routes/guides/styling-components/uno.mdx
@@ -2,6 +2,15 @@
 title: UnoCSS
 order: 6
 mainNavExclude: true
+use_cases: 'styling projects, utility-first css, atomic css, on-demand css generation'
+tags:
+  - unocss
+  - css
+  - styling
+  - utilities
+  - atomic
+  - vite
+version: '1.0'
 ---
 
 [UnoCSS](https://unocss.dev/) is an on-demand utility CSS library that integrates seamlessly with Solid as a Vite plugin.

--- a/src/routes/guides/styling-your-components.mdx
+++ b/src/routes/guides/styling-your-components.mdx
@@ -1,6 +1,17 @@
 ---
 title: Styling your components
 order: 1
+use_cases: >-
+  component styling, css architecture, styling approach selection, design
+  systems
+tags:
+  - styling
+  - css
+  - design
+  - components
+  - preprocessors
+  - css-in-js
+version: '1.0'
 ---
 
 Solid provides flexible and versatile ways to style your components.

--- a/src/routes/guides/testing.mdx
+++ b/src/routes/guides/testing.mdx
@@ -1,6 +1,17 @@
 ---
 title: Testing
 order: 6
+use_cases: >-
+  testing components, test-driven development, quality assurance, regression
+  prevention, component validation
+tags:
+  - testing
+  - vitest
+  - components
+  - quality
+  - tdd
+  - validation
+version: '1.0'
 ---
 
 Testing your Solid applications is important to inspiring confidence in your codebase through preventing regressions.

--- a/src/routes/index.mdx
+++ b/src/routes/index.mdx
@@ -1,6 +1,16 @@
 ---
 title: Overview
 mainNavExclude: true
+use_cases: >-
+  learning solid fundamentals, getting started, understanding reactivity,
+  framework introduction
+tags:
+  - introduction
+  - fundamentals
+  - reactivity
+  - overview
+  - getting-started
+version: '1.0'
 ---
 
 # Overview

--- a/src/routes/pt-br/index.mdx
+++ b/src/routes/pt-br/index.mdx
@@ -1,6 +1,16 @@
 ---
 title: Sumário
 mainNavExclude: true
+use_cases: >-
+  learning solid fundamentals, getting started, understanding reactivity,
+  framework introduction
+tags:
+  - introduction
+  - fundamentals
+  - reactivity
+  - overview
+  - getting-started
+version: '1.0'
 ---
 
 # Sumário

--- a/src/routes/pt-br/quick-start.mdx
+++ b/src/routes/pt-br/quick-start.mdx
@@ -1,5 +1,13 @@
 ---
 title: Começo rápido
+use_cases: 'starting new projects, project setup, development environment, prototyping'
+tags:
+  - quickstart
+  - setup
+  - templates
+  - playground
+  - new-project
+version: '1.0'
 ---
 
 ## Solid playgrounds

--- a/src/routes/pt-br/solid-router/index.mdx
+++ b/src/routes/pt-br/solid-router/index.mdx
@@ -1,6 +1,16 @@
 ---
 title: Sumário
 mainNavExclude: true
+use_cases: >-
+  learning solid fundamentals, getting started, understanding reactivity,
+  framework introduction
+tags:
+  - introduction
+  - fundamentals
+  - reactivity
+  - overview
+  - getting-started
+version: '1.0'
 ---
 
 # Roteador

--- a/src/routes/pt-br/solid-router/quick-start.mdx
+++ b/src/routes/pt-br/solid-router/quick-start.mdx
@@ -1,5 +1,13 @@
 ---
 title: Começo rápido
+use_cases: 'starting new projects, project setup, development environment, prototyping'
+tags:
+  - quickstart
+  - setup
+  - templates
+  - playground
+  - new-project
+version: '1.0'
 ---
 
 ## Solid playgrounds

--- a/src/routes/quick-start.mdx
+++ b/src/routes/quick-start.mdx
@@ -1,5 +1,13 @@
 ---
 title: Quick start
+use_cases: 'starting new projects, project setup, development environment, prototyping'
+tags:
+  - quickstart
+  - setup
+  - templates
+  - playground
+  - new-project
+version: '1.0'
 ---
 
 ## Try Solid online

--- a/src/routes/reference/basic-reactivity/create-effect.mdx
+++ b/src/routes/reference/basic-reactivity/create-effect.mdx
@@ -1,5 +1,16 @@
 ---
 title: createEffect
+use_cases: >-
+  side effects, dom manipulation, event listeners, cleanup, library integration,
+  custom reactive behavior
+tags:
+  - reactivity
+  - side-effects
+  - dom
+  - lifecycle
+  - cleanup
+  - tracking
+version: '1.0'
 ---
 
 ```tsx

--- a/src/routes/reference/basic-reactivity/create-memo.mdx
+++ b/src/routes/reference/basic-reactivity/create-memo.mdx
@@ -1,5 +1,16 @@
 ---
 title: createMemo
+use_cases: >-
+  expensive computations, derived values, performance optimization, preventing
+  duplicate calculations
+tags:
+  - reactivity
+  - performance
+  - memoization
+  - computed
+  - optimization
+  - caching
+version: '1.0'
 ---
 
 Memos let you efficiently use a derived value in many reactive computations. 

--- a/src/routes/reference/basic-reactivity/create-resource.mdx
+++ b/src/routes/reference/basic-reactivity/create-resource.mdx
@@ -1,5 +1,17 @@
 ---
 title: createResource
+use_cases: >-
+  data fetching, api calls, async operations, loading states, error handling,
+  server state management
+tags:
+  - async
+  - data-fetching
+  - api
+  - loading
+  - error-handling
+  - ssr
+  - suspense
+version: '1.0'
 ---
 
 `createResource` takes an asynchronous fetcher function and returns a signal that is updated with the resulting data when the fetcher completes.

--- a/src/routes/reference/basic-reactivity/create-signal.mdx
+++ b/src/routes/reference/basic-reactivity/create-signal.mdx
@@ -1,5 +1,17 @@
 ---
 title: createSignal
+use_cases: >-
+  always, reactive state, component state, global state, any reactive value
+  tracking
+tags:
+  - reactivity
+  - state
+  - signals
+  - core
+  - tracking
+  - getters
+  - setters
+version: '1.0'
 ---
 
 Signals are the most basic reactive primitive.

--- a/src/routes/reference/component-apis/children.mdx
+++ b/src/routes/reference/component-apis/children.mdx
@@ -1,5 +1,16 @@
 ---
 title: children
+use_cases: >-
+  custom component wrappers, manipulating children, reusing children,
+  conditional children rendering
+tags:
+  - components
+  - children
+  - jsx
+  - dom
+  - wrapper
+  - conditional
+version: '1.0'
 ---
 
 ```tsx

--- a/src/routes/reference/component-apis/create-context.mdx
+++ b/src/routes/reference/component-apis/create-context.mdx
@@ -1,6 +1,16 @@
 ---
 title: createContext
 order: 5
+use_cases: >-
+  avoid prop drilling, global state, theme providers, user context, deep
+  component communication
+tags:
+  - context
+  - dependency-injection
+  - prop-drilling
+  - provider
+  - global-state
+version: '1.0'
 ---
 
 

--- a/src/routes/reference/component-apis/create-unique-id.mdx
+++ b/src/routes/reference/component-apis/create-unique-id.mdx
@@ -1,5 +1,16 @@
 ---
 title: createUniqueId
+use_cases: >-
+  accessibility, form labels, unique identifiers, ssr compatibility, aria
+  attributes
+tags:
+  - accessibility
+  - forms
+  - ssr
+  - identifiers
+  - aria
+  - labels
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/component-apis/lazy.mdx
+++ b/src/routes/reference/component-apis/lazy.mdx
@@ -1,5 +1,16 @@
 ---
 title: lazy
+use_cases: >-
+  code splitting, performance optimization, bundle size reduction, dynamic
+  imports, route splitting
+tags:
+  - performance
+  - code-splitting
+  - lazy-loading
+  - dynamic-imports
+  - suspense
+  - optimization
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/component-apis/use-context.mdx
+++ b/src/routes/reference/component-apis/use-context.mdx
@@ -1,5 +1,15 @@
 ---
 title: useContext
+use_cases: >-
+  consuming context, accessing provider data, avoiding prop drilling, shared
+  state access
+tags:
+  - context
+  - provider
+  - prop-drilling
+  - shared-state
+  - dependency-injection
+version: '1.0'
 ---
 
 Used to grab context within a context provider scope to allow for deep passing of props without having to pass them through each Component function.

--- a/src/routes/reference/components/dynamic.mdx
+++ b/src/routes/reference/components/dynamic.mdx
@@ -1,6 +1,17 @@
 ---
 title: <Dynamic>
 order: 5
+use_cases: >-
+  dynamic component rendering, runtime component selection, polymorphic
+  components, flexible layouts
+tags:
+  - components
+  - dynamic
+  - polymorphic
+  - runtime
+  - flexible
+  - conditional
+version: '1.0'
 ---
 
 This component lets you insert an arbitrary Component or tag and passes the props through to it.

--- a/src/routes/reference/components/error-boundary.mdx
+++ b/src/routes/reference/components/error-boundary.mdx
@@ -1,6 +1,16 @@
 ---
 title: <ErrorBoundary>
 order: 5
+use_cases: >-
+  error handling, production apps, graceful error recovery, debugging,
+  preventing crashes, user experience
+tags:
+  - error-handling
+  - production
+  - debugging
+  - user-experience
+  - recovery
+version: '1.0'
 ---
 
 The `<ErrorBoundary>` component catches errors that occur during the rendering or updating of its children and shows a fallback UI instead.

--- a/src/routes/reference/components/for.mdx
+++ b/src/routes/reference/components/for.mdx
@@ -1,6 +1,17 @@
 ---
 title: <For>
 order: 5
+use_cases: >-
+  rendering lists, dynamic content, arrays, iterating data, keyed updates,
+  performance optimization
+tags:
+  - lists
+  - arrays
+  - iteration
+  - dynamic-content
+  - performance
+  - keyed-updates
+version: '1.0'
 ---
 
 The `<For>` component is used to render a list of items. It is similar to the `.map()` function in JavaScript.

--- a/src/routes/reference/components/index-component.mdx
+++ b/src/routes/reference/components/index-component.mdx
@@ -1,5 +1,16 @@
 ---
 title: <Index>
+use_cases: >-
+  primitive arrays, non-keyed lists, index-based rendering, simple data,
+  position-based updates
+tags:
+  - lists
+  - arrays
+  - primitives
+  - index-based
+  - non-keyed
+  - simple-data
+version: '1.0'
 ---
 
 Non-keyed list iteration (rendered nodes are keyed to an array index). This is useful when there is no conceptual key, like if the data consists of primitives and it is the index that is fixed rather than the value.

--- a/src/routes/reference/components/no-hydration.mdx
+++ b/src/routes/reference/components/no-hydration.mdx
@@ -1,5 +1,15 @@
 ---
 title: <NoHydration>
+use_cases: >-
+  ssr optimization, static content, performance, hydration control, server
+  rendering
+tags:
+  - ssr
+  - hydration
+  - performance
+  - static-content
+  - optimization
+version: '1.0'
 ---
 
 The `<NoHydration>` component prevents the client-side hydration process from being applied to its children.

--- a/src/routes/reference/components/portal.mdx
+++ b/src/routes/reference/components/portal.mdx
@@ -1,5 +1,14 @@
 ---
 title: <Portal>
+use_cases: 'modals, tooltips, dropdowns, overlays, z-index issues, dom hierarchy bypass'
+tags:
+  - modals
+  - tooltips
+  - overlays
+  - z-index
+  - dom-hierarchy
+  - ui-components
+version: '1.0'
 ---
 
 `<Portal>` is a component that allows you to render children into a DOM node that exists outside the DOM hierarchy of the parent component.

--- a/src/routes/reference/components/show.mdx
+++ b/src/routes/reference/components/show.mdx
@@ -1,6 +1,16 @@
 ---
 title: <Show>
 order: 5
+use_cases: >-
+  conditional rendering, toggle visibility, boolean states, show hide logic,
+  conditional ui
+tags:
+  - conditional-rendering
+  - visibility
+  - boolean-logic
+  - ui-state
+  - toggle
+version: '1.0'
 ---
 
 The `<Show>` component is used for conditionally rendering UI elements.

--- a/src/routes/reference/components/suspense-list.mdx
+++ b/src/routes/reference/components/suspense-list.mdx
@@ -1,6 +1,16 @@
 ---
 title: <SuspenseList>
 order: 5
+use_cases: >-
+  coordinating multiple async operations, loading sequences, layout stability,
+  multiple suspense boundaries
+tags:
+  - async-coordination
+  - loading-sequences
+  - layout-stability
+  - experimental
+  - multiple-suspense
+version: '1.0'
 ---
 
 SuspenseList allows for coordinating multiple parallel Suspense and SuspenseList components. It controls the order in which content is revealed to reduce layout thrashing and has an option to collapse or hide fallback states.

--- a/src/routes/reference/components/suspense.mdx
+++ b/src/routes/reference/components/suspense.mdx
@@ -1,6 +1,16 @@
 ---
 title: <Suspense>
 order: 5
+use_cases: >-
+  async data loading, loading states, resource fetching, user experience, data
+  dependencies
+tags:
+  - async-loading
+  - loading-states
+  - data-fetching
+  - resources
+  - user-experience
+version: '1.0'
 ---
 
 A component that tracks all resources read under it and shows a fallback placeholder state until they are resolved. What makes `Suspense` different than `Show` is that it is non-blocking in the sense that both branches exist at the same time even if not currently in the DOM. This means that the fallback can be rendered while the children are loading. This is useful for loading states and other asynchronous operations.

--- a/src/routes/reference/components/switch-and-match.mdx
+++ b/src/routes/reference/components/switch-and-match.mdx
@@ -1,6 +1,16 @@
 ---
 title: <Switch> / <Match>
 order: 5
+use_cases: >-
+  multiple conditions, routing, complex conditional logic, state machines,
+  exclusive choices
+tags:
+  - multiple-conditions
+  - routing
+  - conditional-logic
+  - state-machines
+  - exclusive-choices
+version: '1.0'
 ---
 
 Useful for when there are more than 2 mutual exclusive conditions. It is a more flexible version of the if-else-if-else-if-else-... chain.

--- a/src/routes/reference/jsx-attributes/attr.mdx
+++ b/src/routes/reference/jsx-attributes/attr.mdx
@@ -1,5 +1,15 @@
 ---
-title: attr:*
+title: 'attr:*'
+use_cases: >-
+  web components, custom elements, attribute setting, typescript integration,
+  dom attributes
+tags:
+  - web-components
+  - custom-elements
+  - attributes
+  - typescript
+  - dom-manipulation
+version: '1.0'
 ---
 
 Forces the prop to be treated as an attribute instead of a property.

--- a/src/routes/reference/jsx-attributes/bool.mdx
+++ b/src/routes/reference/jsx-attributes/bool.mdx
@@ -1,5 +1,14 @@
 ---
-title: bool:*
+title: 'bool:*'
+use_cases: >-
+  web components, custom elements, boolean attributes, conditional element
+  attributes
+tags:
+  - web-components
+  - custom-elements
+  - boolean-attributes
+  - conditional-rendering
+version: '1.0'
 ---
 
 `bool:*` controls the presence of an attribute in an element.

--- a/src/routes/reference/jsx-attributes/classlist.mdx
+++ b/src/routes/reference/jsx-attributes/classlist.mdx
@@ -1,6 +1,14 @@
 ---
 title: classList
 order: 1
+use_cases: 'styling, conditional classes, dynamic css, ui state changes, theme switching'
+tags:
+  - styling
+  - css-classes
+  - conditional-styling
+  - dynamic-classes
+  - ui-state
+version: '1.0'
 ---
 
 Solid offers two attributes to set the class of an element: `class` and `classList`.

--- a/src/routes/reference/jsx-attributes/innerhtml.mdx
+++ b/src/routes/reference/jsx-attributes/innerhtml.mdx
@@ -1,5 +1,15 @@
 ---
 title: innerHTML
+use_cases: >-
+  raw html rendering, html strings, rich content, wysiwyg editors, markdown
+  output
+tags:
+  - html-rendering
+  - raw-html
+  - content-injection
+  - security
+  - rich-content
+version: '1.0'
 ---
 
 The `innerHTML` attribute is equivalent to the [`innerHTML` DOM property](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML).

--- a/src/routes/reference/jsx-attributes/on.mdx
+++ b/src/routes/reference/jsx-attributes/on.mdx
@@ -1,6 +1,17 @@
 ---
-title: on:*
+title: 'on:*'
 order: 4
+use_cases: >-
+  custom events, event options, capture events, passive events, non-standard
+  events
+tags:
+  - event-handling
+  - custom-events
+  - event-options
+  - capture
+  - passive
+  - dom-events
+version: '1.0'
 ---
 
 For events with capital letters, listener options, or if you need to attach event handlers directly to a DOM element instead of optimized delegating via the document, use `on:*` in place of `on*`.

--- a/src/routes/reference/jsx-attributes/on_.mdx
+++ b/src/routes/reference/jsx-attributes/on_.mdx
@@ -1,6 +1,15 @@
 ---
 title: on*
 order: 3
+use_cases: 'event handling, user interactions, clicks, form inputs, ui responses, always'
+tags:
+  - event-handling
+  - user-interaction
+  - clicks
+  - forms
+  - delegation
+  - performance
+version: '1.0'
 ---
 
 Event handlers in Solid typically take the form of `onclick` or `onClick` depending on style.

--- a/src/routes/reference/jsx-attributes/once.mdx
+++ b/src/routes/reference/jsx-attributes/once.mdx
@@ -1,6 +1,16 @@
 ---
-title: "@once"
+title: '@once'
 order: 5
+use_cases: >-
+  performance optimization, static values, reducing reactivity overhead, large
+  lists
+tags:
+  - performance
+  - optimization
+  - static-values
+  - compiler-hints
+  - reactivity
+version: '1.0'
 ---
 
 Solid's compiler uses a heuristic for reactive wrapping and lazy evaluation of JSX expressions. Does it contain a function call, a property access, or JSX? If yes we wrap it in a getter when passed to components or in an effect if passed to native elements.

--- a/src/routes/reference/jsx-attributes/prop.mdx
+++ b/src/routes/reference/jsx-attributes/prop.mdx
@@ -1,6 +1,15 @@
 ---
-title: prop:*
+title: 'prop:*'
 order: 6
+use_cases: >-
+  dom properties, custom properties, element configuration, non-attribute
+  properties
+tags:
+  - dom-properties
+  - custom-properties
+  - element-configuration
+  - typescript
+version: '1.0'
 ---
 
 Forces the prop to be treated as a property instead of an attribute.

--- a/src/routes/reference/jsx-attributes/ref.mdx
+++ b/src/routes/reference/jsx-attributes/ref.mdx
@@ -1,6 +1,17 @@
 ---
 title: ref
 order: 7
+use_cases: >-
+  dom access, element references, imperative apis, focus management,
+  measurements
+tags:
+  - dom-access
+  - element-refs
+  - imperative
+  - focus
+  - measurements
+  - lifecycle
+version: '1.0'
 ---
 
 Refs are a way of getting access to underlying DOM elements in our JSX. While it is true one could just assign an element to a variable, it is more optimal to leave components in the flow of JSX. Refs are assigned at render time but before the elements are connected to the DOM. They come in 2 flavors.

--- a/src/routes/reference/jsx-attributes/style.mdx
+++ b/src/routes/reference/jsx-attributes/style.mdx
@@ -1,6 +1,14 @@
 ---
 title: style
 order: 7
+use_cases: 'styling, dynamic styles, css variables, inline styles, conditional styling'
+tags:
+  - styling
+  - css
+  - dynamic-styles
+  - css-variables
+  - inline-styles
+version: '1.0'
 ---
 
 Solid's style attribute lets you provide either a CSS string or an object where keys are CSS property names:

--- a/src/routes/reference/jsx-attributes/textcontent.mdx
+++ b/src/routes/reference/jsx-attributes/textcontent.mdx
@@ -1,5 +1,14 @@
 ---
 title: textContent
+use_cases: >-
+  text rendering, performance optimization, plain text content, text-only
+  elements
+tags:
+  - text-rendering
+  - performance
+  - text-content
+  - dom-properties
+version: '1.0'
 ---
 
 The `textContent` attribute is equivalent to the [`textContent` DOM property](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent).

--- a/src/routes/reference/jsx-attributes/use.mdx
+++ b/src/routes/reference/jsx-attributes/use.mdx
@@ -1,6 +1,17 @@
 ---
-title: use:*
+title: 'use:*'
 order: 5
+use_cases: >-
+  complex dom interactions, reusable behaviors, tooltips, scrolling, form
+  handling, two-way data binding, custom element behavior
+tags:
+  - directives
+  - dom-manipulation
+  - reusable-behavior
+  - form-handling
+  - two-way-binding
+  - typescript-support
+version: '1.0'
 ---
 
 Custom directives attach reusable behavior to DOM elements, acting as syntactic sugar over `ref`. They’re ideal for complex DOM interactions like scrolling, tooltips, or form handling, which are cumbersome to repeat in JSX.

--- a/src/routes/reference/lifecycle/on-cleanup.mdx
+++ b/src/routes/reference/lifecycle/on-cleanup.mdx
@@ -1,6 +1,17 @@
 ---
 title: onCleanup
 order: 5
+use_cases: >-
+  component unmounting, memory leak prevention, event listener cleanup, resource
+  disposal, side effect cleanup, tracking scope disposal
+tags:
+  - cleanup
+  - memory-management
+  - lifecycle
+  - event-listeners
+  - resource-disposal
+  - side-effects
+version: '1.0'
 ---
 
 `onCleanup` registers a cleanup method that executes on disposal and recalculation of the current tracking scope.

--- a/src/routes/reference/lifecycle/on-mount.mdx
+++ b/src/routes/reference/lifecycle/on-mount.mdx
@@ -1,6 +1,17 @@
 ---
 title: onMount
 order: 5
+use_cases: >-
+  component initialization, dom element refs, one-time setup, initial dom
+  manipulation, after render tasks
+tags:
+  - lifecycle
+  - mounting
+  - initialization
+  - refs
+  - dom-access
+  - setup
+version: '1.0'
 ---
 
 Registers a method that runs after initial rendering is done and the elements are mounted to the page.

--- a/src/routes/reference/reactive-utilities/batch.mdx
+++ b/src/routes/reference/reactive-utilities/batch.mdx
@@ -1,5 +1,16 @@
 ---
 title: batch
+use_cases: >-
+  performance optimization, avoiding unnecessary recalculations, batching
+  multiple signal updates, expensive dom updates, bulk data changes
+tags:
+  - performance
+  - batching
+  - optimization
+  - signal-updates
+  - dom-updates
+  - bulk-operations
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/reactive-utilities/catch-error.mdx
+++ b/src/routes/reference/reactive-utilities/catch-error.mdx
@@ -1,5 +1,14 @@
 ---
 title: catchError
+use_cases: >-
+  error handling, error boundaries, graceful error recovery, catching
+  computation errors, error propagation control
+tags:
+  - error-handling
+  - error-boundaries
+  - error-recovery
+  - exception-handling
+version: '1.0'
 ---
 
 :::note

--- a/src/routes/reference/reactive-utilities/create-root.mdx
+++ b/src/routes/reference/reactive-utilities/create-root.mdx
@@ -1,5 +1,15 @@
 ---
 title: createRoot
+use_cases: >-
+  top-level app initialization, memory management, non-tracked scopes, manual
+  disposal control, nested tracking scopes
+tags:
+  - root-scope
+  - memory-management
+  - initialization
+  - disposal
+  - tracking-scope
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/reactive-utilities/from.mdx
+++ b/src/routes/reference/reactive-utilities/from.mdx
@@ -1,5 +1,16 @@
 ---
 title: from
+use_cases: >-
+  rxjs integration, external observables, svelte stores interop, third-party
+  reactive libraries, custom producers, subscription management
+tags:
+  - interop
+  - observables
+  - rxjs
+  - subscriptions
+  - external-libraries
+  - reactive-integration
+version: '1.0'
 ---
 
 ```tsx

--- a/src/routes/reference/reactive-utilities/get-owner.mdx
+++ b/src/routes/reference/reactive-utilities/get-owner.mdx
@@ -1,5 +1,15 @@
 ---
 title: getOwner
+use_cases: >-
+  ownership tracking, cleanup management, advanced reactive patterns, passing
+  context outside scope, manual disposal control
+tags:
+  - ownership
+  - tracking-scope
+  - cleanup
+  - advanced-patterns
+  - context-passing
+version: '1.0'
 ---
 
 ```tsx

--- a/src/routes/reference/reactive-utilities/index-array.mdx
+++ b/src/routes/reference/reactive-utilities/index-array.mdx
@@ -1,5 +1,16 @@
 ---
 title: indexArray
+use_cases: >-
+  list rendering by index, dynamic lists, index-based mapping, performance
+  optimization for arrays, control flow optimization
+tags:
+  - arrays
+  - list-rendering
+  - index-mapping
+  - control-flow
+  - performance
+  - mapping
+version: '1.0'
 ---
 
 ```tsx

--- a/src/routes/reference/reactive-utilities/map-array.mdx
+++ b/src/routes/reference/reactive-utilities/map-array.mdx
@@ -1,5 +1,16 @@
 ---
 title: mapArray
+use_cases: >-
+  list rendering by reference, dynamic lists, performance optimization for
+  arrays, reference-based mapping, control flow optimization
+tags:
+  - arrays
+  - list-rendering
+  - reference-mapping
+  - control-flow
+  - performance
+  - mapping
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/reactive-utilities/merge-props.mdx
+++ b/src/routes/reference/reactive-utilities/merge-props.mdx
@@ -1,5 +1,13 @@
 ---
 title: mergeProps
+use_cases: 'component libraries, default props, prop merging, reusable components'
+tags:
+  - props
+  - components
+  - defaults
+  - reactive
+  - merging
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/reactive-utilities/observable.mdx
+++ b/src/routes/reference/reactive-utilities/observable.mdx
@@ -1,5 +1,13 @@
 ---
 title: observable
+use_cases: 'rxjs integration, third-party observables, reactive streams, library interop'
+tags:
+  - rxjs
+  - observables
+  - integration
+  - streams
+  - interop
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/reactive-utilities/on-util.mdx
+++ b/src/routes/reference/reactive-utilities/on-util.mdx
@@ -1,5 +1,15 @@
 ---
-title: on
+title: 'on'
+use_cases: >-
+  explicit dependencies, performance optimization, conditional tracking,
+  fine-grained reactivity
+tags:
+  - effects
+  - dependencies
+  - performance
+  - tracking
+  - optimization
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/reactive-utilities/run-with-owner.mdx
+++ b/src/routes/reference/reactive-utilities/run-with-owner.mdx
@@ -1,6 +1,14 @@
 ---
 title: runWithOwner
 order: 5
+use_cases: 'async operations, timeouts, callbacks, context access, memory management'
+tags:
+  - async
+  - ownership
+  - context
+  - cleanup
+  - memory
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/reactive-utilities/split-props.mdx
+++ b/src/routes/reference/reactive-utilities/split-props.mdx
@@ -1,5 +1,13 @@
 ---
 title: splitProps
+use_cases: 'component composition, prop forwarding, component libraries, prop organization'
+tags:
+  - props
+  - composition
+  - forwarding
+  - organization
+  - components
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/reactive-utilities/start-transition.mdx
+++ b/src/routes/reference/reactive-utilities/start-transition.mdx
@@ -1,5 +1,13 @@
 ---
 title: startTransition
+use_cases: 'async updates, performance optimization, ui transitions, batching'
+tags:
+  - transitions
+  - async
+  - performance
+  - batching
+  - ui
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/reactive-utilities/untrack.mdx
+++ b/src/routes/reference/reactive-utilities/untrack.mdx
@@ -1,5 +1,13 @@
 ---
 title: untrack
+use_cases: 'performance optimization, breaking reactivity, static values, initial values'
+tags:
+  - performance
+  - tracking
+  - optimization
+  - static
+  - reactivity
+version: '1.0'
 ---
 
 Ignores tracking any of the dependencies in the executing code block and returns the value. This helper is useful when a certain `prop` will never update and thus it is ok to use it outside of the tracking scope.

--- a/src/routes/reference/reactive-utilities/use-transition.mdx
+++ b/src/routes/reference/reactive-utilities/use-transition.mdx
@@ -1,5 +1,13 @@
 ---
 title: useTransition
+use_cases: 'suspense boundaries, async operations, loading states, resource management'
+tags:
+  - suspense
+  - async
+  - loading
+  - transitions
+  - resources
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/rendering/dev.mdx
+++ b/src/routes/reference/rendering/dev.mdx
@@ -1,5 +1,15 @@
 ---
 title: DEV
+use_cases: >-
+  development debugging, conditional code, library development, development
+  checks
+tags:
+  - development
+  - debugging
+  - conditional
+  - libraries
+  - dev-mode
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/rendering/hydrate.mdx
+++ b/src/routes/reference/rendering/hydrate.mdx
@@ -1,5 +1,15 @@
 ---
 title: hydrate
+use_cases: >-
+  ssr applications, client-side hydration, server rendering, browser
+  initialization
+tags:
+  - ssr
+  - hydration
+  - client
+  - rendering
+  - browser
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/rendering/hydration-script.mdx
+++ b/src/routes/reference/rendering/hydration-script.mdx
@@ -1,5 +1,16 @@
 ---
 title: hydrationScript
+use_cases: >-
+  server-side rendering, hydration setup, initial page bootstrap, event replay
+  during hydration
+tags:
+  - ssr
+  - hydration
+  - bootstrap
+  - events
+  - server
+  - client
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/rendering/is-server.mdx
+++ b/src/routes/reference/rendering/is-server.mdx
@@ -1,5 +1,15 @@
 ---
 title: isServer
+use_cases: >-
+  conditional rendering, environment detection, bundle optimization, tree
+  shaking, server vs client logic
+tags:
+  - environment
+  - conditional
+  - bundling
+  - tree-shaking
+  - optimization
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/rendering/render-to-stream.mdx
+++ b/src/routes/reference/rendering/render-to-stream.mdx
@@ -1,5 +1,16 @@
 ---
 title: renderToStream
+use_cases: >-
+  streaming ssr, progressive rendering, suspense boundaries, performance
+  optimization, large applications
+tags:
+  - streaming
+  - ssr
+  - suspense
+  - performance
+  - async
+  - server
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/rendering/render-to-string-async.mdx
+++ b/src/routes/reference/rendering/render-to-string-async.mdx
@@ -1,5 +1,16 @@
 ---
 title: renderToStringAsync
+use_cases: >-
+  ssr with async data, suspense resolution, data serialization, complete html
+  generation
+tags:
+  - ssr
+  - async
+  - suspense
+  - serialization
+  - server
+  - data-fetching
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/rendering/render-to-string.mdx
+++ b/src/routes/reference/rendering/render-to-string.mdx
@@ -1,5 +1,15 @@
 ---
 title: renderToString
+use_cases: >-
+  synchronous ssr, static site generation, simple server rendering, progressive
+  hydration setup
+tags:
+  - ssr
+  - static
+  - synchronous
+  - hydration
+  - server
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/rendering/render.mdx
+++ b/src/routes/reference/rendering/render.mdx
@@ -1,5 +1,15 @@
 ---
 title: render
+use_cases: >-
+  client-side rendering, spa setup, browser entry point, component mounting,
+  always
+tags:
+  - client
+  - spa
+  - mounting
+  - browser
+  - entry-point
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/secondary-primitives/create-computed.mdx
+++ b/src/routes/reference/secondary-primitives/create-computed.mdx
@@ -1,5 +1,15 @@
 ---
 title: createComputed
+use_cases: >-
+  immediate reactivity, building primitives, side effects with dependencies,
+  advanced reactive patterns
+tags:
+  - reactivity
+  - primitives
+  - side-effects
+  - tracking
+  - advanced
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/secondary-primitives/create-deferred.mdx
+++ b/src/routes/reference/secondary-primitives/create-deferred.mdx
@@ -1,5 +1,15 @@
 ---
 title: createDeferred
+use_cases: >-
+  performance optimization, debounced updates, idle time processing, expensive
+  computations
+tags:
+  - performance
+  - debounce
+  - idle
+  - optimization
+  - expensive-operations
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/secondary-primitives/create-reaction.mdx
+++ b/src/routes/reference/secondary-primitives/create-reaction.mdx
@@ -1,5 +1,15 @@
 ---
 title: createReaction
+use_cases: >-
+  separating tracking from execution, one-time reactions, custom reactive
+  patterns, advanced control
+tags:
+  - tracking
+  - one-time
+  - custom-patterns
+  - advanced
+  - separation
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/secondary-primitives/create-render-effect.mdx
+++ b/src/routes/reference/secondary-primitives/create-render-effect.mdx
@@ -1,5 +1,15 @@
 ---
 title: createRenderEffect
+use_cases: >-
+  dom manipulation during rendering, immediate effects, ref setup, rendering
+  phase side effects
+tags:
+  - dom
+  - rendering
+  - immediate
+  - refs
+  - side-effects
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/secondary-primitives/create-selector.mdx
+++ b/src/routes/reference/secondary-primitives/create-selector.mdx
@@ -1,5 +1,16 @@
 ---
 title: createSelector
+use_cases: >-
+  optimizing lists with selection state, active items in menus, tabs, toggles,
+  performance optimization for large lists
+tags:
+  - selection
+  - optimization
+  - lists
+  - performance
+  - ui-state
+  - derived-signals
+version: '1.0'
 ---
 
 ```ts

--- a/src/routes/reference/server-utilities/get-request-event.mdx
+++ b/src/routes/reference/server-utilities/get-request-event.mdx
@@ -1,5 +1,17 @@
 ---
 title: getRequestEvent
+use_cases: >-
+  server-side rendering, accessing request headers, authentication, cookies,
+  response modification, server functions
+tags:
+  - server-side
+  - requests
+  - headers
+  - authentication
+  - ssr
+  - server-functions
+  - cookies
+version: '1.0'
 ---
 
 Solid uses Async Local Storage as a way of injecting the request context anywhere on the server.

--- a/src/routes/reference/store-utilities/create-mutable.mdx
+++ b/src/routes/reference/store-utilities/create-mutable.mdx
@@ -1,5 +1,16 @@
 ---
 title: createMutable
+use_cases: >-
+  integrating external systems, framework compatibility with mobx or vue, legacy
+  code migration, third-party libraries
+tags:
+  - external-integration
+  - compatibility
+  - migration
+  - mutable-state
+  - third-party
+  - legacy
+version: '1.0'
 ---
 
 `createMutable` creates a new mutable Store proxy object that provides a way to selectively trigger updates only when values change.

--- a/src/routes/reference/store-utilities/create-store.mdx
+++ b/src/routes/reference/store-utilities/create-store.mdx
@@ -1,5 +1,16 @@
 ---
 title: createStore
+use_cases: >-
+  complex state management, nested data structures, objects and arrays,
+  application state, user data management
+tags:
+  - state-management
+  - nested-data
+  - objects
+  - arrays
+  - application-state
+  - user-data
+version: '1.0'
 ---
 
 Stores were intentionally designed to manage data structures like objects and arrays but are capable of handling other data types, such as strings and numbers.

--- a/src/routes/reference/store-utilities/modify-mutable.mdx
+++ b/src/routes/reference/store-utilities/modify-mutable.mdx
@@ -1,5 +1,15 @@
 ---
 title: modifyMutable
+use_cases: >-
+  batching multiple mutable store changes, performance optimization for multiple
+  updates, reducing ui re-renders
+tags:
+  - batching
+  - performance
+  - multiple-updates
+  - mutable-stores
+  - optimization
+version: '1.0'
 ---
 
 `modifyMutable` streamlines the process of making multiple changes to a mutable Store, as obtained through the use of [`createMutable`](/reference/store-utilities/create-mutable).

--- a/src/routes/reference/store-utilities/produce.mdx
+++ b/src/routes/reference/store-utilities/produce.mdx
@@ -1,5 +1,14 @@
 ---
 title: produce
+use_cases: >-
+  immutable-style mutations, complex store updates, nested object modifications,
+  immer-like patterns
+tags:
+  - immutable-mutations
+  - nested-updates
+  - immer-pattern
+  - store-utilities
+version: '1.0'
 ---
 
 `produce` is an [Immer](https://immerjs.github.io/immer/) inspired API for Solid's Store objects that allows the store to be mutated inside the `produce` function.

--- a/src/routes/reference/store-utilities/reconcile.mdx
+++ b/src/routes/reference/store-utilities/reconcile.mdx
@@ -1,5 +1,15 @@
 ---
 title: reconcile
+use_cases: >-
+  handling api responses, immutable data updates, large data changes, external
+  data synchronization, diffing data
+tags:
+  - api-responses
+  - data-diffing
+  - immutable-data
+  - synchronization
+  - large-updates
+version: '1.0'
 ---
 
 `reconcile` is designed for diffing data changes in situations where granular updates cannot be applied. 

--- a/src/routes/reference/store-utilities/unwrap.mdx
+++ b/src/routes/reference/store-utilities/unwrap.mdx
@@ -1,5 +1,15 @@
 ---
 title: unwrap
+use_cases: >-
+  accessing raw store data, debugging, serialization, third-party library
+  integration, data inspection
+tags:
+  - debugging
+  - serialization
+  - raw-data
+  - inspection
+  - third-party
+version: '1.0'
 ---
 
 `unwrap` returns the underlying data in the store without a proxy.

--- a/src/routes/solid-meta/getting-started/client-setup.mdx
+++ b/src/routes/solid-meta/getting-started/client-setup.mdx
@@ -1,6 +1,16 @@
 ---
 title: Client setup
 order: 2
+use_cases: >-
+  client-side meta tags, spa head management, dynamic title and meta changes,
+  browser-only applications
+tags:
+  - meta-tags
+  - head-management
+  - client-side
+  - spa
+  - browser-apps
+version: '1.0'
 ---
 
 You can inject a tag into the `<head />` by rendering one of the head tag components when necessary.

--- a/src/routes/solid-meta/getting-started/installation-and-setup.mdx
+++ b/src/routes/solid-meta/getting-started/installation-and-setup.mdx
@@ -1,6 +1,17 @@
 ---
 title: Install and configure
 order: 1
+use_cases: >-
+  setting up meta tags, initial project configuration, seo requirements, head
+  tag management setup
+tags:
+  - setup
+  - installation
+  - configuration
+  - meta-tags
+  - seo
+  - head-management
+version: '1.0'
 ---
 
 :::note[Prerequisites]

--- a/src/routes/solid-meta/getting-started/server-setup.mdx
+++ b/src/routes/solid-meta/getting-started/server-setup.mdx
@@ -1,6 +1,14 @@
 ---
 title: Server setup
 order: 3
+use_cases: 'ssr applications, server rendering, head tag management, metaprovider setup'
+tags:
+  - ssr
+  - server-rendering
+  - meta-tags
+  - head-management
+  - setup
+version: '1.0'
 ---
 
 For server setup, wrap your application with [`MetaProvider`](/solid-meta/reference/meta/metaprovider) on the server.

--- a/src/routes/solid-meta/index.mdx
+++ b/src/routes/solid-meta/index.mdx
@@ -1,6 +1,16 @@
 ---
 title: Overview
 mainNavExclude: true
+use_cases: >-
+  document head management, meta tag organization, ssr-ready applications,
+  asynchronous rendering
+tags:
+  - meta-tags
+  - head-management
+  - ssr
+  - document-head
+  - overview
+version: '1.0'
 ---
 
 # Overview

--- a/src/routes/solid-meta/reference/meta/base.mdx
+++ b/src/routes/solid-meta/reference/meta/base.mdx
@@ -1,6 +1,13 @@
 ---
 title: Base
 order: 5
+use_cases: 'setting base url for relative links, document base element configuration'
+tags:
+  - base-url
+  - relative-urls
+  - meta-tags
+  - document-head
+version: '1.0'
 ---
 
 `Base` is a component that specifies the base URL for all relative URLs in the document.

--- a/src/routes/solid-meta/reference/meta/link.mdx
+++ b/src/routes/solid-meta/reference/meta/link.mdx
@@ -1,6 +1,16 @@
 ---
 title: Link
 order: 2
+use_cases: >-
+  adding favicons, linking stylesheets, external resource connections, emoji
+  favicons
+tags:
+  - favicon
+  - stylesheets
+  - external-resources
+  - meta-tags
+  - assets
+version: '1.0'
 ---
 
 The Link component establishes a connection between the page and an external resource.

--- a/src/routes/solid-meta/reference/meta/meta.mdx
+++ b/src/routes/solid-meta/reference/meta/meta.mdx
@@ -1,6 +1,17 @@
 ---
 title: Meta
 order: 3
+use_cases: >-
+  seo metadata, page descriptions, viewport settings, charset configuration,
+  meta tag management
+tags:
+  - seo
+  - metadata
+  - viewport
+  - charset
+  - meta-tags
+  - page-description
+version: '1.0'
 ---
 
 The `<Meta>` component represents metadata that cannot be represented by other HTML elements.

--- a/src/routes/solid-meta/reference/meta/metaprovider.mdx
+++ b/src/routes/solid-meta/reference/meta/metaprovider.mdx
@@ -1,6 +1,13 @@
 ---
 title: MetaProvider
 order: 6
+use_cases: 'always, any project using meta components, wrapping metadata components'
+tags:
+  - meta-provider
+  - wrapper-component
+  - meta-tags
+  - setup
+version: '1.0'
 ---
 
 `MetaProvider` is a parent component responsible for wrapping all the metadata components.

--- a/src/routes/solid-meta/reference/meta/style.mdx
+++ b/src/routes/solid-meta/reference/meta/style.mdx
@@ -1,6 +1,14 @@
 ---
 title: Style
 order: 4
+use_cases: 'inline css styles, global styling, dynamic styles in head'
+tags:
+  - inline-styles
+  - css
+  - styling
+  - meta-tags
+  - global-styles
+version: '1.0'
 ---
 
 `Style` is a component that adds the [`style`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style) element to your document's `head`.

--- a/src/routes/solid-meta/reference/meta/title.mdx
+++ b/src/routes/solid-meta/reference/meta/title.mdx
@@ -1,6 +1,14 @@
 ---
 title: Title
 order: 1
+use_cases: 'page titles, browser tab names, seo titles, document title management'
+tags:
+  - page-title
+  - browser-tab
+  - seo
+  - document-title
+  - meta-tags
+version: '1.0'
 ---
 
 `Title` is a component that renders the [`title`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title) element.

--- a/src/routes/solid-router/advanced-concepts/lazy-loading.mdx
+++ b/src/routes/solid-router/advanced-concepts/lazy-loading.mdx
@@ -1,5 +1,15 @@
 ---
 title: Lazy loading
+use_cases: >-
+  optimizing bundle size, code splitting, large applications, reducing initial
+  load time
+tags:
+  - lazy-loading
+  - code-splitting
+  - performance
+  - bundle-optimization
+  - routing
+version: '1.0'
 ---
 
 Lazy loading allows you to load only the necessary resources when they are needed.

--- a/src/routes/solid-router/concepts/actions.mdx
+++ b/src/routes/solid-router/concepts/actions.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Actions"
+title: Actions
+use_cases: >-
+  form submissions, data mutations, server communication, user interactions,
+  post requests
+tags:
+  - forms
+  - data-submission
+  - server-communication
+  - user-input
+  - mutations
+  - post-requests
+version: '1.0'
 ---
 
 When developing applications, it is common to need to communicate new information to the server based on user interactions.

--- a/src/routes/solid-router/concepts/alternative-routers.mdx
+++ b/src/routes/solid-router/concepts/alternative-routers.mdx
@@ -1,5 +1,16 @@
 ---
 title: Alternative routers
+use_cases: >-
+  client-only routing, testing environments, legacy browser support, offline
+  applications, special url requirements
+tags:
+  - hash-routing
+  - memory-routing
+  - testing
+  - client-side
+  - url-handling
+  - browser-compatibility
+version: '1.0'
 ---
 
 While the default router uses the browser's `location.pathname` to determine the current route, you can use alternative routers to change this behavior.

--- a/src/routes/solid-router/concepts/catch-all.mdx
+++ b/src/routes/solid-router/concepts/catch-all.mdx
@@ -1,5 +1,15 @@
 ---
 title: Catch-all routes
+use_cases: >-
+  404 pages, error handling, invalid urls, fallback routes, page not found
+  scenarios
+tags:
+  - 404-pages
+  - error-handling
+  - fallback-routes
+  - wildcard-routes
+  - url-matching
+version: '1.0'
 ---
 
 Catch-all routes are used to match any URL that does not match any other route in the application. 

--- a/src/routes/solid-router/concepts/dynamic-routes.mdx
+++ b/src/routes/solid-router/concepts/dynamic-routes.mdx
@@ -1,5 +1,16 @@
 ---
 title: Dynamic routes
+use_cases: >-
+  user profiles, product pages, blog posts, detail views, parameterized urls,
+  variable content
+tags:
+  - dynamic-routing
+  - url-parameters
+  - user-profiles
+  - detail-pages
+  - validation
+  - wildcards
+version: '1.0'
 ---
 
 When a path is unknown ahead of time, it can be treated as a flexible parameter that is passed on to the component:

--- a/src/routes/solid-router/concepts/layouts.mdx
+++ b/src/routes/solid-router/concepts/layouts.mdx
@@ -1,5 +1,17 @@
 ---
-title: "Layouts"
+title: Layouts
+use_cases: >-
+  consistent navigation, shared headers/footers, page structure, common ui
+  elements, app-wide components
+tags:
+  - layouts
+  - page-structure
+  - navigation
+  - headers
+  - footers
+  - ui-consistency
+  - nesting
+version: '1.0'
 ---
 
 To maintain consistency across an application's page you can use layouts. 

--- a/src/routes/solid-router/concepts/navigation.mdx
+++ b/src/routes/solid-router/concepts/navigation.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Navigation"
+title: Navigation
+use_cases: >-
+  page transitions, user navigation, programmatic routing, form submissions,
+  login flows, redirects
+tags:
+  - navigation
+  - page-transitions
+  - programmatic-routing
+  - links
+  - redirects
+  - user-flow
+version: '1.0'
 ---
 
 When using Solid Router, you can use the standard standard HTML [`<a>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a), which triggers [soft navigation](/solid-router/reference/components/a#soft-navigation).

--- a/src/routes/solid-router/concepts/nesting.mdx
+++ b/src/routes/solid-router/concepts/nesting.mdx
@@ -1,5 +1,16 @@
 ---
 title: Nesting routes
+use_cases: >-
+  hierarchical pages, admin panels, dashboard sections, multi-level navigation,
+  organized routes
+tags:
+  - nested-routes
+  - route-hierarchy
+  - admin-panels
+  - dashboards
+  - multi-level
+  - config-routing
+version: '1.0'
 ---
 
 Nested routes are a way to create a hierarchy of routes in your application.

--- a/src/routes/solid-router/concepts/path-parameters.mdx
+++ b/src/routes/solid-router/concepts/path-parameters.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Path parameters"
+title: Path parameters
+use_cases: >-
+  dynamic content, user ids, product details, blog posts, flexible routing,
+  data-driven pages
+tags:
+  - path-parameters
+  - dynamic-content
+  - url-params
+  - validation
+  - optional-params
+  - wildcards
+version: '1.0'
 ---
 
 Parameters within a route are used to capture dynamic values from the URL.

--- a/src/routes/solid-router/concepts/search-parameters.mdx
+++ b/src/routes/solid-router/concepts/search-parameters.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Search parameters"
+title: Search parameters
+use_cases: >-
+  filtering, pagination, search results, form state, query strings, url state
+  management
+tags:
+  - search-parameters
+  - query-strings
+  - filtering
+  - pagination
+  - url-state
+  - form-data
+version: '1.0'
 ---
 
 Search parameters are used to pass data to a route using the query string.

--- a/src/routes/solid-router/getting-started/component.mdx
+++ b/src/routes/solid-router/getting-started/component.mdx
@@ -1,5 +1,15 @@
 ---
-title: "Component routing"
+title: Component routing
+use_cases: >-
+  basic routing setup, simple applications, jsx routing, getting started,
+  straightforward route definitions
+tags:
+  - jsx-routing
+  - basic-setup
+  - route-definition
+  - getting-started
+  - simple-routing
+version: '1.0'
 ---
 
 In Solid Router, routes can be defined directly in an application's template using JSX.

--- a/src/routes/solid-router/getting-started/config.mdx
+++ b/src/routes/solid-router/getting-started/config.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Config-based routing"
+title: Config-based routing
+use_cases: >-
+  complex routing, lazy loading, large applications, organized route
+  definitions, performance optimization
+tags:
+  - config-routing
+  - lazy-loading
+  - performance
+  - route-organization
+  - large-apps
+  - code-splitting
+version: '1.0'
 ---
 
 Solid Router supports config-based routing, which offers the same capabilities as [component routing](/solid-router/getting-started/component).

--- a/src/routes/solid-router/getting-started/installation-and-setup.mdx
+++ b/src/routes/solid-router/getting-started/installation-and-setup.mdx
@@ -1,5 +1,16 @@
 ---
 title: Installation and setup
+use_cases: >-
+  starting new spa project, setting up client-side routing, single-page
+  applications, initial project configuration
+tags:
+  - installation
+  - setup
+  - configuration
+  - spa
+  - getting-started
+  - routing-setup
+version: '1.0'
 ---
 
 Solid Router is the universal router for Solid which works for rendering on the client or the server.

--- a/src/routes/solid-router/getting-started/linking-routes.mdx
+++ b/src/routes/solid-router/getting-started/linking-routes.mdx
@@ -1,5 +1,16 @@
 ---
 title: Linking routes
+use_cases: >-
+  navigation between pages, creating menu systems, building nav bars, linking
+  components, page transitions
+tags:
+  - navigation
+  - linking
+  - menu
+  - navbar
+  - page-transitions
+  - active-states
+version: '1.0'
 ---
 
 Once routes have been created within an application, using anchor tags will help users navigate between different views or pages.

--- a/src/routes/solid-router/guides/migration.mdx
+++ b/src/routes/solid-router/guides/migration.mdx
@@ -1,5 +1,16 @@
 ---
 title: Migration from v0.9.x
+use_cases: >-
+  upgrading from v0.9 to v0.10, breaking changes, legacy code migration, api
+  updates, refactoring existing router code
+tags:
+  - migration
+  - upgrade
+  - breaking-changes
+  - legacy
+  - refactoring
+  - v0.10
+version: '1.0'
 ---
 
 v0.10.0 brings some big changes to support the future of routing including Islands/Partial Hydration hybrid solutions.

--- a/src/routes/solid-router/index.mdx
+++ b/src/routes/solid-router/index.mdx
@@ -1,5 +1,16 @@
 ---
 title: Overview
+use_cases: >-
+  understanding router basics, spa fundamentals, getting started overview,
+  routing concepts introduction
+tags:
+  - overview
+  - introduction
+  - basics
+  - spa
+  - routing-concepts
+  - getting-started
+version: '1.0'
 ---
 
 # Overview

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -1,5 +1,16 @@
 ---
 title: A
+use_cases: >-
+  creating navigation links, active link styling, relative navigation, base path
+  support, soft navigation
+tags:
+  - links
+  - navigation
+  - active-states
+  - styling
+  - relative-paths
+  - soft-navigation
+version: '1.0'
 ---
 
 Solid Router exposes the `<A />` component as a wrapper around the [native anchor tag ](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a).

--- a/src/routes/solid-router/reference/components/hash-router.mdx
+++ b/src/routes/solid-router/reference/components/hash-router.mdx
@@ -1,5 +1,15 @@
 ---
 title: HashRouter
+use_cases: >-
+  static file hosting, github pages deployment, no server routing, single html
+  file apps, client-only routing
+tags:
+  - hash-routing
+  - static-hosting
+  - client-side
+  - github-pages
+  - single-file
+version: '1.0'
 ---
 
 The `HashRouter` is a top level component that manages the routing of your application.

--- a/src/routes/solid-router/reference/components/memory-router.mdx
+++ b/src/routes/solid-router/reference/components/memory-router.mdx
@@ -1,5 +1,15 @@
 ---
 title: MemoryRouter
+use_cases: >-
+  testing routing logic, controlling navigation history, testing environments,
+  custom navigation flows
+tags:
+  - testing
+  - memory-routing
+  - history-control
+  - unit-tests
+  - custom-navigation
+version: '1.0'
 ---
 
 The `MemoryRouter` can be used to route while keeping the entire routing history within internal memory.

--- a/src/routes/solid-router/reference/components/navigate.mdx
+++ b/src/routes/solid-router/reference/components/navigate.mdx
@@ -1,5 +1,14 @@
 ---
 title: Navigate
+use_cases: >-
+  programmatic navigation, redirects, conditional routing, automatic navigation,
+  route guards
+tags:
+  - programmatic-navigation
+  - redirects
+  - conditional-routing
+  - automatic-navigation
+version: '1.0'
 ---
 
 Solid Router provides a `Navigate` component that works similarly to [`<A>`](/solid-router/reference/components/a), but it will _immediately_ navigate to the provided path as soon as the component is rendered.

--- a/src/routes/solid-router/reference/components/route.mdx
+++ b/src/routes/solid-router/reference/components/route.mdx
@@ -1,5 +1,15 @@
 ---
 title: Route
+use_cases: >-
+  defining application routes, route configuration, nested routing, multiple
+  path matching, route structure
+tags:
+  - route-definition
+  - configuration
+  - nested-routes
+  - multiple-paths
+  - structure
+version: '1.0'
 ---
 
 `Route` is the component used when defining the routes of an application.

--- a/src/routes/solid-router/reference/components/router.mdx
+++ b/src/routes/solid-router/reference/components/router.mdx
@@ -1,5 +1,15 @@
 ---
 title: Router
+use_cases: >-
+  root router setup, application-wide routing, layout configuration, router
+  configuration, top-level routing
+tags:
+  - root-router
+  - configuration
+  - layouts
+  - application-setup
+  - top-level
+version: '1.0'
 ---
 
 The `Router` component is a top level component that manages the routing of your application.

--- a/src/routes/solid-router/reference/data-apis/action.mdx
+++ b/src/routes/solid-router/reference/data-apis/action.mdx
@@ -1,5 +1,17 @@
 ---
 title: action
+use_cases: >-
+  forms, data mutations, user input submission, crud operations, authentication,
+  server state changes
+tags:
+  - forms
+  - mutations
+  - data
+  - crud
+  - server
+  - post
+  - validation
+version: '1.0'
 ---
 
 Actions are data mutations that can trigger invalidations and further routing.

--- a/src/routes/solid-router/reference/data-apis/cache.mdx
+++ b/src/routes/solid-router/reference/data-apis/cache.mdx
@@ -1,6 +1,16 @@
 ---
 title: cache
 isDeprecated: true
+use_cases: >-
+  legacy projects, upgrading from old router versions, deprecated api
+  maintenance
+tags:
+  - deprecated
+  - caching
+  - legacy
+  - migration
+  - upgrade
+version: '1.0'
 ---
 
 :::caution[Deprecation Warning]

--- a/src/routes/solid-router/reference/data-apis/create-async-store.mdx
+++ b/src/routes/solid-router/reference/data-apis/create-async-store.mdx
@@ -1,5 +1,16 @@
 ---
 title: createAsyncStore
+use_cases: >-
+  large datasets, complex state, fine-grained reactivity, deep object updates,
+  model data
+tags:
+  - store
+  - reactivity
+  - async
+  - data
+  - large-datasets
+  - fine-grained
+version: '1.0'
 ---
 
 Similar to [createAsync](/solid-router/reference/data-apis/create-async) except it uses a deeply reactive store. Perfect for applying fine-grained changes to large model data that updates.

--- a/src/routes/solid-router/reference/data-apis/create-async.mdx
+++ b/src/routes/solid-router/reference/data-apis/create-async.mdx
@@ -1,5 +1,16 @@
 ---
 title: createAsync
+use_cases: >-
+  data fetching, async operations, loading states, suspense, api calls, server
+  data
+tags:
+  - async
+  - data-fetching
+  - suspense
+  - loading
+  - api
+  - promises
+version: '1.0'
 ---
 
 An asynchronous primitive with a function that tracks similar to `createMemo`.

--- a/src/routes/solid-router/reference/data-apis/query.mdx
+++ b/src/routes/solid-router/reference/data-apis/query.mdx
@@ -1,5 +1,16 @@
 ---
 title: query
+use_cases: >-
+  data fetching, caching, api calls, server requests, deduplication, performance
+  optimization
+tags:
+  - query
+  - caching
+  - data-fetching
+  - api
+  - performance
+  - deduplication
+version: '1.0'
 ---
 
 `query` is a [higher-order function](https://en.wikipedia.org/wiki/Higher-order_function) designed to create a new function with the same signature as the function passed to it.

--- a/src/routes/solid-router/reference/data-apis/revalidate.mdx
+++ b/src/routes/solid-router/reference/data-apis/revalidate.mdx
@@ -1,5 +1,14 @@
 ---
 title: revalidate
+use_cases: 'cache invalidation, data refresh, updating stale data, manual refresh, polling'
+tags:
+  - revalidation
+  - cache
+  - refresh
+  - invalidation
+  - polling
+  - update
+version: '1.0'
 ---
 
 The `revalidate` function is used to revalidate queries associated with specified [query keys](/solid-router/reference/data-apis/query#query-keys).

--- a/src/routes/solid-router/reference/data-apis/use-action.mdx
+++ b/src/routes/solid-router/reference/data-apis/use-action.mdx
@@ -1,5 +1,15 @@
 ---
 title: useAction
+use_cases: >-
+  programmatic form submission, javascript-based mutations, custom form
+  handling, non-form actions
+tags:
+  - action
+  - programmatic
+  - javascript
+  - mutations
+  - custom
+version: '1.0'
 ---
 
 `useAction` allows an [`action`](/solid-router/reference/data-apis/action) to be invoked programmatically.

--- a/src/routes/solid-router/reference/data-apis/use-submission.mdx
+++ b/src/routes/solid-router/reference/data-apis/use-submission.mdx
@@ -1,5 +1,16 @@
 ---
 title: useSubmission
+use_cases: >-
+  form feedback, loading states, optimistic updates, error handling, single
+  submissions
+tags:
+  - forms
+  - feedback
+  - optimistic
+  - loading
+  - errors
+  - submission
+version: '1.0'
 ---
 
 This helper is used to handle form submissions and can provide optimistic updates while actions are in flight as well as pending state feedback.

--- a/src/routes/solid-router/reference/data-apis/use-submissions.mdx
+++ b/src/routes/solid-router/reference/data-apis/use-submissions.mdx
@@ -1,5 +1,16 @@
 ---
 title: useSubmissions
+use_cases: >-
+  multiple submissions tracking, batch operations, submission history, complex
+  forms, retry logic
+tags:
+  - forms
+  - multiple
+  - tracking
+  - batch
+  - history
+  - retry
+version: '1.0'
 ---
 
 This helper is used to handle form submissions and can provide optimistic updates while actions are in flight as well as pending state feedback.

--- a/src/routes/solid-router/reference/preload-functions/preload.mdx
+++ b/src/routes/solid-router/reference/preload-functions/preload.mdx
@@ -1,5 +1,16 @@
 ---
 title: Preload
+use_cases: >-
+  performance optimization, data preloading, route preparation, preventing
+  waterfalls, hover prefetch
+tags:
+  - preload
+  - performance
+  - optimization
+  - routes
+  - prefetch
+  - waterfall
+version: '1.0'
 ---
 
 With smart caches waterfalls are still possible with view logic and with lazy loaded code.

--- a/src/routes/solid-router/reference/primitives/use-before-leave.mdx
+++ b/src/routes/solid-router/reference/primitives/use-before-leave.mdx
@@ -1,5 +1,15 @@
 ---
 title: useBeforeLeave
+use_cases: >-
+  forms with unsaved changes, data loss prevention, confirmation dialogs,
+  blocking navigation
+tags:
+  - navigation
+  - forms
+  - confirmation
+  - data-protection
+  - user-experience
+version: '1.0'
 ---
 
 `useBeforeLeave` takes a function that will be called prior to leaving a route.

--- a/src/routes/solid-router/reference/primitives/use-current-matches.mdx
+++ b/src/routes/solid-router/reference/primitives/use-current-matches.mdx
@@ -1,5 +1,13 @@
 ---
 title: useCurrentMatches
+use_cases: 'breadcrumbs, route metadata, nested route information, navigation context'
+tags:
+  - breadcrumbs
+  - metadata
+  - nested-routes
+  - navigation
+  - route-info
+version: '1.0'
 ---
 
 `useCurrentMatches` returns all the matches for the current matched route. Useful for getting all the route information.

--- a/src/routes/solid-router/reference/primitives/use-is-routing.mdx
+++ b/src/routes/solid-router/reference/primitives/use-is-routing.mdx
@@ -1,5 +1,15 @@
 ---
 title: useIsRouting
+use_cases: >-
+  loading states, pending navigation indicators, transition feedback, concurrent
+  rendering
+tags:
+  - loading-states
+  - transitions
+  - pending
+  - feedback
+  - concurrent
+version: '1.0'
 ---
 
 Retrieves a signal that indicates whether the route is currently in a transition.

--- a/src/routes/solid-router/reference/primitives/use-location.mdx
+++ b/src/routes/solid-router/reference/primitives/use-location.mdx
@@ -1,5 +1,13 @@
 ---
 title: useLocation
+use_cases: 'accessing url parts, query parameters, pathname parsing, location-based logic'
+tags:
+  - url
+  - pathname
+  - query-params
+  - location
+  - navigation
+version: '1.0'
 ---
 
 Retrieves reactive `location` object useful for getting things like `pathname`

--- a/src/routes/solid-router/reference/primitives/use-match.mdx
+++ b/src/routes/solid-router/reference/primitives/use-match.mdx
@@ -1,5 +1,15 @@
 ---
 title: useMatch
+use_cases: >-
+  active navigation links, conditional rendering, route matching, menu
+  highlighting
+tags:
+  - active-links
+  - conditional-rendering
+  - navigation
+  - matching
+  - menus
+version: '1.0'
 ---
 
 `useMatch` takes an accessor that returns the path and creates a Memo that returns match information if the current path matches the provided path.

--- a/src/routes/solid-router/reference/primitives/use-navigate.mdx
+++ b/src/routes/solid-router/reference/primitives/use-navigate.mdx
@@ -1,5 +1,13 @@
 ---
 title: useNavigate
+use_cases: 'programmatic navigation, redirects, conditional routing, authentication flows'
+tags:
+  - navigation
+  - redirects
+  - programmatic
+  - authentication
+  - routing
+version: '1.0'
 ---
 
 Retrieves the method which accepts a path to navigate to and an optional object with the following options:

--- a/src/routes/solid-router/reference/primitives/use-params.mdx
+++ b/src/routes/solid-router/reference/primitives/use-params.mdx
@@ -1,5 +1,12 @@
 ---
 title: useParams
+use_cases: 'dynamic routes, path parameters, user ids, resource identifiers'
+tags:
+  - dynamic-routes
+  - parameters
+  - path-params
+  - routing
+version: '1.0'
 ---
 
 `useParams` retrieves a reactive object similar to a store.

--- a/src/routes/solid-router/reference/primitives/use-preload-route.mdx
+++ b/src/routes/solid-router/reference/primitives/use-preload-route.mdx
@@ -1,5 +1,14 @@
 ---
 title: usePreloadRoute
+use_cases: >-
+  performance optimization, manual preloading, custom preload triggers, faster
+  navigation
+tags:
+  - performance
+  - preloading
+  - optimization
+  - prefetch
+version: '1.0'
 ---
 
 `usePreloadRoute` returns a function that can be used to preload a route manually. This is what happens automatically with link hovering and similar focus based behavior, but it is available here as an API.

--- a/src/routes/solid-router/reference/primitives/use-resolved-path.mdx
+++ b/src/routes/solid-router/reference/primitives/use-resolved-path.mdx
@@ -1,5 +1,12 @@
 ---
 title: useResolvedPath
+use_cases: 'modular routers, nested routing systems, path resolution, component libraries'
+tags:
+  - modular-routing
+  - nested-routes
+  - path-resolution
+  - components
+version: '1.0'
 ---
 
 `useResolvedPath` retrieves a signal\<string\>.

--- a/src/routes/solid-router/reference/primitives/use-search-params.mdx
+++ b/src/routes/solid-router/reference/primitives/use-search-params.mdx
@@ -1,5 +1,13 @@
 ---
 title: useSearchParams
+use_cases: 'query parameters, search filters, pagination, url state management'
+tags:
+  - query-params
+  - search
+  - pagination
+  - filters
+  - url-state
+version: '1.0'
 ---
 
 Retrieves a tuple containing a reactive object to read the current location's query parameters and a method to update them.

--- a/src/routes/solid-router/reference/response-helpers/json.mdx
+++ b/src/routes/solid-router/reference/response-helpers/json.mdx
@@ -1,5 +1,16 @@
 ---
 title: json
+use_cases: >-
+  api responses, data fetching, actions returning data, cache revalidation,
+  structured responses
+tags:
+  - api
+  - responses
+  - actions
+  - cache
+  - revalidation
+  - data
+version: '1.0'
 ---
 
 Returns JSON data from an action while also providing options for controlling revalidation of cache data on the route.

--- a/src/routes/solid-router/reference/response-helpers/redirect.mdx
+++ b/src/routes/solid-router/reference/response-helpers/redirect.mdx
@@ -1,5 +1,16 @@
 ---
 title: redirect
+use_cases: >-
+  authentication flows, login pages, navigation, route protection, form
+  submissions, single-flight mutations
+tags:
+  - authentication
+  - navigation
+  - routing
+  - forms
+  - mutations
+  - login
+version: '1.0'
 ---
 
 Redirects to the next route.

--- a/src/routes/solid-router/reference/response-helpers/reload.mdx
+++ b/src/routes/solid-router/reference/response-helpers/reload.mdx
@@ -1,5 +1,16 @@
 ---
 title: reload
+use_cases: >-
+  cache invalidation, data refresh, query revalidation, optimistic updates, data
+  synchronization
+tags:
+  - cache
+  - revalidation
+  - queries
+  - data
+  - updates
+  - invalidation
+version: '1.0'
 ---
 
 Reload is a response helper built on top of [revalidate](/solid-router/reference/response-helpers/revalidate).

--- a/src/routes/solid-router/rendering-modes/spa.mdx
+++ b/src/routes/solid-router/rendering-modes/spa.mdx
@@ -1,5 +1,16 @@
 ---
 title: Single page applications
+use_cases: >-
+  client-side routing, spa deployment, hosting configuration, cdn setup, static
+  hosting
+tags:
+  - spa
+  - deployment
+  - hosting
+  - cdn
+  - client-routing
+  - static
+version: '1.0'
 ---
 
 When deploying applications that use a client-side router without relying on Server-Side Rendering, it is important that redirects to the index page are handled properly. 

--- a/src/routes/solid-router/rendering-modes/ssr.mdx
+++ b/src/routes/solid-router/rendering-modes/ssr.mdx
@@ -1,5 +1,16 @@
 ---
 title: Server side rendering
+use_cases: >-
+  server-side rendering, preloading data, suspense, resources, lazy loading,
+  initial page loads
+tags:
+  - ssr
+  - preloading
+  - suspense
+  - resources
+  - lazy
+  - performance
+version: '1.0'
 ---
 
 Solid Router supports all of Solid's SSR capabilities.

--- a/src/routes/solid-start/advanced/auth.mdx
+++ b/src/routes/solid-start/advanced/auth.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Auth"
+title: Auth
+use_cases: >-
+  authentication, user protection, login systems, private routes, user data,
+  session management
+tags:
+  - authentication
+  - authorization
+  - login
+  - sessions
+  - user
+  - security
+version: '1.0'
 ---
 
 Server functions can be used to protect sensitive resources like user data.

--- a/src/routes/solid-start/advanced/middleware.mdx
+++ b/src/routes/solid-start/advanced/middleware.mdx
@@ -1,5 +1,17 @@
 ---
-title: "Middleware"
+title: Middleware
+use_cases: >-
+  request interception, authentication, logging, headers, global data sharing,
+  redirects, preprocessing
+tags:
+  - middleware
+  - requests
+  - authentication
+  - logging
+  - headers
+  - preprocessing
+  - globals
+version: '1.0'
 ---
 
 Middleware intercepts HTTP requests and responses to perform tasks like authentication, redirection, logging, and more.

--- a/src/routes/solid-start/advanced/request-events.mdx
+++ b/src/routes/solid-start/advanced/request-events.mdx
@@ -1,5 +1,16 @@
 ---
 title: Request events
+use_cases: >-
+  server context, request data, locals typing, native events, vinxi integration,
+  server functions
+tags:
+  - server
+  - context
+  - events
+  - locals
+  - vinxi
+  - typing
+version: '1.0'
 ---
 
 Request events in SolidStart are retrieved using the [`getRequestEvent`](/reference/server-utilities/get-request-event) from `@solidjs/web`.

--- a/src/routes/solid-start/advanced/return-responses.mdx
+++ b/src/routes/solid-start/advanced/return-responses.mdx
@@ -1,5 +1,16 @@
 ---
 title: Returning responses
+use_cases: >-
+  server functions, response objects, typescript typing, error handling, custom
+  responses
+tags:
+  - server
+  - responses
+  - typescript
+  - errors
+  - functions
+  - types
+version: '1.0'
 ---
 
 In SolidStart, it is possible to return a Response object from a server function. 

--- a/src/routes/solid-start/advanced/session.mdx
+++ b/src/routes/solid-start/advanced/session.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Sessions"
+title: Sessions
+use_cases: >-
+  user sessions, state persistence, authentication, user preferences, login
+  state, stateful applications
+tags:
+  - sessions
+  - state
+  - authentication
+  - persistence
+  - preferences
+  - cookies
+version: '1.0'
 ---
 
 Sessions allow web applications to maintain state between user requests.

--- a/src/routes/solid-start/advanced/websocket.mdx
+++ b/src/routes/solid-start/advanced/websocket.mdx
@@ -1,5 +1,16 @@
 ---
 title: WebSocket endpoint
+use_cases: >-
+  real-time communication, live chat, live updates, multiplayer games,
+  collaborative apps, streaming data
+tags:
+  - websockets
+  - real-time
+  - experimental
+  - streaming
+  - chat
+  - live-updates
+version: '1.0'
 ---
 
 WebSocket endpoint may be included by passing the ws handler file you specify in your start config.

--- a/src/routes/solid-start/building-your-application/api-routes.mdx
+++ b/src/routes/solid-start/building-your-application/api-routes.mdx
@@ -1,5 +1,17 @@
 ---
-title: "API routes"
+title: API routes
+use_cases: >-
+  rest api, graphql endpoints, webhooks, oauth callbacks, third-party
+  integrations, non-html responses, public apis
+tags:
+  - api
+  - rest
+  - graphql
+  - trpc
+  - webhooks
+  - oauth
+  - endpoints
+version: '1.0'
 ---
 
 While Server Functions can be a good way to write server-side code for data needed by your UI, sometimes you need to expose API routes.

--- a/src/routes/solid-start/building-your-application/css-and-styling.mdx
+++ b/src/routes/solid-start/building-your-application/css-and-styling.mdx
@@ -1,5 +1,16 @@
 ---
-title: "CSS and styling"
+title: CSS and styling
+use_cases: >-
+  styling components, css organization, scoped styles, maintaining design
+  systems, component libraries
+tags:
+  - css
+  - styling
+  - css-modules
+  - scoped-styles
+  - design
+  - components
+version: '1.0'
 ---
 
 SolidStart is a standards-based framework that, instead of modifying the behavior of the [`<style>` tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style), strives to build on top of it. 

--- a/src/routes/solid-start/building-your-application/data-loading.mdx
+++ b/src/routes/solid-start/building-your-application/data-loading.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Data loading"
+title: Data loading
+use_cases: >-
+  loading data from apis, database queries, server-side data fetching, client
+  hydration, data synchronization
+tags:
+  - data-loading
+  - server-functions
+  - database
+  - apis
+  - ssr
+  - hydration
+version: '1.0'
 ---
 
 SolidStart aims to make it easy to load data from your data sources to keep your UI updated with your data.

--- a/src/routes/solid-start/building-your-application/head-and-metadata.mdx
+++ b/src/routes/solid-start/building-your-application/head-and-metadata.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Head and metadata"
+title: Head and metadata
+use_cases: >-
+  seo optimization, social media sharing, page titles, meta tags, open graph,
+  site branding
+tags:
+  - seo
+  - metadata
+  - head
+  - titles
+  - open-graph
+  - social-media
+version: '1.0'
 ---
 
 SolidStart does not come with a metadata library.

--- a/src/routes/solid-start/building-your-application/route-prerendering.mdx
+++ b/src/routes/solid-start/building-your-application/route-prerendering.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Route Pre-rendering"
+title: Route Pre-rendering
+use_cases: >-
+  static site generation, blogs, documentation sites, marketing pages, seo
+  optimization, fast loading
+tags:
+  - ssg
+  - prerendering
+  - static
+  - performance
+  - seo
+  - build-time
+version: '1.0'
 ---
 
 Route pre-rendering powers Static Site Generation (SSG) by producing static HTML pages during the build process.

--- a/src/routes/solid-start/building-your-application/routing.mdx
+++ b/src/routes/solid-start/building-your-application/routing.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Routing"
+title: Routing
+use_cases: >-
+  always, navigation, page structure, url organization, nested layouts, dynamic
+  pages
+tags:
+  - routing
+  - navigation
+  - file-based
+  - dynamic-routes
+  - layouts
+  - pages
+version: '1.0'
 ---
 
 Routing serves as a key component of web applications.

--- a/src/routes/solid-start/building-your-application/static-assets.mdx
+++ b/src/routes/solid-start/building-your-application/static-assets.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Static assets"
+title: Static assets
+use_cases: >-
+  images, documents, media files, favicon, manifest files, downloadable content,
+  branding assets
+tags:
+  - assets
+  - images
+  - static-files
+  - public
+  - media
+  - documents
+version: '1.0'
 ---
 
 Within SolidStart there are two ways to import static assets into your project: using the public directory and using imports.

--- a/src/routes/solid-start/getting-started.mdx
+++ b/src/routes/solid-start/getting-started.mdx
@@ -1,5 +1,15 @@
 ---
-title: "Getting started"
+title: Getting started
+use_cases: >-
+  new projects, project setup, initial configuration, learning solidstart,
+  project scaffolding
+tags:
+  - getting-started
+  - setup
+  - templates
+  - project-structure
+  - initialization
+version: '1.0'
 ---
 
 The easiest way to get started with Solid is to use the SolidStart starter.

--- a/src/routes/solid-start/guides/data-fetching.mdx
+++ b/src/routes/solid-start/guides/data-fetching.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Data fetching"
+title: Data fetching
+use_cases: >-
+  api calls, database queries, loading states, error handling, async data,
+  server data fetching
+tags:
+  - data-fetching
+  - async
+  - loading
+  - errors
+  - queries
+  - apis
+version: '1.0'
 ---
 
 SolidStart is built on top of [Solid](/) and uses [Solid Router](/solid-router) by default.

--- a/src/routes/solid-start/guides/data-mutation.mdx
+++ b/src/routes/solid-start/guides/data-mutation.mdx
@@ -1,5 +1,17 @@
 ---
-title: "Data mutation"
+title: Data mutation
+use_cases: >-
+  forms, user input, data updates, crud operations, post requests,
+  authentication, database writes
+tags:
+  - forms
+  - mutations
+  - actions
+  - data-updates
+  - crud
+  - validation
+  - server-functions
+version: '1.0'
 ---
 
 This guide provides practical examples of using actions to mutate data in SolidStart.

--- a/src/routes/solid-start/guides/security.mdx
+++ b/src/routes/solid-start/guides/security.mdx
@@ -1,5 +1,18 @@
 ---
 title: Security
+use_cases: >-
+  production deployment, security hardening, preventing attacks, user input
+  validation, api protection
+tags:
+  - security
+  - xss
+  - csrf
+  - csp
+  - cors
+  - production
+  - middleware
+  - validation
+version: '1.0'
 ---
 
 ## XSS (Cross Site Scripting)

--- a/src/routes/solid-start/guides/service-workers.mdx
+++ b/src/routes/solid-start/guides/service-workers.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Service workers"
+title: Service workers
+use_cases: >-
+  offline functionality, caching, push notifications, background sync, pwa
+  development
+tags:
+  - service-workers
+  - pwa
+  - offline
+  - caching
+  - background-sync
+  - client-side
+version: '1.0'
 ---
 
 To register a service worker:

--- a/src/routes/solid-start/index.mdx
+++ b/src/routes/solid-start/index.mdx
@@ -1,5 +1,16 @@
 ---
 title: Overview
+use_cases: >-
+  getting started, learning solidstart, understanding concepts, project
+  overview, first time users
+tags:
+  - overview
+  - getting-started
+  - concepts
+  - introduction
+  - features
+  - rendering-modes
+version: '1.0'
 ---
 
 # Overview

--- a/src/routes/solid-start/reference/client/client-only.mdx
+++ b/src/routes/solid-start/reference/client/client-only.mdx
@@ -1,5 +1,16 @@
 ---
 title: clientOnly
+use_cases: >-
+  browser apis, dom manipulation, client-side libraries, bypassing ssr,
+  window/document access
+tags:
+  - client-only
+  - browser-apis
+  - dom
+  - ssr-bypass
+  - hydration
+  - dynamic-imports
+version: '1.0'
 ---
 
 The `clientOnly` function allows components or pages to render exclusively on the client side, bypassing server-side rendering (_SSR_).

--- a/src/routes/solid-start/reference/client/mount.mdx
+++ b/src/routes/solid-start/reference/client/mount.mdx
@@ -1,5 +1,15 @@
 ---
 title: mount
+use_cases: >-
+  application bootstrap, entry client setup, hydration configuration, app
+  initialization
+tags:
+  - bootstrap
+  - entry-client
+  - hydration
+  - mounting
+  - initialization
+version: '1.0'
 ---
 
 `mount` is a method that calls either [`hydrate`](/reference/rendering/hydrate) (server rendering) or [`render`](/reference/rendering/render) (client rendering) depending on the configuration. 

--- a/src/routes/solid-start/reference/client/start-client.mdx
+++ b/src/routes/solid-start/reference/client/start-client.mdx
@@ -1,5 +1,12 @@
 ---
-title: "StartClient"
+title: StartClient
+use_cases: 'client-side setup, application wrapper, entry client configuration, app root'
+tags:
+  - client-wrapper
+  - app-root
+  - entry-client
+  - bootstrap
+version: '1.0'
 ---
 
 `StartClient` is a component that wraps the application root. 

--- a/src/routes/solid-start/reference/config/define-config.mdx
+++ b/src/routes/solid-start/reference/config/define-config.mdx
@@ -1,5 +1,16 @@
 ---
 title: defineConfig
+use_cases: >-
+  project configuration, build setup, deployment settings, vite customization,
+  nitro configuration
+tags:
+  - configuration
+  - build-setup
+  - deployment
+  - vite
+  - nitro
+  - presets
+version: '1.0'
 ---
 
 The `defineConfig` helper is from `@solidjs/start/config` and is used within [`app.config.ts`](/solid-start/reference/entrypoints/app-config).

--- a/src/routes/solid-start/reference/entrypoints/app-config.mdx
+++ b/src/routes/solid-start/reference/entrypoints/app-config.mdx
@@ -1,5 +1,12 @@
 ---
 title: app.config.ts
+use_cases: 'project setup, build configuration, deployment configuration, initial setup'
+tags:
+  - config-file
+  - setup
+  - build-config
+  - deployment-config
+version: '1.0'
 ---
 
 The `app.config.ts` is the root of every SolidStart app and the main point of configuration.

--- a/src/routes/solid-start/reference/entrypoints/app.mdx
+++ b/src/routes/solid-start/reference/entrypoints/app.mdx
@@ -1,5 +1,15 @@
 ---
 title: app.tsx
+use_cases: >-
+  application structure, routing setup, top-level components, app entry point,
+  layout definition
+tags:
+  - app-structure
+  - routing
+  - entry-point
+  - layout
+  - isomorphic
+version: '1.0'
 ---
 
 The `App` component is the isomorphic (shared on server and browser) entry point into your application.

--- a/src/routes/solid-start/reference/entrypoints/entry-client.mdx
+++ b/src/routes/solid-start/reference/entrypoints/entry-client.mdx
@@ -1,5 +1,15 @@
 ---
 title: entry-client.tsx
+use_cases: >-
+  browser hydration, client-side startup, service worker registration,
+  client-only rendering
+tags:
+  - client-side
+  - hydration
+  - startup
+  - browser
+  - service-workers
+version: '1.0'
 ---
 
 `entry-client.tsx` is where an application starts in the browser. 

--- a/src/routes/solid-start/reference/entrypoints/entry-server.mdx
+++ b/src/routes/solid-start/reference/entrypoints/entry-server.mdx
@@ -1,5 +1,15 @@
 ---
 title: entry-server.tsx
+use_cases: >-
+  server-side rendering, ssr configuration, html document setup, custom document
+  structure
+tags:
+  - server-side-rendering
+  - ssr
+  - document
+  - html
+  - configuration
+version: '1.0'
 ---
 
 `entry-server.tsx` is where an application starts on the server.

--- a/src/routes/solid-start/reference/routing/file-routes.mdx
+++ b/src/routes/solid-start/reference/routing/file-routes.mdx
@@ -1,5 +1,15 @@
 ---
 title: FileRoutes
+use_cases: >-
+  file-based routing, automatic route generation, routing configuration,
+  organizing routes
+tags:
+  - routing
+  - file-based
+  - automatic
+  - navigation
+  - routes
+version: '1.0'
 ---
 
 `FileRoutes` is a component that creates a [`Route`](/solid-router/reference/components/route) for each file in the `/src/routes` directory.

--- a/src/routes/solid-start/reference/server/create-handler.mdx
+++ b/src/routes/solid-start/reference/server/create-handler.mdx
@@ -1,5 +1,15 @@
 ---
 title: createHandler
+use_cases: >-
+  server configuration, ssr mode selection, rendering strategy, performance
+  optimization
+tags:
+  - server
+  - rendering
+  - configuration
+  - ssr-modes
+  - performance
+version: '1.0'
 ---
 
 The `createHandler` is used to start the server in [`entry-server.tsx`](/solid-start/reference/entrypoints/entry-server).

--- a/src/routes/solid-start/reference/server/create-middleware.mdx
+++ b/src/routes/solid-start/reference/server/create-middleware.mdx
@@ -1,5 +1,15 @@
 ---
 title: createMiddleware
+use_cases: >-
+  request interception, authentication, logging, api middleware,
+  request/response processing
+tags:
+  - middleware
+  - authentication
+  - logging
+  - request-processing
+  - api
+version: '1.0'
 ---
 
 `createMiddleware` creates a configuration object for SolidStart that specifies when middleware functions are executed during the request lifecycle.

--- a/src/routes/solid-start/reference/server/get-server-function-meta.mdx
+++ b/src/routes/solid-start/reference/server/get-server-function-meta.mdx
@@ -1,5 +1,15 @@
 ---
 title: getServerFunctionMeta
+use_cases: >-
+  server function identification, parallel execution, caching strategies, server
+  state management
+tags:
+  - server-functions
+  - parallel-execution
+  - caching
+  - state-management
+  - identification
+version: '1.0'
 ---
 
 `getServerFunctionMeta` returns a function-specific id string, that is stable across all instances when server functions are run in parallel on multiple CPU cores or workers.

--- a/src/routes/solid-start/reference/server/get.mdx
+++ b/src/routes/solid-start/reference/server/get.mdx
@@ -1,5 +1,15 @@
 ---
 title: GET
+use_cases: >-
+  cacheable server functions, http caching, streaming data, get requests with
+  cache control
+tags:
+  - server-functions
+  - caching
+  - http-cache
+  - streaming
+  - get-requests
+version: '1.0'
 ---
 
 `GET` helps to create a server function which is accessed via an [HTTP GET request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET). 

--- a/src/routes/solid-start/reference/server/http-header.mdx
+++ b/src/routes/solid-start/reference/server/http-header.mdx
@@ -1,5 +1,15 @@
 ---
 title: HttpHeader
+use_cases: >-
+  custom http headers, seo headers, security headers, api responses, caching
+  headers
+tags:
+  - http-headers
+  - seo
+  - security
+  - api
+  - response-headers
+version: '1.0'
 ---
 
 `HttpHeader` provides a way to set headers on HTTPs response sent by the server.

--- a/src/routes/solid-start/reference/server/http-status-code.mdx
+++ b/src/routes/solid-start/reference/server/http-status-code.mdx
@@ -1,5 +1,15 @@
 ---
 title: HttpStatusCode
+use_cases: >-
+  404 pages, error pages, dynamic status codes, seo optimization, proper http
+  responses
+tags:
+  - http-status
+  - error-pages
+  - '404'
+  - seo
+  - status-codes
+version: '1.0'
 ---
 
 `HttpStatusCode` sets the HTTP status code for the page response while server-side rendering.

--- a/src/routes/solid-start/reference/server/start-server.mdx
+++ b/src/routes/solid-start/reference/server/start-server.mdx
@@ -1,5 +1,13 @@
 ---
-title: "StartServer"
+title: StartServer
+use_cases: 'server bootstrapping, document structure, server setup, ssr initialization'
+tags:
+  - server
+  - bootstrapping
+  - document
+  - initialization
+  - setup
+version: '1.0'
 ---
 
 `StartServer` takes a function returning a document component and converts it to a static document which can be used in [`createHandler`](/solid-start/reference/server/create-handler) to bootstrap the server.

--- a/src/routes/solid-start/reference/server/use-server.mdx
+++ b/src/routes/solid-start/reference/server/use-server.mdx
@@ -1,5 +1,18 @@
 ---
 title: '"use server"'
+use_cases: >-
+  server-only functions, database operations, authentication, api endpoints,
+  form actions, data mutations, server-side logging, secure operations
+tags:
+  - server-functions
+  - rpc
+  - database
+  - authentication
+  - api
+  - data-fetching
+  - actions
+  - security
+version: '1.0'
 ---
 
 `"use server"` will enable functions that only run on the server.


### PR DESCRIPTION
This PR adds a number of metadata values to the whole docs dataset. Each section will now have:

- `tags` - A list of values identifying what the page is about
- `use_cases` - Short format comma separated list of use cases that the documentation might be relevant to
- `version` - The version of Solid the documentation is tied to

I'm open to suggestions on how to change these values. Perhaps the version should be broken out by SolidJS and SolidStart versions? These values are all currently generated by Claude. I'm including them here because we would like to use these upstream in other projects such as a future AI project as well as improved Orama search.

Ps. also added proper standard Solid banner to the repo.