### PR TITLE
Adds note about overriding existing tags

### DIFF
--- a/src/routes/solid-meta/getting-started/installation-and-setup.mdx
+++ b/src/routes/solid-meta/getting-started/installation-and-setup.mdx
@@ -44,6 +44,10 @@ To get started, install using your preferred package manager.
 
 3.  If using Solid on the server with JSX, no additional configuration is required.
 
+:::note[Overriding existing tags]
+If your `index.html` includes a `<head>` tag, Solid-Meta will not overwrite its contents. You can mark individual tags as overwritable by adding an empty `data-sm` attribute to them.
+:::
+
 Here is an example of how your code might look after this setup.
 
 ```js


### PR DESCRIPTION
### Description(required)

Adds a note to the solid-meta docs explaining the undocumented override behavior.

### Related issues & labels

solidjs/solid-meta#18
