### PR TITLE
add deferStream: true to auth code example

### DIFF
--- a/src/routes/solid-start/advanced/auth.mdx
+++ b/src/routes/solid-start/advanced/auth.mdx
@@ -50,9 +50,11 @@ const getPrivatePosts = query(async function() {
 })
 
 export default function Page() {
-	const posts = createAsync(() => getPrivatePosts());
+	const posts = createAsync(() => getPrivatePosts(), { deferStream: true });
 }
 ```
 
 Once the user hits this route, the router will attempt to fetch `getPrivatePosts` data.
 If the user is not signed in, `getPrivatePosts` will throw and the router will redirect to the login page.
+
+Setting `{ deferStream: true }` will wait until `getPrivatePosts` resolves before loading the page. Otherwise, opening the page directly will error, because server side redirects cannot occur after an initial response has streamed to the client.

--- a/src/routes/solid-start/advanced/auth.mdx
+++ b/src/routes/solid-start/advanced/auth.mdx
@@ -57,4 +57,5 @@ export default function Page() {
 Once the user hits this route, the router will attempt to fetch `getPrivatePosts` data.
 If the user is not signed in, `getPrivatePosts` will throw and the router will redirect to the login page.
 
-Setting `{ deferStream: true }` will wait until `getPrivatePosts` resolves before loading the page. Otherwise, opening the page directly will error, because server side redirects cannot occur after an initial response has streamed to the client.
+To prevent errors when opening the page directly, set `deferStream: true`. 
+This would ensure `getPrivatePosts` resolves before the page loads since server-side redirects cannot occur after streaming has started.


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
This adds `{ deferStream: true }` to the protected routes code example. Without deferStream, the code cannot redirect on initial load with streaming.

### Related issues & labels

- Part of #1384 
- Suggested label(s) (optional): <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
