### PR TITLE
Fix 404 error

### DIFF
--- a/osmium/src/Layout.tsx
+++ b/osmium/src/Layout.tsx
@@ -16,12 +16,7 @@ export default function (props: ParentProps) {
 	return (
 		<OsmiumThemeStateProvider>
 			<SidebarProvider config={config().themeConfig?.sidebar}>
-				<ErrorBoundary
-					fallback={(err) => {
-						console.log({ err });
-						return <NotFound />;
-					}}
-				>
+				<ErrorBoundary fallback={() => <NotFound />}>
 					<Layout>{props.children}</Layout>
 				</ErrorBoundary>
 			</SidebarProvider>

--- a/osmium/src/Layout.tsx
+++ b/osmium/src/Layout.tsx
@@ -16,7 +16,12 @@ export default function (props: ParentProps) {
 	return (
 		<OsmiumThemeStateProvider>
 			<SidebarProvider config={config().themeConfig?.sidebar}>
-				<ErrorBoundary fallback={() => <NotFound />}>
+				<ErrorBoundary
+					fallback={(err) => {
+						console.log({ err });
+						return <NotFound />;
+					}}
+				>
 					<Layout>{props.children}</Layout>
 				</ErrorBoundary>
 			</SidebarProvider>

--- a/osmium/src/mdx-components.tsx
+++ b/osmium/src/mdx-components.tsx
@@ -15,6 +15,7 @@ import { Tabs, TabList, TabPanel, Tab } from "./ui/tabs";
 
 export { Callout } from "./ui/callout";
 export { QuickLinks } from "./ui/quick-links";
+export { ImageLink } from "./ui/image-link";
 
 const EraserLinkImpl = clientOnly(() => import("./ui/eraser-link"));
 

--- a/osmium/src/ui/image-link.tsx
+++ b/osmium/src/ui/image-link.tsx
@@ -24,13 +24,13 @@ export const logos: { [key: string]: { file: string; style?: string } } = {
 	uno: { file: "uno.svg" },
 };
 
-export type ImageLinksProps = {
+export type ImageLinkProps = {
 	title: string;
 	logo: keyof typeof logos;
 	href: string;
 };
 
-export const ImageLink: ParentComponent<ImageLinksProps> = (props) => {
+export const ImageLink: ParentComponent<ImageLinkProps> = (props) => {
 	const locale = useLocale();
 
 	const logoImage = untrack(() => props.logo);

--- a/src/routes/(2)guides/(0)styling-your-components.mdx
+++ b/src/routes/(2)guides/(0)styling-your-components.mdx
@@ -25,8 +25,8 @@ Solid also supports a range of styling methods - from traditional CSS preprocess
 
 <div class="flex flex-col md:grid md:grid-cols-2 md:grid-rows-1  gap-3">
 
-<ImageLinks title="SASS" href="/guides/styling-components/sass" logo="sass" />
-<ImageLinks title="LESS" href="/guides/styling-components/less" logo="less" />
+<ImageLink title="SASS" href="/guides/styling-components/sass" logo="sass" />
+<ImageLink title="LESS" href="/guides/styling-components/less" logo="less" />
 
 </div>
 
@@ -35,7 +35,7 @@ LESS
 
 ## CSS modules
 
-<ImageLinks
+<ImageLink
 	title="CSS Modules"
 	href="/guides/styling-components/css-modules"
 	logo="cssmodules"
@@ -56,7 +56,7 @@ Many also offer features like theming, media queries, and server-side rendering 
 
 ### Macaron
 
-<ImageLinks
+<ImageLink
 	title="Macaron"
 	href="/guides/styling-components/macaron"
 	logo="macaron"
@@ -67,11 +67,11 @@ CSS frameworks provide pre-styled components and utility classes to speed up dev
 
 <div class="flex flex-col md:grid md:grid-cols-2 md:grid-rows-1  gap-3">
 
-<ImageLinks
+<ImageLink
 	title="Tailwind CSS"
 	href="/guides/styling-components/tailwind"
 	logo="tailwind"
 />
-<ImageLinks title="UnoCSS" href="/guides/styling-components/uno" logo="uno" />
+<ImageLink title="UnoCSS" href="/guides/styling-components/uno" logo="uno" />
 
 </div>

--- a/src/routes/(2)guides/(6)deploying-your-app.mdx
+++ b/src/routes/(2)guides/(6)deploying-your-app.mdx
@@ -15,8 +15,6 @@ description: >-
   Cloudflare, Vercel, Netlify, AWS, and more with guides.
 ---
 
-import { ImageLink } from "~/components/ImageLink";
-
 Are you ready to deploy your Solid application? Follow our guides for different deployment services.
 
 <div class="flex flex-col md:grid md:grid-cols-4 md:grid-rows-2  gap-3">

--- a/src/routes/reference/jsx-attributes/classlist.mdx
+++ b/src/routes/reference/jsx-attributes/classlist.mdx
@@ -14,7 +14,7 @@ description: >-
   Toggle element classes from an object of class names and boolean values.
 ---
 
-:::warning
+:::caution
 `className` was deprecated in Solid 1.4 in favor of `class`.
 :::
 


### PR DESCRIPTION
This PR fixes two 404 errors that happened for different reasons.

#1524: The `<ImageLinks>` component was not defined properly. I think it was created during the transaction to the osmium theme. I'm not familiar with that theme and not sure if that's a bug on their side. The most reasonable fix was to move it to the `osmium/src/ui/image-link.tsx` file and export it from the `mdx-components.ts` file.
#1546 and #1472: We don't have a `warning` callout. Changed it to `caution`.

Closes #1546
Closes #1524
Closes #1472
