### PR TITLE
Add padding to children container in docs layout

### DIFF
--- a/src/ui/docs-layout.tsx
+++ b/src/ui/docs-layout.tsx
@@ -56,7 +56,7 @@ export const DocsLayout = (props: DocsLayoutProps) => {
 					<span class="-mt-[15px] block text-sm xl:hidden">
 						<EditPageLink />
 					</span>
-					<div class="w-full">{props.children}</div>
+					<div class="w-full px-2">{props.children}</div>
 					<span class="text-sm xl:hidden">
 						<PageIssueLink />
 					</span>

--- a/src/ui/docs-layout.tsx
+++ b/src/ui/docs-layout.tsx
@@ -56,7 +56,7 @@ export const DocsLayout = (props: DocsLayoutProps) => {
 					<span class="-mt-[15px] block text-sm xl:hidden">
 						<EditPageLink />
 					</span>
-					<div class="w-full px-2">{props.children}</div>
+					<div class="w-full px-1">{props.children}</div>
 					<span class="text-sm xl:hidden">
 						<PageIssueLink />
 					</span>


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description
This PR adds horizontal padding (px-2) to the content container.

In some cases, content near the edges could appear visually clipped. Adding a small horizontal padding ensures content is fully visible, improves readability, and gives the documentation a more polished, professional appearance.

---

<img width="200" alt="image" src="https://github.com/user-attachments/assets/ee2828ba-d2cc-4477-9c78-2f6e904d9e50" />
