### PR TITLE
fix(session): use @solidjs/start/http instead of vinxi/http

### DIFF
--- a/src/routes/solid-start/advanced/session.mdx
+++ b/src/routes/solid-start/advanced/session.mdx
@@ -68,7 +68,7 @@ The `useSession` helper is the primary way to create and manage sessions.
 It provides a comprehensive interface for all session operations.
 
 ```ts title="src/lib/session.ts"
-import { useSession } from "vinxi/http";
+import { useSession } from "@solidjs/start/http";
 
 type SessionData = {
 	theme: "light" | "dark";


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

The session.mdx example imports `useSession` from `vinxi/http`, but this causes a runtime error in SolidStart v2 default setup (created via CLI).

Changing the import to `@solidjs/start/http` resolves the error.

### Related issues & labels

- Closes #1469
- Suggested label(s): bug
