### PR TITLE
fix: Highlight active version in version selector dropdown

### DIFF
--- a/osmium/src/ui/layout/version-selector.tsx
+++ b/osmium/src/ui/layout/version-selector.tsx
@@ -68,7 +68,7 @@ export default function VersionSelector() {
 
 									return (
 										<a
-											class="group flex cursor-pointer items-center rounded-[0.625rem] p-1 select-none hover:bg-slate-200 focus:bg-slate-200 focus:font-medium focus:outline-hidden hover:dark:bg-slate-600 focus:dark:bg-slate-700"
+											class="group flex cursor-pointer items-center rounded-[0.625rem] p-1 select-none hover:bg-slate-200 focus-visible:bg-slate-200 focus-visible:font-medium focus-visible:outline-hidden hover:dark:bg-slate-600 focus-visible:dark:bg-slate-700 aria-[current]:bg-blue-50 dark:aria-[current]:bg-blue-900/30"
 											target={outbound() ? "_blank" : undefined}
 											rel={outbound() ? "noopener noreferrer" : undefined}
 											aria-current={option === currentOption() || undefined}

--- a/osmium/src/ui/layout/version-selector.tsx
+++ b/osmium/src/ui/layout/version-selector.tsx
@@ -68,7 +68,7 @@ export default function VersionSelector() {
 
 									return (
 										<a
-											class="group flex cursor-pointer items-center rounded-[0.625rem] p-1 select-none hover:bg-slate-200 focus-visible:bg-slate-200 focus-visible:font-medium focus-visible:outline-hidden hover:dark:bg-slate-600 focus-visible:dark:bg-slate-700 aria-[current]:bg-blue-50 dark:aria-[current]:bg-blue-900/30"
+											class="group flex cursor-pointer items-center rounded-[0.625rem] p-1 select-none hover:bg-slate-200 focus-visible:bg-slate-200 focus-visible:font-medium focus-visible:outline-hidden aria-[current]:bg-blue-50 hover:dark:bg-slate-600 focus-visible:dark:bg-slate-700 dark:aria-[current]:bg-blue-900/30"
 											target={outbound() ? "_blank" : undefined}
 											rel={outbound() ? "noopener noreferrer" : undefined}
 											aria-current={option === currentOption() || undefined}


### PR DESCRIPTION
- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

The version selector dropdown was auto-focusing the first item ("Latest") when opened, giving it a focus background — making it appear selected regardless of the current version. Meanwhile, the `aria-current` attribute on the actual active item had no visual styling applied.

This fix:
- Changes `focus:` to `focus-visible:` on dropdown items so programmatic/auto-focus no longer triggers the background highlight
- Adds `aria-[current]:bg-blue-50` / `dark:aria-[current]:bg-blue-900/30` to visually highlight the active version

### Related issues & labels

- Closes #1571
- Suggested label(s): bug