### PR TITLE
fix: SolidStart v2 routing: sidebar and inline links

### DIFF
--- a/src/routes/solid-start/v2/(0)building-your-application/(0)routing.mdx
+++ b/src/routes/solid-start/v2/(0)building-your-application/(0)routing.mdx
@@ -27,7 +27,7 @@ There are two route shapes:
 - Files with a default export become UI routes.
 - Files that export HTTP method names such as `GET` or `POST` become API routes.
 
-You can read more about handler exports in [API routes](/v2/solid-start/building-your-application/api-routes).
+You can read more about handler exports in [API routes](/solid-start/v2/building-your-application/api-routes).
 
 ## Basic filename mapping
 

--- a/src/routes/solid-start/v2/(0)building-your-application/(1)api-routes.mdx
+++ b/src/routes/solid-start/v2/(0)building-your-application/(1)api-routes.mdx
@@ -17,7 +17,7 @@ description: >-
 
 Use an API route when you need a route that returns data or handles incoming HTTP requests instead of rendering page UI.
 
-A file becomes an API route when it exports one or more HTTP method names such as [`GET`](/v2/solid-start/reference/server/get), `POST`, `PATCH`, or `DELETE`.
+A file becomes an API route when it exports one or more HTTP method names such as [`GET`](/solid-start/v2/reference/server/get), `POST`, `PATCH`, or `DELETE`.
 
 ## Create an API route
 
@@ -87,4 +87,4 @@ API routes are a good fit when you need:
 - auth callback handlers
 - routes that return non-HTML responses
 
-If the data is only needed by your route UI, prefer [Data fetching](/v2/solid-start/building-your-application/data-fetching) or [Data mutation](/v2/solid-start/building-your-application/data-mutation) before introducing a separate API boundary.
+If the data is only needed by your route UI, prefer [Data fetching](/solid-start/v2/building-your-application/data-fetching) or [Data mutation](/solid-start/v2/building-your-application/data-mutation) before introducing a separate API boundary.

--- a/src/routes/solid-start/v2/(0)building-your-application/(4)data-mutation.mdx
+++ b/src/routes/solid-start/v2/(0)building-your-application/(4)data-mutation.mdx
@@ -16,7 +16,7 @@ description: >-
 ---
 
 Mutations run through Solid Router's [`action`](/solid-router/reference/data-apis/action) API.
-When a mutation must run on the server, place the [`"use server"`](/v2/solid-start/reference/server/use-server) directive inside the action body.
+When a mutation must run on the server, place the [`"use server"`](/solid-start/v2/reference/server/use-server) directive inside the action body.
 
 ## Handle form submissions with actions
 
@@ -109,4 +109,4 @@ export default function ProjectPage(props: { params: { id: string } }) {
 When a mutation changes data that is also loaded by a route `query`, keep the read path and write path close together.
 That makes it easier to reason about revalidation behavior through the Solid Router data APIs.
 
-Read this page together with [Data fetching](/v2/solid-start/building-your-application/data-fetching).
+Read this page together with [Data fetching](/solid-start/v2/building-your-application/data-fetching).

--- a/src/routes/solid-start/v2/(0)index.mdx
+++ b/src/routes/solid-start/v2/(0)index.mdx
@@ -39,4 +39,4 @@ The core model carries over from v1:
 
 Configuration moved from `app.config.ts` to `vite.config.ts` through `solidStart()`.
 
-If you are upgrading an existing app, start with the [migration guide](/v2/solid-start/migrating-from-v1).
+If you are upgrading an existing app, start with the [migration guide](/solid-start/v2/migrating-from-v1).

--- a/src/routes/solid-start/v2/(1)advanced/(4)serialization.mdx
+++ b/src/routes/solid-start/v2/(1)advanced/(4)serialization.mdx
@@ -56,5 +56,5 @@ Because these values are transferred directly, this can yield smaller payloads f
 
 ## Related
 
-- [Data fetching](/v2/solid-start/building-your-application/data-fetching)
-- [Data mutation](/v2/solid-start/building-your-application/data-mutation)
+- [Data fetching](/solid-start/v2/building-your-application/data-fetching)
+- [Data mutation](/solid-start/v2/building-your-application/data-mutation)

--- a/src/routes/solid-start/v2/(1)getting-started.mdx
+++ b/src/routes/solid-start/v2/(1)getting-started.mdx
@@ -73,7 +73,7 @@ For example:
 - `src/routes/about.tsx` becomes `/about`
 - `src/routes/api/ping.ts` can expose `/api/ping`
 
-Read [Routing](/v2/solid-start/building-your-application/routing) next if you want the exact filename conventions.
+Read [Routing](/solid-start/v2/building-your-application/routing) next if you want the exact filename conventions.
 
 ## Type support
 
@@ -88,4 +88,4 @@ Add it to your TypeScript config if your template has not already done so.
 }
 ```
 
-If you are migrating an existing app instead of creating a new one, continue with [Migrating from v1](/v2/solid-start/migrating-from-v1).
+If you are migrating an existing app instead of creating a new one, continue with [Migrating from v1](/solid-start/v2/migrating-from-v1).

--- a/src/routes/solid-start/v2/reference/client/client-only.mdx
+++ b/src/routes/solid-start/v2/reference/client/client-only.mdx
@@ -72,4 +72,4 @@ export default function Page() {
 
 ## Related
 
-- [Routing](/v2/solid-start/building-your-application/routing)
+- [Routing](/solid-start/v2/building-your-application/routing)

--- a/src/routes/solid-start/v2/reference/routing/file-routes.mdx
+++ b/src/routes/solid-start/v2/reference/routing/file-routes.mdx
@@ -60,4 +60,4 @@ export default function App() {
 
 ## Related
 
-- [Routing](/v2/solid-start/building-your-application/routing)
+- [Routing](/solid-start/v2/building-your-application/routing)

--- a/src/routes/solid-start/v2/reference/server/create-middleware.mdx
+++ b/src/routes/solid-start/v2/reference/server/create-middleware.mdx
@@ -65,4 +65,4 @@ export default createMiddleware([
 
 ## Related
 
-- [API routes](/v2/solid-start/building-your-application/api-routes)
+- [API routes](/solid-start/v2/building-your-application/api-routes)

--- a/src/routes/solid-start/v2/reference/server/get-server-function-meta.mdx
+++ b/src/routes/solid-start/v2/reference/server/get-server-function-meta.mdx
@@ -55,4 +55,4 @@ const meta = getServerFunctionMeta();
 
 ## Related
 
-- [`"use server"`](/v2/solid-start/reference/server/use-server)
+- [`"use server"`](/solid-start/v2/reference/server/use-server)

--- a/src/routes/solid-start/v2/reference/server/get.mdx
+++ b/src/routes/solid-start/v2/reference/server/get.mdx
@@ -58,4 +58,4 @@ const handler = GET(getMessage);
 
 ## Related
 
-- [Data fetching](/v2/solid-start/building-your-application/data-fetching)
+- [Data fetching](/solid-start/v2/building-your-application/data-fetching)

--- a/src/routes/solid-start/v2/reference/server/use-server.mdx
+++ b/src/routes/solid-start/v2/reference/server/use-server.mdx
@@ -73,4 +73,4 @@ export const logMessage = query(async (message: string) => {
 
 ## Related
 
-- [`getServerFunctionMeta`](/v2/solid-start/reference/server/get-server-function-meta)
+- [`getServerFunctionMeta`](/solid-start/v2/reference/server/get-server-function-meta)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -97,7 +97,11 @@ export default defineConfig({
 					themeConfig: {
 						sidebar: {
 							"/solid-start": createFilesystemSidebar(
-								"./src/routes/solid-start"
+								"./src/routes/solid-start",
+								{
+									filter: (item) =>
+										!item.filePath.includes("/solid-start/v2"),
+								}
 							),
 						},
 					},
@@ -108,7 +112,7 @@ export default defineConfig({
 					title: "SolidStart",
 					themeConfig: {
 						sidebar: {
-							"/v2/solid-start": createFilesystemSidebar(
+							"/solid-start/v2": createFilesystemSidebar(
 								"./src/routes/solid-start/v2"
 							),
 						},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -99,8 +99,7 @@ export default defineConfig({
 							"/solid-start": createFilesystemSidebar(
 								"./src/routes/solid-start",
 								{
-									filter: (item) =>
-										!item.filePath.includes("/solid-start/v2"),
+									filter: (item) => !item.filePath.includes("/solid-start/v2"),
 								}
 							),
 						},


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

Three routing bugs affecting the SolidStart v2 documentation:

1. The `start, latest` sidebar was built without a filter, causing the `v2/` subdirectory to appear as a collapsible "V2" section in the Latest SolidStart navigation.
2. The `start, v2` sidebar was registered under the wrong key (`/v2/solid-start` instead of `/solid-start/v2`), producing broken prev/next navigation links on v2 pages.
3. All inline cross-links in 12 v2 MDX files used the wrong URL pattern (`/v2/solid-start/...` instead of `/solid-start/v2/...`), resulting in 404s.

### Related issues & labels

- Closes #1569
- Suggested label(s): bug