### PR TITLE
fix: use `solid` instead of `solid@latest` in SolidStart getting started

### DIFF
--- a/src/routes/solid-start/getting-started.mdx
+++ b/src/routes/solid-start/getting-started.mdx
@@ -24,7 +24,7 @@ This starter contains a collection of templates that can be used to quickly boot
 To start a new project you can initialize SolidStart with the following command:
 
 ```package-create
-solid@latest
+solid
 ```
 
 This will create a new directory for your project based on the name you enter.


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

Updates the `package-create` command in `src/routes/solid-start/getting-started.mdx`
from `solid@latest` to `solid` to avoid the Yarn create issue.

This also matches the existing usage in `src/routes/quick-start.mdx`.

### Related issues & labels

- Closes #1457
