### PR TITLE
docs: fix createAsync example to pass required argument to query function

### DIFF
--- a/src/routes/solid-router/reference/data-apis/create-async.mdx
+++ b/src/routes/solid-router/reference/data-apis/create-async.mdx
@@ -106,11 +106,14 @@ While the fetcher is executing for the first time, unless an `initialValue` is s
 import { createAsync, query } from "@solidjs/router";
 
 const getUserQuery = query(async (id: string) => {
+	// You can use the parameters here
+	console.log(id);
+
 	// ... Fetches the user from the server.
 }, "user");
 
 function UserProfile() {
-	const user = createAsync(() => getUserQuery());
+	const user = createAsync(() => getUserQuery("user-123"));
 
 	return <p>{user()?.name}</p>;
 }

--- a/src/routes/solid-router/reference/data-apis/create-async.mdx
+++ b/src/routes/solid-router/reference/data-apis/create-async.mdx
@@ -123,11 +123,14 @@ import { Suspense, ErrorBoundary, For } from "solid-js";
 import { createAsync, query } from "@solidjs/router";
 
 const getUserQuery = query(async (id: string) => {
+	// You can use the parameters here
+	console.log(id);
+
 	// ... Fetches the user from the server.
 }, "user");
 
 function UserProfile() {
-	const user = createAsync(() => getUserQuery());
+	const user = createAsync(() => getUserQuery("user-123"));
 
 	return (
 		<ErrorBoundary fallback={<p>Could not fetch user data.</p>}>


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

Fixes the `createAsync()` example in the documentation to properly demonstrate passing arguments to a query function.

The current example defines `getUserQuery` with a required `id` parameter but never passes this argument when calling the function:

```tsx
const getUserQuery = query(async (id: string) => {
  // ... Fetches the user from the server.
}, "user");

function UserProfile() {
  const user = createAsync(() => getUserQuery());
 ```
 
 This causes a TypeScript error and fails at runtime. 
 
 I updated the example to pass an argument to `getUserQuery()`. 
 
 Thanks for considering! 


### Related issues & labels

Suggested label: documentation
