### PR TITLE
docs: link first component occurrence to reference pages

### DIFF
--- a/src/routes/(0)concepts/(1)control-flow/(0)conditional-rendering.mdx
+++ b/src/routes/(0)concepts/(1)control-flow/(0)conditional-rendering.mdx
@@ -25,7 +25,7 @@ Solid offers dedicated components to handle conditional rendering in a more stra
 
 ## Show
 
-`<Show>` renders its children when a condition is evaluated to be true.
+[`<Show>`](/reference/components/show) renders its children when a condition is evaluated to be true.
 Similar to the [ternary operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator) in JavaScript, it uses control logic flow within JSX to determine what to render.
 
 `<Show>` has a `when` property that is used to determine whether or not to render its children.

--- a/src/routes/(0)concepts/(1)control-flow/(1)list-rendering.mdx
+++ b/src/routes/(0)concepts/(1)control-flow/(1)list-rendering.mdx
@@ -21,7 +21,7 @@ description: >-
 
 List rendering allows you to generate multiple elements from a collection of data, such as an array or object, where each element corresponds to an item in the collection.
 
-When dealing with dynamic data, Solid offers two ways to render lists: the `<For>` and `<Index>` components.
+When dealing with dynamic data, Solid offers two ways to render lists: the [`<For>`](/reference/components/for) and `<Index>` components.
 Both of these components help you loop over data collections to generate elements, however, they both cater to different scenarios.
 
 ## `<For>`

--- a/src/routes/(0)concepts/(1)control-flow/(2)dynamic.mdx
+++ b/src/routes/(0)concepts/(1)control-flow/(2)dynamic.mdx
@@ -18,7 +18,7 @@ description: >-
   flexible UIs with runtime component selection.
 ---
 
-`<Dynamic>` is a Solid component that allows you to render components dynamically based on data.
+[`<Dynamic>`](/reference/components/dynamic) is a Solid component that allows you to render components dynamically based on data.
 By passing either a string representing a [native HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element) or a component function to the `component` prop, you can render the chosen component with the remaining props you provide.
 
 ```jsx

--- a/src/routes/(0)concepts/(1)control-flow/(4)portal.mdx
+++ b/src/routes/(0)concepts/(1)control-flow/(4)portal.mdx
@@ -19,7 +19,7 @@ description: >-
 ---
 
 When an element requires rendering outside of the usual document flow, challenges related to stacking contents and z-index can interfere with the desired intention or look of an application.
-`<Portal>` helps with this by putting elements in a different place in the document, bringing an element into the document flow so they can render as expected.
+[`<Portal>`](/reference/components/portal) helps with this by putting elements in a different place in the document, bringing an element into the document flow so they can render as expected.
 
 ```jsx
 import { Portal } from "solid-js/web";


### PR DESCRIPTION
Closes #745

Each concept page's first inline mention of a Solid component now links to its API reference page, making navigation from concept docs to full API docs easy.

### Pages updated

| Page | Component linked |
|------|-----------------|
| `concepts/control-flow/portal.mdx` | `<Portal>` → [/reference/components/portal](/reference/components/portal) |
| `concepts/control-flow/conditional-rendering.mdx` | `<Show>` → [/reference/components/show](/reference/components/show) |
| `concepts/control-flow/list-rendering.mdx` | `<For>` → [/reference/components/for](/reference/components/for) |
| `concepts/control-flow/dynamic.mdx` | `<Dynamic>` → [/reference/components/dynamic](/reference/components/dynamic) |

Only the **first** plain-text occurrence in each file is linked. Code blocks and already-linked occurrences are unchanged.