### PR TITLE
fix(docs): add missing createEffect and createSignal imports in lifecycle examples

### DIFF
--- a/src/routes/(0)concepts/(3)effects.mdx
+++ b/src/routes/(0)concepts/(3)effects.mdx
@@ -159,7 +159,7 @@ This lifecycle function is similar to an effect, but it does not track any depen
 Rather, once the component has been initialized, the `onMount` callback will be executed and will not run again.
 
 ```jsx
-import { onMount } from "solid-js";
+import { onMount, createEffect, createSignal } from "solid-js";
 
 function Component() {
 	const [data, setData] = createSignal(null);
@@ -188,7 +188,7 @@ While `onMount` is useful for running a side effect once, [`onCleanup`](/referen
 `onCleanup` will run whenever the component unmounts, removing any subscriptions that the effect has.
 
 ```jsx
-import { onCleanup } from "solid-js";
+import { onCleanup, createSignal } from "solid-js";
 
 function App() {
 	const [count, setCount] = createSignal(0);


### PR DESCRIPTION
<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [ ] This PR references an issue (except for typos, broken links, or other minor problems)

### Description

The lifecycle documentation examples for `onMount` and `onCleanup` were missing necessary imports from `"solid-js"`, causing code snippets to be non-functional if copied directly by readers.

Changes made:
- In the `onMount` example: added `createEffect` and `createSignal` to the import statement
- In the `onCleanup` example: added `createSignal` to the import statement
- No logic, prose, or structure was changed — import lines only

This ensures documentation snippets are self-contained and copy-paste ready for developers learning SolidJS lifecycle primitives.

### Related issues & labels

- Closes #<!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): Suggested label(s): `documentation`, `bug`, `fix` <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
