### PR TITLE
update untrack.mdx example

### DIFF
--- a/src/routes/reference/reactive-utilities/untrack.mdx
+++ b/src/routes/reference/reactive-utilities/untrack.mdx
@@ -18,13 +18,11 @@ description: >-
 
 Ignores tracking any of the dependencies in the executing code block and returns the value. This helper is useful when a certain `prop` will never update and thus it is ok to use it outside of the tracking scope.
 
-```tsx title="component.tsx"
+```tsx title="component.tsx" {4}
 import { untrack } from "solid-js";
 
 export function Component(props) {
-	const value = untrack(() => props.value);
-
-	return <div>{value}</div>;
+	return <div>{untrack(() => props.value)}</div>;
 }
 ```
 


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [X] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)
The current example shows "const value = untrack(() => props.value)" which is not a recommended pattern especially because the same could be achieved with "const value = props.value" which is also not a recommended pattern as shown in the following link -> https://docs.solidjs.com/concepts/components/props#destructuring-props. The example i propose follows the recommended pattern of accessing the props directly.
<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

### Related issues & labels


- Suggested label(s) (optional): documentation
