### PR TITLE
Add server usage section for user profile query

### DIFF
--- a/src/routes/solid-router/reference/data-apis/query.mdx
+++ b/src/routes/solid-router/reference/data-apis/query.mdx
@@ -101,3 +101,22 @@ const getUserProfileQuery = query(async (userId: string) => {
 	return json;
 }, "userProfile");
 ```
+
+### Server usage
+```tsx
+import { query } from "@solidjs/router";
+
+const getUserProfileQuery = query(async (userId: string) => {
+	"use server";
+
+	const response = await fetch(
+		`https://api.example.com/users/${encodeURIComponent(userId)}`
+	);
+	const json = await response.json();
+
+	if (!response.ok) {
+		throw new Error(json?.message ?? "Failed to load user profile.");
+	}
+
+	return json;
+}, "userProfile");


### PR DESCRIPTION
Added server usage example for user profile query.

<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [ x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

Right now I've experienced some confusion around what makes a `query` run only on the server. I feel an example would've helped my out a ton, and not make the mistake of going with file-level `"use server";`. See issue #2066 on Solid Start. https://github.com/solidjs/solid-start/issues/2066

Be happy to adjust if needed. Thanks!

### Related issues & labels

- Closes / helps: https://github.com/solidjs/solid-start/issues/2066 <!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): documentation <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
