### PR TITLE
Clarify that onMount/onCleanup are reactive-tree based

### DIFF
--- a/src/routes/reference/lifecycle/on-mount.mdx
+++ b/src/routes/reference/lifecycle/on-mount.mdx
@@ -52,6 +52,14 @@ Non-tracking function executed once on mount.
 - By the time `onMount` runs, refs have already been assigned.
 - Returning a function from `fn` does not register cleanup. Use [`onCleanup`](/reference/lifecycle/on-cleanup) inside `onMount` when cleanup is needed.
 
+:::note
+"Mounted" in Solid refers to when a component is rendered within the reactive tree, not when it is physically inserted into the DOM.
+If you store JSX in a variable before conditionally rendering it, `onMount` runs when that JSX is evaluated, even if the elements have not yet been added to the visible page.
+Similarly, [`onCleanup`](/reference/lifecycle/on-cleanup) runs based on the reactive ownership tree rather than DOM removal.
+
+For cases where you need to detect actual DOM insertion or removal, consider using a [`ref`](/concepts/refs) callback or the [Lifecycle primitives from solid-primitives](https://github.com/solidjs-community/solid-primitives/tree/main/packages/lifecycle).
+:::
+
 ## Examples
 
 ### Access a ref after mount


### PR DESCRIPTION
Users sometimes expect onMount to fire when a component is literally inserted into the DOM, but it actually runs when the component is created within the reactive tree. This distinction matters when JSX is stored in a variable before being conditionally rendered.

I added a note to the onMount reference page explaining:
- The 'mounted' term refers to the reactive tree, not DOM insertion
- onCleanup follows the same pattern
- Links to solid-primitives lifecycle package for DOM-based detection

As Ryan confirmed on the issue, this is by design. The docs should reflect this clearly.

Closes #1167