### PR TITLE
Fix GitHub link unconditionally navigating to Discord

### DIFF
--- a/osmium/src/ui/layout/main-header.tsx
+++ b/osmium/src/ui/layout/main-header.tsx
@@ -113,7 +113,7 @@ export function MainHeader(_props: MainHeaderProps) {
 				<div class="order- flex basis-0 items-center justify-end gap-4 lg:order-2">
 					<ClientSearch />
 					<a
-						href={`${config().themeConfig?.discord}/${project().projects[project().current].path || "solid"}`}
+						href={`${config().themeConfig?.github}/${project().projects[project().current].path || "solid"}`}
 						class="group"
 						aria-label="GitHub"
 						target="_blank"


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description

<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->

The GitHub link in the site header across all pages is unconditionally linking to Discord, not GitHub. More details in the issue, but the gist is it appears to be a regression from a large refactor merged 2 days ago: fef6139dc457914a8aa67eae81f5be6dfc300e1c

All the context was already wired up, it just appears to be using the wrong context field.

Tested locally by smoke testing the link across a few pages and project roots.

### Related issues & labels

- Closes #1482
- Suggested label: `bug`