### PR TITLE
Add a note about using `redirect` with server functions

### DIFF
--- a/src/routes/solid-start/building-your-application/data-fetching.mdx
+++ b/src/routes/solid-start/building-your-application/data-fetching.mdx
@@ -41,3 +41,19 @@ const getCurrentUserQuery = query(async (id: string) => {
 In this example, the `getCurrentUserQuery` retrieves the session data, and if an authenticated user exists, it gets their information from the database and returns it.
 Otherwise, it redirects the user to the login page.
 All of these operations are performed completely on the server regardless of how the query is called.
+
+:::caution[Redirects and streaming don't mix]
+HTTP redirects work by setting a `3xx` status code on the response.
+Once a response has started streaming, its headers (including the status code) are already sent to the client and cannot be changed, even if the stream hasn't finished yet.
+
+If a server function attempts to redirect after streaming has begun, you'll encounter the common error:
+
+**"Cannot set headers after they are sent to the client."**
+
+To avoid this, disable streaming for queries that may perform a redirect by enabling the [`deferStream`](/solid-router/reference/data-apis/create-async#deferstream) option.
+
+```tsx
+const user = createAsync(() => getCurrentUserQuery(), { deferStream: true });
+```
+
+:::

--- a/src/routes/solid-start/building-your-application/data-fetching.mdx
+++ b/src/routes/solid-start/building-your-application/data-fetching.mdx
@@ -46,7 +46,7 @@ All of these operations are performed completely on the server regardless of how
 Once streaming begins, response headers (including status and cookies) are sent and cannot be changed.
 Any header-modifying logic within a server function, such as redirects or APIs like `useSession` that set cookies, must run before streaming starts;
 otherwise, this error will occur:
-Cannot set headers after they are sent to the client.
+`Cannot set headers after they are sent to the client.`
 
 To avoid this, disable streaming for queries that may modify headers by enabling the [`deferStream`](/solid-router/reference/data-apis/create-async#deferstream) option.
 

--- a/src/routes/solid-start/building-your-application/data-fetching.mdx
+++ b/src/routes/solid-start/building-your-application/data-fetching.mdx
@@ -42,15 +42,15 @@ In this example, the `getCurrentUserQuery` retrieves the session data, and if an
 Otherwise, it redirects the user to the login page.
 All of these operations are performed completely on the server regardless of how the query is called.
 
-:::caution[Redirects and streaming don't mix]
-HTTP redirects work by setting a `3xx` status code on the response.
-Once a response has started streaming, its headers (including the status code) are already sent to the client and cannot be changed, even if the stream hasn't finished yet.
+:::caution[Modifying headers after streaming]
+Once a response starts streaming, its headers (including the status code and cookies) are immediately sent to the client and **cannot be modified**.
 
-If a server function attempts to redirect after streaming has begun, you'll encounter the common error:
+Any server-side operation that changes headers, such as performing a redirect (`3xx` status) or using APIs like `useSession` that modify cookies, must happen **before** streaming begins.
+Otherwise, you'll encounter errors like:
 
 **"Cannot set headers after they are sent to the client."**
 
-To avoid this, disable streaming for queries that may perform a redirect by enabling the [`deferStream`](/solid-router/reference/data-apis/create-async#deferstream) option.
+To avoid this, disable streaming for queries that may modify headers by enabling the [`deferStream`](/solid-router/reference/data-apis/create-async#deferstream) option.
 
 ```tsx
 const user = createAsync(() => getCurrentUserQuery(), { deferStream: true });

--- a/src/routes/solid-start/building-your-application/data-fetching.mdx
+++ b/src/routes/solid-start/building-your-application/data-fetching.mdx
@@ -44,9 +44,7 @@ All of these operations are performed completely on the server regardless of how
 
 :::caution[Modifying headers after streaming]
 Once streaming begins, response headers (including status and cookies) are sent and cannot be changed.
-Any header-modifying logic within a server function, such as redirects or APIs like `useSession` that set cookies, must run before streaming starts, or this error will occur:
-
-**"Cannot set headers after they are sent to the client."**
+Any header-modifying logic within a server function, such as redirects or APIs like `useSession` that set cookies, must run before streaming starts; otherwise, this error will occur: Cannot set headers after they are sent to the client.
 
 To avoid this, disable streaming for queries that may modify headers by enabling the [`deferStream`](/solid-router/reference/data-apis/create-async#deferstream) option.
 

--- a/src/routes/solid-start/building-your-application/data-fetching.mdx
+++ b/src/routes/solid-start/building-your-application/data-fetching.mdx
@@ -43,10 +43,8 @@ Otherwise, it redirects the user to the login page.
 All of these operations are performed completely on the server regardless of how the query is called.
 
 :::caution[Modifying headers after streaming]
-Once a response starts streaming, its headers (including the status code and cookies) are immediately sent to the client and **cannot be modified**.
-
-Any server-side operation that changes headers, such as performing a redirect (`3xx` status) or using APIs like `useSession` that modify cookies, must happen **before** streaming begins.
-Otherwise, you'll encounter errors like:
+Once streaming begins, response headers (including status and cookies) are sent and cannot be changed.
+Any header-modifying logic within a server function, such as redirects or APIs like `useSession` that set cookies, must run before streaming starts, or this error will occur:
 
 **"Cannot set headers after they are sent to the client."**
 

--- a/src/routes/solid-start/building-your-application/data-fetching.mdx
+++ b/src/routes/solid-start/building-your-application/data-fetching.mdx
@@ -44,7 +44,9 @@ All of these operations are performed completely on the server regardless of how
 
 :::caution[Modifying headers after streaming]
 Once streaming begins, response headers (including status and cookies) are sent and cannot be changed.
-Any header-modifying logic within a server function, such as redirects or APIs like `useSession` that set cookies, must run before streaming starts; otherwise, this error will occur: Cannot set headers after they are sent to the client.
+Any header-modifying logic within a server function, such as redirects or APIs like `useSession` that set cookies, must run before streaming starts;
+otherwise, this error will occur:
+Cannot set headers after they are sent to the client.
 
 To avoid this, disable streaming for queries that may modify headers by enabling the [`deferStream`](/solid-router/reference/data-apis/create-async#deferstream) option.
 


### PR DESCRIPTION
This is complementary to https://github.com/solidjs/solid-docs/pull/1385.