### PR TITLE
Add reference pages guidance to writing guide

### DIFF
--- a/WRITING.md
+++ b/WRITING.md
@@ -188,6 +188,25 @@ Do: Check the [Solid homepage](https://www.solidjs.com)
 Don't: Click [here](https://www.solidjs.com) to go to the Solid homepage.
 ```
 
+## Reference pages
+
+Reference pages document the API surface.
+Keep them concise and easy to scan.
+
+Include:
+- Imports
+- Signatures
+- Parameters
+- Return values
+- Short examples
+
+Avoid:
+- Narrative context or “why”
+- Usage guidance (“when to use”, best practices)
+- Long notes
+
+If explanation is needed, link to a guide or how-to page.
+
 ## Voice and tone
 
 So far, we've dealt with how your contributions should look and function.


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description
This change is necessary to add explicit guidance for reference pages so API documentation stays concise, scannable, and consistent with the writing guide.
It inserts a "Reference pages" section before "Voice and tone", listing required elements, what to avoid, and when to link to a guide or how-to page.

### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): documentation
