### PR TITLE
Improve styling of tables containing large inline code

### DIFF
--- a/src/solidbase-theme/mdx-components.tsx
+++ b/src/solidbase-theme/mdx-components.tsx
@@ -234,7 +234,7 @@ export const pre = (props: ParentProps) => {
 export const code = (props: ParentProps) => {
 	return (
 		<code
-			class="not-prose inline-block rounded-lg bg-blue-200 px-1 py-0.5 !font-mono text-[0.8em] font-semibold leading-snug text-slate-900 dark:bg-slate-600/60 dark:text-white"
+			class="not-prose inline-flex rounded-lg bg-blue-200 px-1 py-0.5 !font-mono text-[0.8em] font-semibold leading-snug text-slate-900 dark:bg-slate-600/60 dark:text-white"
 			{...props}
 		>
 			{props.children}


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

Fixed a bug where tables with large inline codes were rendered incorrectly or misaligned in Firefox. It also improves the overall appearance of tables containing inline code.

Before:

<img width="677" height="223" alt="2025-11-07_17-14" src="https://github.com/user-attachments/assets/a1e3df5d-8ab5-4e76-b8cd-da049ecb7235" />

After:

<img width="690" height="235" alt="2025-11-07_17-15" src="https://github.com/user-attachments/assets/387a63bf-1995-4a81-b00c-7f24a3591097" />

### Related issues & labels

- Closes #1329
