### PR TITLE
update broken link to Suspense in lazy.mdx

### DIFF
--- a/src/routes/reference/component-apis/lazy.mdx
+++ b/src/routes/reference/component-apis/lazy.mdx
@@ -92,5 +92,5 @@ const ComponentWithPreload = () => {
 
 ## See also
 
-- [`Suspense`](https://docs.solidjs.com/reference/component-apis/suspense)
+- [`Suspense`](https://docs.solidjs.com/reference/components/suspense)
 - [Router preloading guide](/solid-router/advanced-concepts/preloading)


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
Fixing Copilot's typo from #1306 - the link to the Suspense page in docs was broken

### Related issues & labels

- Suggested label(s) (optional): documentation, solid <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
