### PR TITLE
Add Start v1 coverage to Start v2

### DIFF
--- a/osmium/src/index.ts
+++ b/osmium/src/index.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from "node:url";
 
 export interface OsmiumThemeConfig {
 	sidebar?: SidebarConfig;
-	versionLabels?: Record<string, string>;
 	reportPagePath?: string;
 	missingPagePath?: string;
 	discord?: string;

--- a/osmium/src/index.ts
+++ b/osmium/src/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 
 export interface OsmiumThemeConfig {
 	sidebar?: SidebarConfig;
+	versionLabels?: Record<string, string>;
 	reportPagePath?: string;
 	missingPagePath?: string;
 	discord?: string;

--- a/osmium/src/ui/layout/version-selector.tsx
+++ b/osmium/src/ui/layout/version-selector.tsx
@@ -23,9 +23,10 @@ export default function VersionSelector() {
 	);
 
 	const getOptionLabel = (option: SolidBaseRouteOption) => {
-		return typeof option.meta.label === "string"
-			? option.meta.label
-			: option.name;
+		return (
+			config().themeConfig?.versionLabels?.[option.name] ??
+			(typeof option.meta.label === "string" ? option.meta.label : option.name)
+		);
 	};
 
 	return (

--- a/osmium/src/ui/layout/version-selector.tsx
+++ b/osmium/src/ui/layout/version-selector.tsx
@@ -23,10 +23,9 @@ export default function VersionSelector() {
 	);
 
 	const getOptionLabel = (option: SolidBaseRouteOption) => {
-		return (
-			config().themeConfig?.versionLabels?.[option.name] ??
-			(typeof option.meta.label === "string" ? option.meta.label : option.name)
-		);
+		return typeof option.meta.label === "string"
+			? option.meta.label
+			: option.name;
 	};
 
 	return (

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
 		"@kobalte/solidbase": "catalog:",
 		"@solidjs/meta": "^0.29.4",
 		"@solidjs/router": "^0.16.1",
-		"@solidjs/start": "https://pkg.pr.new/solidjs/solid-start/@solidjs/start@2080",
+		"@solidjs/start": "2.0.0-rc.1",
 		"@tailwindcss/vite": "^4.3.0",
 		"dotenv": "^17.3.1",
-		"nitro": "v3.0.260429-beta",
+		"nitro": "^3.0.260610-beta",
 		"resolve": "1.22.12",
 		"solid-heroicons": "^3.2.4",
 		"solid-js": "1.9.12",
@@ -51,7 +51,7 @@
 		"typescript-eslint": "^8.54.0"
 	},
 	"overrides": {
-		"@solidjs/start": "https://pkg.pr.new/solidjs/solid-start/@solidjs/start@2080"
+		"@solidjs/start": "2.0.0-rc.1"
 	},
 	"engines": {
 		"node": ">=24",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@kobalte/solidbase": "catalog:",
 		"@solidjs/meta": "^0.29.4",
 		"@solidjs/router": "^0.16.1",
-		"@solidjs/start": "2.0.0-rc.1",
+		"@solidjs/start": "2.0.0-rc.5",
 		"@tailwindcss/vite": "^4.3.0",
 		"dotenv": "^17.3.1",
 		"nitro": "^3.0.260610-beta",
@@ -51,7 +51,7 @@
 		"typescript-eslint": "^8.54.0"
 	},
 	"overrides": {
-		"@solidjs/start": "2.0.0-rc.1"
+		"@solidjs/start": "2.0.0-rc.5"
 	},
 	"engines": {
 		"node": ">=24",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@kobalte/solidbase": "catalog:",
 		"@solidjs/meta": "^0.29.4",
 		"@solidjs/router": "^0.16.1",
-		"@solidjs/start": "2.0.0-rc.5",
+		"@solidjs/start": "2.0.0-rc.1",
 		"@tailwindcss/vite": "^4.3.0",
 		"dotenv": "^17.3.1",
 		"nitro": "^3.0.260610-beta",
@@ -51,7 +51,7 @@
 		"typescript-eslint": "^8.54.0"
 	},
 	"overrides": {
-		"@solidjs/start": "2.0.0-rc.5"
+		"@solidjs/start": "2.0.0-rc.1"
 	},
 	"engines": {
 		"node": ">=24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 0.13.11(solid-js@1.9.12)
       "@kobalte/solidbase":
         specifier: "catalog:"
-        version: 0.6.4(@solidjs/start@https://pkg.pr.new/solidjs/solid-start/@solidjs/start@2080(crossws@0.4.5(srvx@0.11.15))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.6.4(@solidjs/start@2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       "@solidjs/meta":
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.9.12)
@@ -29,8 +29,8 @@ importers:
         specifier: ^0.16.1
         version: 0.16.1(solid-js@1.9.12)
       "@solidjs/start":
-        specifier: https://pkg.pr.new/solidjs/solid-start/@solidjs/start@2080
-        version: https://pkg.pr.new/solidjs/solid-start/@solidjs/start@2080(crossws@0.4.5(srvx@0.11.15))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       "@tailwindcss/vite":
         specifier: ^4.3.0
         version: 4.3.1(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
@@ -38,8 +38,8 @@ importers:
         specifier: ^17.3.1
         version: 17.4.2
       nitro:
-        specifier: v3.0.260429-beta
-        version: 3.0.260429-beta(dotenv@17.4.2)(jiti@2.7.0)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        specifier: ^3.0.260610-beta
+        version: 3.0.260610-beta(dotenv@17.4.2)(jiti@2.7.0)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       resolve:
         specifier: 1.22.12
         version: 1.22.12
@@ -121,7 +121,7 @@ importers:
         version: 0.13.11(solid-js@1.9.12)
       "@kobalte/solidbase":
         specifier: "catalog:"
-        version: 0.6.4(@solidjs/start@https://pkg.pr.new/solidjs/solid-start/@solidjs/start@2080(crossws@0.4.5(srvx@0.11.15))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.6.4(@solidjs/start@2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       "@kobalte/tailwindcss":
         specifier: ^0.9.0
         version: 0.9.0(tailwindcss@4.3.1)
@@ -335,34 +335,16 @@ packages:
         integrity: sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==,
       }
 
-  "@emnapi/core@1.10.0":
-    resolution:
-      {
-        integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
-      }
-
   "@emnapi/core@1.11.1":
     resolution:
       {
         integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==,
       }
 
-  "@emnapi/runtime@1.10.0":
-    resolution:
-      {
-        integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
-      }
-
   "@emnapi/runtime@1.11.1":
     resolution:
       {
         integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==,
-      }
-
-  "@emnapi/wasi-threads@1.2.1":
-    resolution:
-      {
-        integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
       }
 
   "@emnapi/wasi-threads@1.2.2":
@@ -855,7 +837,6 @@ packages:
       {
         integrity: sha512-qW7rVdM1OyGF2UrQ1P5TkAW8LNlLsgsJCpf+XiNUVM0tdeVA8OTdBgSdmDx6fJy+URBrK4n28DUPSdJVzXk3jA==,
       }
-    version: 0.6.4
     engines: { node: ">=22" }
     peerDependencies:
       "@solidjs/start": ^2.0.0
@@ -883,15 +864,6 @@ packages:
       {
         integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==,
       }
-
-  "@napi-rs/wasm-runtime@1.1.4":
-    resolution:
-      {
-        integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==,
-      }
-    peerDependencies:
-      "@emnapi/core": ^1.7.1
-      "@emnapi/runtime": ^1.7.1
 
   "@napi-rs/wasm-runtime@1.1.6":
     resolution:
@@ -954,11 +926,192 @@ packages:
         integrity: sha512-yAuSwog+HQBAXgZ60TNKEwu04y81/09mpbYBCmz1RCxnr4ObNY2JnPZI7HmALbjAhLJ8t5p+wc2JHRK93ubO4w==,
       }
 
-  "@oxc-project/types@0.128.0":
+  "@oxc-parser/binding-android-arm-eabi@0.139.0":
     resolution:
       {
-        integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==,
+        integrity: sha512-22EsXTA3Vc7OvrF4bfT48PFln2UbxkVgrp/Tm32qLw76Dv7SmcInfClJe6yPYamnli6HiqasnESZ5ezN+X4ybg==,
       }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [android]
+
+  "@oxc-parser/binding-android-arm64@0.139.0":
+    resolution:
+      {
+        integrity: sha512-uASQkZV+CUQ6xXvoMzDQyfhd8OMusdv2FyCPfAi5ZDYptesapJlw7erhpGi1Lc+U8QjQV2JUrIh7d/3su2LzmQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  "@oxc-parser/binding-darwin-arm64@0.139.0":
+    resolution:
+      {
+        integrity: sha512-vuQOv2WF5pZCkdSPEExul98o853M3MCR24DpWsGrUoPJu5KcnGE34kLXY2yFwBwZwT+eN1x40Tt4q6ZzlEdNUA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@oxc-parser/binding-darwin-x64@0.139.0":
+    resolution:
+      {
+        integrity: sha512-zxZB8ChS+7XactZhcyxQ292P/DNiiBaPPKYiVUlb3RC0V/hme5bokNubjcmEmbW9uTfmqLTpveAdkbe66H3pGg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  "@oxc-parser/binding-freebsd-x64@0.139.0":
+    resolution:
+      {
+        integrity: sha512-iw2MsoCPBQwdJqywRAGsF1jEAcGoZ+DeG2LVzt5pdUvRHqajsMF46BH0rHiWoWtMwcMSia+oQYga7fHo7u7Bcw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.139.0":
+    resolution:
+      {
+        integrity: sha512-SwjD/k3Y5bwGJWOH313VyaDrAuaYg1Pe+4AAXCgUKvSO5IHkj+mZ0oFcOWmB5nTuOM3uwdT+leL8h4OnFlI5hw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm-musleabihf@0.139.0":
+    resolution:
+      {
+        integrity: sha512-qbeygDkcvailKFhphb2YGMMXsaZIynHlPtoOrcx4NZB/tRbUKraCCMbw8dPeFtEKasfS2qWh1VnReY+Lcys1zA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm64-gnu@0.139.0":
+    resolution:
+      {
+        integrity: sha512-SrlL02KeImKlvx/9rCeopOLH7qKI3rqKKEguK6KBwVwEGLhV/A47dW4DNigf6/LFhrwoovaiayEQryjYAI86dQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-arm64-musl@0.139.0":
+    resolution:
+      {
+        integrity: sha512-u9e884ChAVRmIZ1jr/m46S96FoDQnruFjISLi4Y0i6Wu/JUUmIiw7+umLyXILJsPfUuqnN5BJLe23t07+Y6+IA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-linux-ppc64-gnu@0.139.0":
+    resolution:
+      {
+        integrity: sha512-Z9tU2b3GJfAXOdirQmz4gZQkQkVjy53i77gf91l0733MQKa/qtk73KQQE2GzDtMqim+HyjpzvemmqzBtH2IJUA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-riscv64-gnu@0.139.0":
+    resolution:
+      {
+        integrity: sha512-RyUbr7hzPK84YDWKs77PRYk9VBwWbsbuYsQzQWiSmLnARXTg2zntLPGfCH/1wpfUYdmGkp/6SsqTXSsYdw9Jgw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-riscv64-musl@0.139.0":
+    resolution:
+      {
+        integrity: sha512-dcQhjtcDvtR8BgkUpt03Yz5SzxdzYvTigenIJOEsiSX6G2t6yybEMxGWjp0dOuYGror0BaqcZfTyXR58amCEig==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-linux-s390x-gnu@0.139.0":
+    resolution:
+      {
+        integrity: sha512-iuGrxysV4rGUymdKpn7bgZQ6Vix8Bi/6D/rp71HYIzphq6NKrsBhsGOYsSZte+uBFL43tXh7Xr7TM72sGliJNA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-x64-gnu@0.139.0":
+    resolution:
+      {
+        integrity: sha512-NxJdZZyaa2JLLvNfH/iJQXfCNfKcPMylwY4ObMpBVmW4Nq+RyUpVVQXrMMelcQ6rwx3nuhF1Iga8n+eoAKGCIA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-x64-musl@0.139.0":
+    resolution:
+      {
+        integrity: sha512-ePxBvvtzISmSsJ0RIj8FNikSCn58i1jtccj7XR4U9Li4iSzhkFyYlnJ51cQTUwkairz8WMTD4SpKoot8RyTnQA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-openharmony-arm64@0.139.0":
+    resolution:
+      {
+        integrity: sha512-b/c2+mPXMOxG5x16n8yf9cjor/ntQQScmYnSmLEWIWJ4rfXd5dokMxx0kliSLA+YAGq6DD3K9BWi+aFXHiiV1w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@oxc-parser/binding-wasm32-wasi@0.139.0":
+    resolution:
+      {
+        integrity: sha512-rNU0pO+/CVPC2qZ+xtX5R2cOje9Q75q3UkfgwUCPlplqxMv6Iffd5tMPGVMCLGnPINxPlmi0WPsW94HltbYvfQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [wasm32]
+
+  "@oxc-parser/binding-win32-arm64-msvc@0.139.0":
+    resolution:
+      {
+        integrity: sha512-JPEmfncZfqAFiGsAN6UZSMIBqnG8wn8buywRacFOWjP+9dZwcs03SsBp4tmyjM/4l/VoH/IuThrW1Jof3OyQUw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@oxc-parser/binding-win32-ia32-msvc@0.139.0":
+    resolution:
+      {
+        integrity: sha512-c06dWBwEnFHof5JN7T9/ts23uATXS9czPEBO60d4xnjH2Am29Bo7OGKdVHRmcWQnw0OBxlTg9fIEXAvtcwOBfw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ia32]
+    os: [win32]
+
+  "@oxc-parser/binding-win32-x64-msvc@0.139.0":
+    resolution:
+      {
+        integrity: sha512-bI3/44urQjW/D495JPXe+c9d+4Q+ONi3DvDNnzwRZYTWHZ3hAlFdmirYK4mzhTfCZiAly02EbMYir7QGU+9O2Q==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
 
   "@oxc-project/types@0.137.0":
     resolution:
@@ -966,14 +1119,11 @@ packages:
         integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==,
       }
 
-  "@rolldown/binding-android-arm64@1.0.0-rc.18":
+  "@oxc-project/types@0.139.0":
     resolution:
       {
-        integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==,
+        integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==,
       }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm64]
-    os: [android]
 
   "@rolldown/binding-android-arm64@1.1.3":
     resolution:
@@ -984,15 +1134,6 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  "@rolldown/binding-darwin-arm64@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm64]
-    os: [darwin]
-
   "@rolldown/binding-darwin-arm64@1.1.3":
     resolution:
       {
@@ -1000,15 +1141,6 @@ packages:
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
-    os: [darwin]
-
-  "@rolldown/binding-darwin-x64@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [x64]
     os: [darwin]
 
   "@rolldown/binding-darwin-x64@1.1.3":
@@ -1020,15 +1152,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  "@rolldown/binding-freebsd-x64@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [x64]
-    os: [freebsd]
-
   "@rolldown/binding-freebsd-x64@1.1.3":
     resolution:
       {
@@ -1038,15 +1161,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm]
-    os: [linux]
-
   "@rolldown/binding-linux-arm-gnueabihf@1.1.3":
     resolution:
       {
@@ -1055,16 +1169,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
-
-  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   "@rolldown/binding-linux-arm64-gnu@1.1.3":
     resolution:
@@ -1076,16 +1180,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   "@rolldown/binding-linux-arm64-musl@1.1.3":
     resolution:
       {
@@ -1096,16 +1190,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   "@rolldown/binding-linux-ppc64-gnu@1.1.3":
     resolution:
       {
@@ -1113,16 +1197,6 @@ packages:
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -1136,16 +1210,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   "@rolldown/binding-linux-x64-gnu@1.1.3":
     resolution:
       {
@@ -1155,16 +1219,6 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  "@rolldown/binding-linux-x64-musl@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   "@rolldown/binding-linux-x64-musl@1.1.3":
     resolution:
@@ -1176,15 +1230,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  "@rolldown/binding-openharmony-arm64@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm64]
-    os: [openharmony]
-
   "@rolldown/binding-openharmony-arm64@1.1.3":
     resolution:
       {
@@ -1194,14 +1239,6 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [wasm32]
-
   "@rolldown/binding-wasm32-wasi@1.1.3":
     resolution:
       {
@@ -1209,15 +1246,6 @@ packages:
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [wasm32]
-
-  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm64]
-    os: [win32]
 
   "@rolldown/binding-win32-arm64-msvc@1.1.3":
     resolution:
@@ -1228,15 +1256,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [x64]
-    os: [win32]
-
   "@rolldown/binding-win32-x64-msvc@1.1.3":
     resolution:
       {
@@ -1245,12 +1264,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [win32]
-
-  "@rolldown/pluginutils@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==,
-      }
 
   "@rolldown/pluginutils@1.0.1":
     resolution:
@@ -1519,16 +1532,14 @@ packages:
     peerDependencies:
       solid-js: ^1.8.6
 
-  "@solidjs/start@https://pkg.pr.new/solidjs/solid-start/@solidjs/start@2080":
+  "@solidjs/start@2.0.0-rc.1":
     resolution:
       {
-        integrity: sha512-gpqlCmgEBL/FbGoiiaYKUPz03un2YLog7MT7cvM0hRgXH4iG/JEzKpsGVkS0+QyRDtEgBB4qGB9BKJndGcTrWA==,
-        tarball: https://pkg.pr.new/solidjs/solid-start/@solidjs/start@2080,
+        integrity: sha512-T+rVcD4Si6wyUsgwpxka8pGph8OLrIrxWK7wb4b/JyLDaCrx+q6dxTJ3TxCljCgw58NWY+grmGllEgAcTm783g==,
       }
-    version: 2.0.0-alpha.2
-    engines: { node: ">=22" }
+    engines: { node: ">=24" }
     peerDependencies:
-      vite: ^7
+      vite: ^8 || ^9
 
   "@swc/helpers@0.5.21":
     resolution:
@@ -1682,12 +1693,6 @@ packages:
       }
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
-
-  "@tybys/wasm-util@0.10.2":
-    resolution:
-      {
-        integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==,
-      }
 
   "@tybys/wasm-util@0.10.3":
     resolution:
@@ -2179,10 +2184,10 @@ packages:
       }
     engines: { node: ">= 8" }
 
-  crossws@0.4.5:
+  crossws@0.4.10:
     resolution:
       {
-        integrity: sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA==,
+        integrity: sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==,
       }
     peerDependencies:
       srvx: ">=0.11.5"
@@ -2378,19 +2383,25 @@ packages:
       }
     engines: { node: ">=0.12" }
 
-  env-runner@0.1.7:
+  env-runner@0.1.16:
     resolution:
       {
-        integrity: sha512-i7h96jxETJYhXy5grgHNJ9xNzCzWIn9Ck/VkkYgOlE4gOqknsLX3CmlVb5LmwNex8sOoLFVZLz+TIw/+b5rktA==,
+        integrity: sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA==,
       }
     hasBin: true
     peerDependencies:
-      "@netlify/runtime": ^4
-      miniflare: ^4.20260317.3
+      "@netlify/runtime": ^4.1.23
+      "@vercel/queue": ">=0.2.0"
+      miniflare: ^4.20260515.0
+      wrangler: ^4.0.0
     peerDependenciesMeta:
       "@netlify/runtime":
         optional: true
+      "@vercel/queue":
+        optional: true
       miniflare:
+        optional: true
+      wrangler:
         optional: true
 
   error-stack-parser@2.1.4:
@@ -2405,12 +2416,6 @@ packages:
         integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
       }
     engines: { node: ">= 0.4" }
-
-  es-module-lexer@2.1.0:
-    resolution:
-      {
-        integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
-      }
 
   esast-util-from-estree@2.0.0:
     resolution:
@@ -2604,12 +2609,6 @@ packages:
         integrity: sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA==,
       }
 
-  exsolve@1.0.8:
-    resolution:
-      {
-        integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==,
-      }
-
   exsolve@1.1.0:
     resolution:
       {
@@ -2780,19 +2779,6 @@ packages:
       }
     engines: { node: ">=6.0" }
 
-  h3@2.0.1-rc.16:
-    resolution:
-      {
-        integrity: sha512-h+pjvyujdo9way8qj6FUbhaQcHlR8FEq65EhTX9ViT5pK8aLj68uFl4hBkF+hsTJAH+H1END2Yv6hTIsabGfag==,
-      }
-    engines: { node: ">=20.11.1" }
-    hasBin: true
-    peerDependencies:
-      crossws: ^0.4.1
-    peerDependenciesMeta:
-      crossws:
-        optional: true
-
   h3@2.0.1-rc.22:
     resolution:
       {
@@ -2802,6 +2788,19 @@ packages:
     hasBin: true
     peerDependencies:
       crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
+  h3@2.0.1-rc.25:
+    resolution:
+      {
+        integrity: sha512-uIK++Up28xDt4n0+bSWfVssRivNXpUmMmA6CCiK6j9+utLcBMcFK97Gn9PlSZwAPW9oLy3CjGJ4ag40CY9YYtQ==,
+      }
+    engines: { node: ">=20.11.1" }
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.9
     peerDependenciesMeta:
       crossws:
         optional: true
@@ -2940,10 +2939,10 @@ packages:
         integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==,
       }
 
-  httpxy@0.5.1:
+  httpxy@0.5.5:
     resolution:
       {
-        integrity: sha512-JPhqYiixe1A1I+MXDewWDZqeudBGU8Q9jCHYN8ML+779RQzLjTi78HBvWz4jMxUD6h2/vUL12g4q/mFM0OUw1A==,
+        integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==,
       }
 
   ignore@5.3.2:
@@ -3702,25 +3701,25 @@ packages:
         integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
       }
 
-  nf3@0.3.16:
+  nf3@0.3.22:
     resolution:
       {
-        integrity: sha512-Gs0xRPpUm2nDkqbi40NJ9g7qDIcjcJzgExiydnq6LAyqhI2jfno8wG3NKTL+IiJsx799UHOb1CnSd4Wg4SG4Pw==,
+        integrity: sha512-NOcqlHu22X1rUakd0SrqllP8kb3LWFmSAi1svTxaKxz+yB604xlaOmUfI3oO+RkODvaocKDDy8bgthnZL8hrkw==,
       }
 
-  nitro@3.0.260429-beta:
+  nitro@3.0.260610-beta:
     resolution:
       {
-        integrity: sha512-KweLVCUN5X9v9g+4yxAyRcz3FcOlnjmt9FyrAIWDxJETJmNT7I0JV0clgsONjo2nI0U5gwedXYA3RaNtF5XWzg==,
+        integrity: sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
-      "@vercel/queue": ^0.1.6
+      "@vercel/queue": ^0.3.0
       dotenv: "*"
       giget: "*"
-      jiti: ^2.6.1
-      rollup: ^4.60.2
+      jiti: ^2.7.0
+      rollup: ^4.61.1
       vite: ^7 || ^8
       xml2js: ^0.6.2
       zephyr-agent: ^0.2.0
@@ -3754,10 +3753,10 @@ packages:
         integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
       }
 
-  ocache@0.1.4:
+  ocache@0.1.5:
     resolution:
       {
-        integrity: sha512-e7geNdWjxSnvsSgvLuPvgKgu7ubM10ZmTPOgpr7mz2BXYtvjMKTiLhjFi/gWU8chkuP6hNkZBsa9LzOusyaqkQ==,
+        integrity: sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==,
       }
 
   ofetch@2.0.0-alpha.3:
@@ -3796,6 +3795,13 @@ packages:
         integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
       }
     engines: { node: ">= 0.8.0" }
+
+  oxc-parser@0.139.0:
+    resolution:
+      {
+        integrity: sha512-cf1TKZN+zc0lwqigeyXKzKVk5+vNRe99Or2+wVJsXLdlhJgC+gsIniYDfj/ZEBzCJ8Xm21ZG6YtMbR262CcS2w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
 
   p-limit@3.1.0:
     resolution:
@@ -4196,14 +4202,6 @@ packages:
       }
     engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
 
-  rolldown@1.0.0-rc.18:
-    resolution:
-      {
-        integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    hasBin: true
-
   rolldown@1.1.3:
     resolution:
       {
@@ -4216,6 +4214,12 @@ packages:
     resolution:
       {
         integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==,
+      }
+
+  rou3@0.9.1:
+    resolution:
+      {
+        integrity: sha512-z/sSmzvtwMDDnxsPVhfWMuG6F6mbmhFDXoVqLmMfbpDD9qfV3GDmSQpf0+W296/ZDIpW2wcMmBfpVFzcnOi/nA==,
       }
 
   run-parallel@1.2.0:
@@ -4394,6 +4398,14 @@ packages:
     resolution:
       {
         integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==,
+      }
+    engines: { node: ">=20.16.0" }
+    hasBin: true
+
+  srvx@0.11.22:
+    resolution:
+      {
+        integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==,
       }
     engines: { node: ">=20.16.0" }
     hasBin: true
@@ -5081,29 +5093,13 @@ snapshots:
 
   "@docsearch/css@3.9.0": {}
 
-  "@emnapi/core@1.10.0":
-    dependencies:
-      "@emnapi/wasi-threads": 1.2.1
-      tslib: 2.8.1
-    optional: true
-
   "@emnapi/core@1.11.1":
     dependencies:
       "@emnapi/wasi-threads": 1.2.2
       tslib: 2.8.1
     optional: true
 
-  "@emnapi/runtime@1.10.0":
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   "@emnapi/runtime@1.11.1":
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  "@emnapi/wasi-threads@1.2.1":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5342,7 +5338,7 @@ snapshots:
       solid-presence: 0.1.8(solid-js@1.9.12)
       solid-prevent-scroll: 0.1.10(solid-js@1.9.12)
 
-  "@kobalte/solidbase@0.6.4(@solidjs/start@https://pkg.pr.new/solidjs/solid-start/@solidjs/start@2080(crossws@0.4.5(srvx@0.11.15))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
+  "@kobalte/solidbase@0.6.4(@solidjs/start@2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
     dependencies:
       "@alloc/quick-lru": 5.2.0
       "@bprogress/core": 1.3.4
@@ -5366,7 +5362,7 @@ snapshots:
       "@solid-primitives/storage": 4.3.4(solid-js@1.9.12)
       "@solidjs/meta": 0.29.4(solid-js@1.9.12)
       "@solidjs/router": 0.16.1(solid-js@1.9.12)
-      "@solidjs/start": https://pkg.pr.new/solidjs/solid-start/@solidjs/start@2080(crossws@0.4.5(srvx@0.11.15))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      "@solidjs/start": 2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       cross-spawn: 7.0.6
       diff: 8.0.4
       esast-util-from-js: 2.0.1
@@ -5463,13 +5459,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
-    dependencies:
-      "@emnapi/core": 1.10.0
-      "@emnapi/runtime": 1.10.0
-      "@tybys/wasm-util": 0.10.2
-    optional: true
-
   "@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)":
     dependencies:
       "@emnapi/core": 1.11.1
@@ -5507,87 +5496,108 @@ snapshots:
 
   "@orama/oramacore-events-parser@0.0.5": {}
 
-  "@oxc-project/types@0.128.0": {}
+  "@oxc-parser/binding-android-arm-eabi@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-android-arm64@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-darwin-arm64@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-darwin-x64@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-freebsd-x64@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm-musleabihf@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm64-gnu@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm64-musl@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-ppc64-gnu@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-riscv64-gnu@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-riscv64-musl@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-s390x-gnu@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-x64-gnu@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-x64-musl@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-openharmony-arm64@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-wasm32-wasi@0.139.0":
+    dependencies:
+      "@emnapi/core": 1.11.1
+      "@emnapi/runtime": 1.11.1
+      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  "@oxc-parser/binding-win32-arm64-msvc@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-ia32-msvc@0.139.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-x64-msvc@0.139.0":
+    optional: true
 
   "@oxc-project/types@0.137.0": {}
 
-  "@rolldown/binding-android-arm64@1.0.0-rc.18":
-    optional: true
+  "@oxc-project/types@0.139.0": {}
 
   "@rolldown/binding-android-arm64@1.1.3":
-    optional: true
-
-  "@rolldown/binding-darwin-arm64@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-darwin-arm64@1.1.3":
     optional: true
 
-  "@rolldown/binding-darwin-x64@1.0.0-rc.18":
-    optional: true
-
   "@rolldown/binding-darwin-x64@1.1.3":
-    optional: true
-
-  "@rolldown/binding-freebsd-x64@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-freebsd-x64@1.1.3":
     optional: true
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18":
-    optional: true
-
   "@rolldown/binding-linux-arm-gnueabihf@1.1.3":
-    optional: true
-
-  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-linux-arm64-gnu@1.1.3":
     optional: true
 
-  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.18":
-    optional: true
-
   "@rolldown/binding-linux-arm64-musl@1.1.3":
-    optional: true
-
-  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-linux-ppc64-gnu@1.1.3":
     optional: true
 
-  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18":
-    optional: true
-
   "@rolldown/binding-linux-s390x-gnu@1.1.3":
-    optional: true
-
-  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-linux-x64-gnu@1.1.3":
     optional: true
 
-  "@rolldown/binding-linux-x64-musl@1.0.0-rc.18":
-    optional: true
-
   "@rolldown/binding-linux-x64-musl@1.1.3":
     optional: true
 
-  "@rolldown/binding-openharmony-arm64@1.0.0-rc.18":
-    optional: true
-
   "@rolldown/binding-openharmony-arm64@1.1.3":
-    optional: true
-
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.18":
-    dependencies:
-      "@emnapi/core": 1.10.0
-      "@emnapi/runtime": 1.10.0
-      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   "@rolldown/binding-wasm32-wasi@1.1.3":
@@ -5597,19 +5607,11 @@ snapshots:
       "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18":
-    optional: true
-
   "@rolldown/binding-win32-arm64-msvc@1.1.3":
-    optional: true
-
-  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-win32-x64-msvc@1.1.3":
     optional: true
-
-  "@rolldown/pluginutils@1.0.0-rc.18": {}
 
   "@rolldown/pluginutils@1.0.1": {}
 
@@ -5790,7 +5792,7 @@ snapshots:
     dependencies:
       solid-js: 1.9.12
 
-  "@solidjs/start@https://pkg.pr.new/solidjs/solid-start/@solidjs/start@2080(crossws@0.4.5(srvx@0.11.15))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
+  "@solidjs/start@2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/traverse": 7.29.0
@@ -5801,12 +5803,11 @@ snapshots:
       cookie-es: 2.0.1
       defu: 6.1.7
       error-stack-parser: 2.1.4
-      es-module-lexer: 2.1.0
-      esbuild: 0.27.7
       fast-glob: 3.3.3
-      h3: 2.0.1-rc.16(crossws@0.4.5(srvx@0.11.15))
+      h3: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
       html-to-image: 1.11.13
       micromatch: 4.0.8
+      oxc-parser: 0.139.0
       path-to-regexp: 8.4.2
       pathe: 2.0.3
       radix3: 1.1.2
@@ -5815,7 +5816,7 @@ snapshots:
       shiki: 1.29.2
       solid-js: 1.9.12
       source-map-js: 1.2.1
-      srvx: 0.11.15
+      srvx: 0.11.22
       terracotta: 1.1.0(solid-js@1.9.12)
       vite: 8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-solid: 2.11.12(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
@@ -5900,11 +5901,6 @@ snapshots:
       "@tailwindcss/oxide": 4.3.1
       tailwindcss: 4.3.1
       vite: 8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
-
-  "@tybys/wasm-util@0.10.2":
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   "@tybys/wasm-util@0.10.3":
     dependencies:
@@ -6237,9 +6233,9 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  crossws@0.4.5(srvx@0.11.15):
+  crossws@0.4.10(srvx@0.11.22):
     optionalDependencies:
-      srvx: 0.11.15
+      srvx: 0.11.22
 
   css-select@5.2.2:
     dependencies:
@@ -6316,20 +6312,18 @@ snapshots:
 
   entities@6.0.1: {}
 
-  env-runner@0.1.7:
+  env-runner@0.1.16:
     dependencies:
-      crossws: 0.4.5(srvx@0.11.15)
-      exsolve: 1.0.8
-      httpxy: 0.5.1
-      srvx: 0.11.15
+      crossws: 0.4.10(srvx@0.11.22)
+      exsolve: 1.1.0
+      httpxy: 0.5.5
+      srvx: 0.11.22
 
   error-stack-parser@2.1.4:
     dependencies:
       stackframe: 1.3.4
 
   es-errors@1.3.0: {}
-
-  es-module-lexer@2.1.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -6373,6 +6367,7 @@ snapshots:
       "@esbuild/win32-arm64": 0.27.7
       "@esbuild/win32-ia32": 0.27.7
       "@esbuild/win32-x64": 0.27.7
+    optional: true
 
   escalade@3.2.0: {}
 
@@ -6517,8 +6512,6 @@ snapshots:
       "@expressive-code/plugin-shiki": 0.41.7
       "@expressive-code/plugin-text-markers": 0.41.7
 
-  exsolve@1.0.8: {}
-
   exsolve@1.1.0: {}
 
   extend-shallow@2.0.1:
@@ -6603,19 +6596,19 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
-  h3@2.0.1-rc.16(crossws@0.4.5(srvx@0.11.15)):
+  h3@2.0.1-rc.22(crossws@0.4.10(srvx@0.11.22)):
     dependencies:
       rou3: 0.8.1
       srvx: 0.11.15
     optionalDependencies:
-      crossws: 0.4.5(srvx@0.11.15)
+      crossws: 0.4.10(srvx@0.11.22)
 
-  h3@2.0.1-rc.22(crossws@0.4.5(srvx@0.11.15)):
+  h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)):
     dependencies:
-      rou3: 0.8.1
-      srvx: 0.11.15
+      rou3: 0.9.1
+      srvx: 0.11.22
     optionalDependencies:
-      crossws: 0.4.5(srvx@0.11.15)
+      crossws: 0.4.10(srvx@0.11.22)
 
   hasown@2.0.3:
     dependencies:
@@ -6787,7 +6780,7 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
-  httpxy@0.5.1: {}
+  httpxy@0.5.5: {}
 
   ignore@5.3.2: {}
 
@@ -7450,22 +7443,22 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  nf3@0.3.16: {}
+  nf3@0.3.22: {}
 
-  nitro@3.0.260429-beta(dotenv@17.4.2)(jiti@2.7.0)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)):
+  nitro@3.0.260610-beta(dotenv@17.4.2)(jiti@2.7.0)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       consola: 3.4.2
-      crossws: 0.4.5(srvx@0.11.15)
+      crossws: 0.4.10(srvx@0.11.22)
       db0: 0.3.4
-      env-runner: 0.1.7
-      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.15))
+      env-runner: 0.1.16
+      h3: 2.0.1-rc.22(crossws@0.4.10(srvx@0.11.22))
       hookable: 6.1.1
-      nf3: 0.3.16
-      ocache: 0.1.4
+      nf3: 0.3.22
+      ocache: 0.1.5
       ofetch: 2.0.0-alpha.3
       ohash: 2.0.11
-      rolldown: 1.0.0-rc.18
-      srvx: 0.11.15
+      rolldown: 1.1.3
+      srvx: 0.11.22
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.7(db0@0.3.4)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
@@ -7502,6 +7495,7 @@ snapshots:
       - mysql2
       - sqlite3
       - uploadthing
+      - wrangler
 
   node-releases@2.0.38: {}
 
@@ -7509,7 +7503,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  ocache@0.1.4:
+  ocache@0.1.5:
     dependencies:
       ohash: 2.0.11
 
@@ -7539,6 +7533,31 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  oxc-parser@0.139.0:
+    dependencies:
+      "@oxc-project/types": 0.139.0
+    optionalDependencies:
+      "@oxc-parser/binding-android-arm-eabi": 0.139.0
+      "@oxc-parser/binding-android-arm64": 0.139.0
+      "@oxc-parser/binding-darwin-arm64": 0.139.0
+      "@oxc-parser/binding-darwin-x64": 0.139.0
+      "@oxc-parser/binding-freebsd-x64": 0.139.0
+      "@oxc-parser/binding-linux-arm-gnueabihf": 0.139.0
+      "@oxc-parser/binding-linux-arm-musleabihf": 0.139.0
+      "@oxc-parser/binding-linux-arm64-gnu": 0.139.0
+      "@oxc-parser/binding-linux-arm64-musl": 0.139.0
+      "@oxc-parser/binding-linux-ppc64-gnu": 0.139.0
+      "@oxc-parser/binding-linux-riscv64-gnu": 0.139.0
+      "@oxc-parser/binding-linux-riscv64-musl": 0.139.0
+      "@oxc-parser/binding-linux-s390x-gnu": 0.139.0
+      "@oxc-parser/binding-linux-x64-gnu": 0.139.0
+      "@oxc-parser/binding-linux-x64-musl": 0.139.0
+      "@oxc-parser/binding-openharmony-arm64": 0.139.0
+      "@oxc-parser/binding-wasm32-wasi": 0.139.0
+      "@oxc-parser/binding-win32-arm64-msvc": 0.139.0
+      "@oxc-parser/binding-win32-ia32-msvc": 0.139.0
+      "@oxc-parser/binding-win32-x64-msvc": 0.139.0
 
   p-limit@3.1.0:
     dependencies:
@@ -7800,27 +7819,6 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown@1.0.0-rc.18:
-    dependencies:
-      "@oxc-project/types": 0.128.0
-      "@rolldown/pluginutils": 1.0.0-rc.18
-    optionalDependencies:
-      "@rolldown/binding-android-arm64": 1.0.0-rc.18
-      "@rolldown/binding-darwin-arm64": 1.0.0-rc.18
-      "@rolldown/binding-darwin-x64": 1.0.0-rc.18
-      "@rolldown/binding-freebsd-x64": 1.0.0-rc.18
-      "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-rc.18
-      "@rolldown/binding-linux-arm64-gnu": 1.0.0-rc.18
-      "@rolldown/binding-linux-arm64-musl": 1.0.0-rc.18
-      "@rolldown/binding-linux-ppc64-gnu": 1.0.0-rc.18
-      "@rolldown/binding-linux-s390x-gnu": 1.0.0-rc.18
-      "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.18
-      "@rolldown/binding-linux-x64-musl": 1.0.0-rc.18
-      "@rolldown/binding-openharmony-arm64": 1.0.0-rc.18
-      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.18
-      "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.18
-      "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.18
-
   rolldown@1.1.3:
     dependencies:
       "@oxc-project/types": 0.137.0
@@ -7843,6 +7841,8 @@ snapshots:
       "@rolldown/binding-win32-x64-msvc": 1.1.3
 
   rou3@0.8.1: {}
+
+  rou3@0.9.1: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -7944,6 +7944,8 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   srvx@0.11.15: {}
+
+  srvx@0.11.22: {}
 
   stackframe@1.3.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 0.13.11(solid-js@1.9.12)
       "@kobalte/solidbase":
         specifier: "catalog:"
-        version: 0.6.4(@solidjs/start@2.0.0-rc.5(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.6.4(@solidjs/start@2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       "@solidjs/meta":
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.9.12)
@@ -29,8 +29,8 @@ importers:
         specifier: ^0.16.1
         version: 0.16.1(solid-js@1.9.12)
       "@solidjs/start":
-        specifier: 2.0.0-rc.5
-        version: 2.0.0-rc.5(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       "@tailwindcss/vite":
         specifier: ^4.3.0
         version: 4.3.1(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
@@ -121,7 +121,7 @@ importers:
         version: 0.13.11(solid-js@1.9.12)
       "@kobalte/solidbase":
         specifier: "catalog:"
-        version: 0.6.4(@solidjs/start@2.0.0-rc.5(crossws@0.4.10(srvx@0.12.4))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.6.4(@solidjs/start@2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       "@kobalte/tailwindcss":
         specifier: ^0.9.0
         version: 0.9.0(tailwindcss@4.3.1)
@@ -177,24 +177,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/code-frame@7.29.7":
-    resolution:
-      {
-        integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/compat-data@7.29.3":
     resolution:
       {
         integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/compat-data@7.29.7":
-    resolution:
-      {
-        integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -205,24 +191,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/core@7.29.7":
-    resolution:
-      {
-        integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/generator@7.29.1":
     resolution:
       {
         integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/generator@7.29.7":
-    resolution:
-      {
-        integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -233,24 +205,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helper-compilation-targets@7.29.7":
-    resolution:
-      {
-        integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/helper-globals@7.28.0":
     resolution:
       {
         integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helper-globals@7.29.7":
-    resolution:
-      {
-        integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -268,26 +226,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helper-module-imports@7.29.7":
-    resolution:
-      {
-        integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/helper-module-transforms@7.28.6":
     resolution:
       {
         integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==,
-      }
-    engines: { node: ">=6.9.0" }
-    peerDependencies:
-      "@babel/core": ^7.0.0
-
-  "@babel/helper-module-transforms@7.29.7":
-    resolution:
-      {
-        integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==,
       }
     engines: { node: ">=6.9.0" }
     peerDependencies:
@@ -307,24 +249,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helper-string-parser@7.29.7":
-    resolution:
-      {
-        integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/helper-validator-identifier@7.28.5":
     resolution:
       {
         integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helper-validator-identifier@7.29.7":
-    resolution:
-      {
-        integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -335,13 +263,6 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helper-validator-option@7.29.7":
-    resolution:
-      {
-        integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/helpers@7.29.2":
     resolution:
       {
@@ -349,25 +270,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helpers@7.29.7":
-    resolution:
-      {
-        integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/parser@7.29.3":
     resolution:
       {
         integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==,
-      }
-    engines: { node: ">=6.0.0" }
-    hasBin: true
-
-  "@babel/parser@7.29.7":
-    resolution:
-      {
-        integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==,
       }
     engines: { node: ">=6.0.0" }
     hasBin: true
@@ -388,13 +294,6 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/template@7.29.7":
-    resolution:
-      {
-        integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/traverse@7.29.0":
     resolution:
       {
@@ -402,24 +301,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/traverse@7.29.7":
-    resolution:
-      {
-        integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/types@7.29.0":
     resolution:
       {
         integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/types@7.29.7":
-    resolution:
-      {
-        integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -456,22 +341,10 @@ packages:
         integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==,
       }
 
-  "@emnapi/core@1.11.2":
-    resolution:
-      {
-        integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==,
-      }
-
   "@emnapi/runtime@1.11.1":
     resolution:
       {
         integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==,
-      }
-
-  "@emnapi/runtime@1.11.2":
-    resolution:
-      {
-        integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==,
       }
 
   "@emnapi/wasi-threads@1.2.2":
@@ -1053,188 +926,188 @@ packages:
         integrity: sha512-yAuSwog+HQBAXgZ60TNKEwu04y81/09mpbYBCmz1RCxnr4ObNY2JnPZI7HmALbjAhLJ8t5p+wc2JHRK93ubO4w==,
       }
 
-  "@oxc-parser/binding-android-arm-eabi@0.141.0":
+  "@oxc-parser/binding-android-arm-eabi@0.139.0":
     resolution:
       {
-        integrity: sha512-jk7086MFvR/T4DG9IY7MKBVt1PMxvSZoz/TvnifodvS0pjghVwJHRttnAExhlwdMOgHv1TmLdENnbNpYk2zjvA==,
+        integrity: sha512-22EsXTA3Vc7OvrF4bfT48PFln2UbxkVgrp/Tm32qLw76Dv7SmcInfClJe6yPYamnli6HiqasnESZ5ezN+X4ybg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [android]
 
-  "@oxc-parser/binding-android-arm64@0.141.0":
+  "@oxc-parser/binding-android-arm64@0.139.0":
     resolution:
       {
-        integrity: sha512-a4XDQ27ZT7e7zwAlxJDTiCA7IBGWDuy2+MhFq85Of7XlBSmpkfcBFml11q0Zx6f7RMuI0B4xCtt2ytBS4yOptg==,
+        integrity: sha512-uASQkZV+CUQ6xXvoMzDQyfhd8OMusdv2FyCPfAi5ZDYptesapJlw7erhpGi1Lc+U8QjQV2JUrIh7d/3su2LzmQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [android]
 
-  "@oxc-parser/binding-darwin-arm64@0.141.0":
+  "@oxc-parser/binding-darwin-arm64@0.139.0":
     resolution:
       {
-        integrity: sha512-m/kVk6rzYmBeHYnz+1Y5fod00AVTTxMbC71azFfm/zjx1j9XxwKtA0+VfkKuVMC8rbghb9TtfevnuWZa9OuPEg==,
+        integrity: sha512-vuQOv2WF5pZCkdSPEExul98o853M3MCR24DpWsGrUoPJu5KcnGE34kLXY2yFwBwZwT+eN1x40Tt4q6ZzlEdNUA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [darwin]
 
-  "@oxc-parser/binding-darwin-x64@0.141.0":
+  "@oxc-parser/binding-darwin-x64@0.139.0":
     resolution:
       {
-        integrity: sha512-o0X+6KZlfucWU/v5oKRQPwdFXsXAjW8jmpo/Gpw/qyKsbKtlfkHoeH9Bjp/m13TwjewvJnCkwF0DWzgpC4HjTQ==,
+        integrity: sha512-zxZB8ChS+7XactZhcyxQ292P/DNiiBaPPKYiVUlb3RC0V/hme5bokNubjcmEmbW9uTfmqLTpveAdkbe66H3pGg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [darwin]
 
-  "@oxc-parser/binding-freebsd-x64@0.141.0":
+  "@oxc-parser/binding-freebsd-x64@0.139.0":
     resolution:
       {
-        integrity: sha512-W5KbTnNkTMMMylqj6dYqnsXvkmESVPodPKYLJ5zdzIPdl9fUJtolkpUeSzYEbGGYB4a4A4avl3EePnZ/wLIdJg==,
+        integrity: sha512-iw2MsoCPBQwdJqywRAGsF1jEAcGoZ+DeG2LVzt5pdUvRHqajsMF46BH0rHiWoWtMwcMSia+oQYga7fHo7u7Bcw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [freebsd]
 
-  "@oxc-parser/binding-linux-arm-gnueabihf@0.141.0":
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.139.0":
     resolution:
       {
-        integrity: sha512-g3dtbJa8zeOGK36Sr9cQavsdi5H/ie2hVjrSjIxsNAR1qZA40ZYVXnfdfoMAlq8CmB9qFL1yhsSCUHeNmdmt8w==,
+        integrity: sha512-SwjD/k3Y5bwGJWOH313VyaDrAuaYg1Pe+4AAXCgUKvSO5IHkj+mZ0oFcOWmB5nTuOM3uwdT+leL8h4OnFlI5hw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@oxc-parser/binding-linux-arm-musleabihf@0.141.0":
+  "@oxc-parser/binding-linux-arm-musleabihf@0.139.0":
     resolution:
       {
-        integrity: sha512-e6hwQqd+3lvP13G2jxvFpoA7dzHcFLN+Mq47JCVMtdNHbbyBRo756JCtbbJH6ca8inTfyqZoqBmS3vhQlzAK2w==,
+        integrity: sha512-qbeygDkcvailKFhphb2YGMMXsaZIynHlPtoOrcx4NZB/tRbUKraCCMbw8dPeFtEKasfS2qWh1VnReY+Lcys1zA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@oxc-parser/binding-linux-arm64-gnu@0.141.0":
+  "@oxc-parser/binding-linux-arm64-gnu@0.139.0":
     resolution:
       {
-        integrity: sha512-vXz2BLAuypA+4MLyBg94pzEo6THVnzYnCtAjXoihIIQo0t2pnp/AmW+SH1EI+4VbuJnC//KplIJ5yyaCGua4jA==,
+        integrity: sha512-SrlL02KeImKlvx/9rCeopOLH7qKI3rqKKEguK6KBwVwEGLhV/A47dW4DNigf6/LFhrwoovaiayEQryjYAI86dQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@oxc-parser/binding-linux-arm64-musl@0.141.0":
+  "@oxc-parser/binding-linux-arm64-musl@0.139.0":
     resolution:
       {
-        integrity: sha512-jMkS/EztNW34HKsXIaT/SoHcmtocq/vWhwFOVduF9kduuuRIVwfwQ6uxzIO+qPKSXdd2TXt54of0BJ2zFMXnmw==,
+        integrity: sha512-u9e884ChAVRmIZ1jr/m46S96FoDQnruFjISLi4Y0i6Wu/JUUmIiw7+umLyXILJsPfUuqnN5BJLe23t07+Y6+IA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@oxc-parser/binding-linux-ppc64-gnu@0.141.0":
+  "@oxc-parser/binding-linux-ppc64-gnu@0.139.0":
     resolution:
       {
-        integrity: sha512-vo+MR+n3zQJ6Mq92hiP084NZcgDv5iJlVR02gMf28neMvVT1tKVm7VeiW/DxhdqOi3QLeaXIk9cUcLL1qrkngw==,
+        integrity: sha512-Z9tU2b3GJfAXOdirQmz4gZQkQkVjy53i77gf91l0733MQKa/qtk73KQQE2GzDtMqim+HyjpzvemmqzBtH2IJUA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@oxc-parser/binding-linux-riscv64-gnu@0.141.0":
+  "@oxc-parser/binding-linux-riscv64-gnu@0.139.0":
     resolution:
       {
-        integrity: sha512-oh80w+7RuiO5gBp9Jnoa/H8Qlt3JsHL2MkW+0dwEdlDMdslVZX/YsekSK6EeyEenY66/mhCfypsNATQ7Ph3qlQ==,
+        integrity: sha512-RyUbr7hzPK84YDWKs77PRYk9VBwWbsbuYsQzQWiSmLnARXTg2zntLPGfCH/1wpfUYdmGkp/6SsqTXSsYdw9Jgw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@oxc-parser/binding-linux-riscv64-musl@0.141.0":
+  "@oxc-parser/binding-linux-riscv64-musl@0.139.0":
     resolution:
       {
-        integrity: sha512-LOyEmFA8sCnYbEXP1+iQvCC/P1YXHMA/t6x1Ksp0Y9VwhLFsiBJFzV1zIxrOIE2LKaGGhDjQ29xq9cbq6omDXA==,
+        integrity: sha512-dcQhjtcDvtR8BgkUpt03Yz5SzxdzYvTigenIJOEsiSX6G2t6yybEMxGWjp0dOuYGror0BaqcZfTyXR58amCEig==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  "@oxc-parser/binding-linux-s390x-gnu@0.141.0":
+  "@oxc-parser/binding-linux-s390x-gnu@0.139.0":
     resolution:
       {
-        integrity: sha512-3wnwk/l1CvszVE5TJR1wSl/zSEfydRqrNhn6s7Vr9IzSJpUQIroqVsIoPARHRFA+FQwkxAFDAHDAasa7v8OobQ==,
+        integrity: sha512-iuGrxysV4rGUymdKpn7bgZQ6Vix8Bi/6D/rp71HYIzphq6NKrsBhsGOYsSZte+uBFL43tXh7Xr7TM72sGliJNA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@oxc-parser/binding-linux-x64-gnu@0.141.0":
+  "@oxc-parser/binding-linux-x64-gnu@0.139.0":
     resolution:
       {
-        integrity: sha512-qtyQVAAebFq57B2tifTlel3TgGqUtsYNI/e+p6aya9rN9lOZVTDvr215fGYSA9XWooxzMxDiVxkBLk2jQHbsOQ==,
+        integrity: sha512-NxJdZZyaa2JLLvNfH/iJQXfCNfKcPMylwY4ObMpBVmW4Nq+RyUpVVQXrMMelcQ6rwx3nuhF1Iga8n+eoAKGCIA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@oxc-parser/binding-linux-x64-musl@0.141.0":
+  "@oxc-parser/binding-linux-x64-musl@0.139.0":
     resolution:
       {
-        integrity: sha512-SkGV1nKw40roEc94pv5EaaeH2ay14G6+roe8Q0wIUC1LcEKxzKW921h7+ZuZX0D3q2Mb/7aSFmxEVqnko3lPRw==,
+        integrity: sha512-ePxBvvtzISmSsJ0RIj8FNikSCn58i1jtccj7XR4U9Li4iSzhkFyYlnJ51cQTUwkairz8WMTD4SpKoot8RyTnQA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@oxc-parser/binding-openharmony-arm64@0.141.0":
+  "@oxc-parser/binding-openharmony-arm64@0.139.0":
     resolution:
       {
-        integrity: sha512-cVgDM7n8QziQqOaP5hNgUYfMG7S/ZeuPxFWXnnHRv7rh025COk0rfQ6eEdKG3j/GaUuyvNZN4ifF1J8KmuXLLA==,
+        integrity: sha512-b/c2+mPXMOxG5x16n8yf9cjor/ntQQScmYnSmLEWIWJ4rfXd5dokMxx0kliSLA+YAGq6DD3K9BWi+aFXHiiV1w==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [openharmony]
 
-  "@oxc-parser/binding-wasm32-wasi@0.141.0":
+  "@oxc-parser/binding-wasm32-wasi@0.139.0":
     resolution:
       {
-        integrity: sha512-HggH++Fkn3OilBn+bs3jpgIFQa34oMAyUUHy0vpGum+gt1Eb5nyLc8dNU/RAPSw6lsLrx7ncKtHSZE+3Sp0l2g==,
+        integrity: sha512-rNU0pO+/CVPC2qZ+xtX5R2cOje9Q75q3UkfgwUCPlplqxMv6Iffd5tMPGVMCLGnPINxPlmi0WPsW94HltbYvfQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [wasm32]
 
-  "@oxc-parser/binding-win32-arm64-msvc@0.141.0":
+  "@oxc-parser/binding-win32-arm64-msvc@0.139.0":
     resolution:
       {
-        integrity: sha512-KLSEH9GwgbrqbJOjtGHt9STw96s+78yDzp7IDN8Lno+7Ut9sNBfZ4jYZIz4mD50qmWUjoOI7i9I6UENbhNbMZQ==,
+        integrity: sha512-JPEmfncZfqAFiGsAN6UZSMIBqnG8wn8buywRacFOWjP+9dZwcs03SsBp4tmyjM/4l/VoH/IuThrW1Jof3OyQUw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [win32]
 
-  "@oxc-parser/binding-win32-ia32-msvc@0.141.0":
+  "@oxc-parser/binding-win32-ia32-msvc@0.139.0":
     resolution:
       {
-        integrity: sha512-9UVWUOOCI/1YkiSSNjg2zyBJYM9E/t1A/8GNobd48JDn/fQ6mzxcVO3H08jb3rAaW/B1VBf8eCORTvSsO9T08g==,
+        integrity: sha512-c06dWBwEnFHof5JN7T9/ts23uATXS9czPEBO60d4xnjH2Am29Bo7OGKdVHRmcWQnw0OBxlTg9fIEXAvtcwOBfw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ia32]
     os: [win32]
 
-  "@oxc-parser/binding-win32-x64-msvc@0.141.0":
+  "@oxc-parser/binding-win32-x64-msvc@0.139.0":
     resolution:
       {
-        integrity: sha512-HI/wsvbWT5RHHw5c37D0fEgeTd8/1Q4OJs5jUmEBc17VZFG6SsCIe4barq7NsAPPks/JW+3ayi3Rp+PQI5h4Kg==,
+        integrity: sha512-bI3/44urQjW/D495JPXe+c9d+4Q+ONi3DvDNnzwRZYTWHZ3hAlFdmirYK4mzhTfCZiAly02EbMYir7QGU+9O2Q==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -1246,10 +1119,10 @@ packages:
         integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==,
       }
 
-  "@oxc-project/types@0.141.0":
+  "@oxc-project/types@0.139.0":
     resolution:
       {
-        integrity: sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==,
+        integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==,
       }
 
   "@rolldown/binding-android-arm64@1.1.3":
@@ -1398,18 +1271,23 @@ packages:
         integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
       }
 
+  "@shikijs/core@1.29.2":
+    resolution:
+      {
+        integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==,
+      }
+
   "@shikijs/core@3.23.0":
     resolution:
       {
         integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==,
       }
 
-  "@shikijs/core@4.3.1":
+  "@shikijs/engine-javascript@1.29.2":
     resolution:
       {
-        integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==,
+        integrity: sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==,
       }
-    engines: { node: ">=20" }
 
   "@shikijs/engine-javascript@3.23.0":
     resolution:
@@ -1417,12 +1295,11 @@ packages:
         integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==,
       }
 
-  "@shikijs/engine-javascript@4.3.1":
+  "@shikijs/engine-oniguruma@1.29.2":
     resolution:
       {
-        integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==,
+        integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==,
       }
-    engines: { node: ">=20" }
 
   "@shikijs/engine-oniguruma@3.23.0":
     resolution:
@@ -1430,12 +1307,11 @@ packages:
         integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==,
       }
 
-  "@shikijs/engine-oniguruma@4.3.1":
+  "@shikijs/langs@1.29.2":
     resolution:
       {
-        integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==,
+        integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==,
       }
-    engines: { node: ">=20" }
 
   "@shikijs/langs@3.23.0":
     resolution:
@@ -1443,19 +1319,11 @@ packages:
         integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==,
       }
 
-  "@shikijs/langs@4.3.1":
+  "@shikijs/themes@1.29.2":
     resolution:
       {
-        integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==,
+        integrity: sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==,
       }
-    engines: { node: ">=20" }
-
-  "@shikijs/primitive@4.3.1":
-    resolution:
-      {
-        integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==,
-      }
-    engines: { node: ">=20" }
 
   "@shikijs/themes@3.23.0":
     resolution:
@@ -1463,25 +1331,17 @@ packages:
         integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==,
       }
 
-  "@shikijs/themes@4.3.1":
+  "@shikijs/types@1.29.2":
     resolution:
       {
-        integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==,
+        integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==,
       }
-    engines: { node: ">=20" }
 
   "@shikijs/types@3.23.0":
     resolution:
       {
         integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==,
       }
-
-  "@shikijs/types@4.3.1":
-    resolution:
-      {
-        integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==,
-      }
-    engines: { node: ">=20" }
 
   "@shikijs/vscode-textmate@10.0.2":
     resolution:
@@ -1672,10 +1532,10 @@ packages:
     peerDependencies:
       solid-js: ^1.8.6
 
-  "@solidjs/start@2.0.0-rc.5":
+  "@solidjs/start@2.0.0-rc.1":
     resolution:
       {
-        integrity: sha512-utQ94yp83gd/Th6IXQq+jgGTAIZEHQIFlwBEmFeLZS4jI3qZyY5DMV0iQDwQ4ZU0ZsYHKRmMzUhQm1TQI9jtZQ==,
+        integrity: sha512-T+rVcD4Si6wyUsgwpxka8pGph8OLrIrxWK7wb4b/JyLDaCrx+q6dxTJ3TxCljCgw58NWY+grmGllEgAcTm783g==,
       }
     engines: { node: ">=24" }
     peerDependencies:
@@ -2311,10 +2171,10 @@ packages:
         integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
       }
 
-  cookie-es@3.1.1:
+  cookie-es@2.0.1:
     resolution:
       {
-        integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==,
+        integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==,
       }
 
   cross-spawn@7.0.6:
@@ -2494,6 +2354,12 @@ packages:
     resolution:
       {
         integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==,
+      }
+
+  emoji-regex-xs@1.0.0:
+    resolution:
+      {
+        integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==,
       }
 
   enhanced-resolve@5.21.6:
@@ -2926,10 +2792,10 @@ packages:
       crossws:
         optional: true
 
-  h3@2.0.1-rc.26:
+  h3@2.0.1-rc.25:
     resolution:
       {
-        integrity: sha512-GDxlvDsKxgjRvG5UBRJYyGJTMWLV30CJ4cV+e7QCTgftDHihrvio1fVPbNembhEr6J4WNm8IWy3fookgyTweLw==,
+        integrity: sha512-uIK++Up28xDt4n0+bSWfVssRivNXpUmMmA6CCiK6j9+utLcBMcFK97Gn9PlSZwAPW9oLy3CjGJ4ag40CY9YYtQ==,
       }
     engines: { node: ">=20.11.1" }
     hasBin: true
@@ -3911,6 +3777,12 @@ packages:
         integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==,
       }
 
+  oniguruma-to-es@2.3.0:
+    resolution:
+      {
+        integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==,
+      }
+
   oniguruma-to-es@4.3.6:
     resolution:
       {
@@ -3924,10 +3796,10 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  oxc-parser@0.141.0:
+  oxc-parser@0.139.0:
     resolution:
       {
-        integrity: sha512-uFkGGr1KMWd6aWv9UAqooYrN78trw8MWWmoPvgWokfBEUq1+eiIQ+qfj3wokhy0fxtZWZk+0dHoS7/yRTJtd6w==,
+        integrity: sha512-cf1TKZN+zc0lwqigeyXKzKVk5+vNRe99Or2+wVJsXLdlhJgC+gsIniYDfj/ZEBzCJ8Xm21ZG6YtMbR262CcS2w==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
 
@@ -4207,6 +4079,12 @@ packages:
         integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==,
       }
 
+  regex-recursion@5.1.1:
+    resolution:
+      {
+        integrity: sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==,
+      }
+
   regex-recursion@6.0.2:
     resolution:
       {
@@ -4217,6 +4095,12 @@ packages:
     resolution:
       {
         integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==,
+      }
+
+  regex@5.1.1:
+    resolution:
+      {
+        integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==,
       }
 
   regex@6.1.0:
@@ -4389,26 +4273,10 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
-  seroval-plugins@1.5.6:
-    resolution:
-      {
-        integrity: sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==,
-      }
-    engines: { node: ">=10" }
-    peerDependencies:
-      seroval: ^1.0
-
   seroval@1.5.4:
     resolution:
       {
         integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==,
-      }
-    engines: { node: ">=10" }
-
-  seroval@1.5.6:
-    resolution:
-      {
-        integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==,
       }
     engines: { node: ">=10" }
 
@@ -4426,18 +4294,17 @@ packages:
       }
     engines: { node: ">=8" }
 
+  shiki@1.29.2:
+    resolution:
+      {
+        integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==,
+      }
+
   shiki@3.23.0:
     resolution:
       {
         integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==,
       }
-
-  shiki@4.3.1:
-    resolution:
-      {
-        integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==,
-      }
-    engines: { node: ">=20" }
 
   slugify@1.6.6:
     resolution:
@@ -4458,12 +4325,6 @@ packages:
     resolution:
       {
         integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==,
-      }
-
-  solid-js@1.9.14:
-    resolution:
-      {
-        integrity: sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==,
       }
 
   solid-list@0.3.0:
@@ -4549,14 +4410,6 @@ packages:
     engines: { node: ">=20.16.0" }
     hasBin: true
 
-  srvx@0.12.4:
-    resolution:
-      {
-        integrity: sha512-RixzFlMn3dvzDTpKIAXhXrqL4cy6vScNCP0VVwgVbUBU94o+DiXLsFnAZetbyKAEnK6Ox3hzHXWGsyv/Iibv7g==,
-      }
-    engines: { node: ">=20.16.0" }
-    hasBin: true
-
   stackframe@1.3.4:
     resolution:
       {
@@ -4614,10 +4467,10 @@ packages:
       }
     engines: { node: ">=6" }
 
-  terracotta@1.1.1:
+  terracotta@1.1.0:
     resolution:
       {
-        integrity: sha512-Sa6wnvkGMFmPq8N/wQb2aKkIW2eXH0LJvUOEk6QZLBEjqy+LsbzAOpDuqEfOmfA/hexssE6eQve2i1IIOeOh4g==,
+        integrity: sha512-kfQciWUBUBgYkXu7gh3CK3FAJng/iqZslAaY08C+k1Hdx17aVEpcFFb/WPaysxAfcupNH3y53s/pc53xxZauww==,
       }
     engines: { node: ">=10" }
     peerDependencies:
@@ -4980,15 +4833,15 @@ packages:
         integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
       }
 
-  vite-plugin-solid@2.11.13:
+  vite-plugin-solid@2.11.12:
     resolution:
       {
-        integrity: sha512-YaCNMzwIawUO8K16uj5jaxUJIYCstBEjkUppC5OKElBz/K2+R7Q7MWycHDgqzjBca5WWy/2ZQQ45IHexaabYew==,
+        integrity: sha512-FgjPcx2OwX9h6f28jli7A4bG7PP3te8uyakE5iqsmpq3Jqi1TWLgSroC9N6cMfGRU2zXsl4Q6ISvTr2VL0QHpA==,
       }
     peerDependencies:
       "@testing-library/jest-dom": ^5.16.6 || ^5.17.0 || ^6.*
       solid-js: ^1.7.2
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       "@testing-library/jest-dom":
         optional: true
@@ -5124,15 +4977,7 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  "@babel/code-frame@7.29.7":
-    dependencies:
-      "@babel/helper-validator-identifier": 7.29.7
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   "@babel/compat-data@7.29.3": {}
-
-  "@babel/compat-data@7.29.7": {}
 
   "@babel/core@7.29.0":
     dependencies:
@@ -5154,38 +4999,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/core@7.29.7":
-    dependencies:
-      "@babel/code-frame": 7.29.7
-      "@babel/generator": 7.29.7
-      "@babel/helper-compilation-targets": 7.29.7
-      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
-      "@babel/helpers": 7.29.7
-      "@babel/parser": 7.29.7
-      "@babel/template": 7.29.7
-      "@babel/traverse": 7.29.7
-      "@babel/types": 7.29.7
-      "@jridgewell/remapping": 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   "@babel/generator@7.29.1":
     dependencies:
       "@babel/parser": 7.29.3
       "@babel/types": 7.29.0
-      "@jridgewell/gen-mapping": 0.3.13
-      "@jridgewell/trace-mapping": 0.3.31
-      jsesc: 3.1.0
-
-  "@babel/generator@7.29.7":
-    dependencies:
-      "@babel/parser": 7.29.7
-      "@babel/types": 7.29.7
       "@jridgewell/gen-mapping": 0.3.13
       "@jridgewell/trace-mapping": 0.3.31
       jsesc: 3.1.0
@@ -5198,17 +5015,7 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  "@babel/helper-compilation-targets@7.29.7":
-    dependencies:
-      "@babel/compat-data": 7.29.7
-      "@babel/helper-validator-option": 7.29.7
-      browserslist: 4.28.2
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
   "@babel/helper-globals@7.28.0": {}
-
-  "@babel/helper-globals@7.29.7": {}
 
   "@babel/helper-module-imports@7.18.6":
     dependencies:
@@ -5221,13 +5028,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/helper-module-imports@7.29.7":
-    dependencies:
-      "@babel/traverse": 7.29.7
-      "@babel/types": 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   "@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)":
     dependencies:
       "@babel/core": 7.29.0
@@ -5237,46 +5037,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)":
-    dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-module-imports": 7.29.7
-      "@babel/helper-validator-identifier": 7.29.7
-      "@babel/traverse": 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   "@babel/helper-plugin-utils@7.28.6": {}
 
   "@babel/helper-string-parser@7.27.1": {}
 
-  "@babel/helper-string-parser@7.29.7": {}
-
   "@babel/helper-validator-identifier@7.28.5": {}
 
-  "@babel/helper-validator-identifier@7.29.7": {}
-
   "@babel/helper-validator-option@7.27.1": {}
-
-  "@babel/helper-validator-option@7.29.7": {}
 
   "@babel/helpers@7.29.2":
     dependencies:
       "@babel/template": 7.28.6
       "@babel/types": 7.29.0
 
-  "@babel/helpers@7.29.7":
-    dependencies:
-      "@babel/template": 7.29.7
-      "@babel/types": 7.29.7
-
   "@babel/parser@7.29.3":
     dependencies:
       "@babel/types": 7.29.0
-
-  "@babel/parser@7.29.7":
-    dependencies:
-      "@babel/types": 7.29.7
 
   "@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)":
     dependencies:
@@ -5288,12 +5064,6 @@ snapshots:
       "@babel/code-frame": 7.29.0
       "@babel/parser": 7.29.3
       "@babel/types": 7.29.0
-
-  "@babel/template@7.29.7":
-    dependencies:
-      "@babel/code-frame": 7.29.7
-      "@babel/parser": 7.29.7
-      "@babel/types": 7.29.7
 
   "@babel/traverse@7.29.0":
     dependencies:
@@ -5307,27 +5077,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/traverse@7.29.7":
-    dependencies:
-      "@babel/code-frame": 7.29.7
-      "@babel/generator": 7.29.7
-      "@babel/helper-globals": 7.29.7
-      "@babel/parser": 7.29.7
-      "@babel/template": 7.29.7
-      "@babel/types": 7.29.7
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   "@babel/types@7.29.0":
     dependencies:
       "@babel/helper-string-parser": 7.27.1
       "@babel/helper-validator-identifier": 7.28.5
-
-  "@babel/types@7.29.7":
-    dependencies:
-      "@babel/helper-string-parser": 7.29.7
-      "@babel/helper-validator-identifier": 7.29.7
 
   "@bprogress/core@1.3.4": {}
 
@@ -5346,18 +5099,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  "@emnapi/core@1.11.2":
-    dependencies:
-      "@emnapi/wasi-threads": 1.2.2
-      tslib: 2.8.1
-    optional: true
-
   "@emnapi/runtime@1.11.1":
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  "@emnapi/runtime@1.11.2":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5596,7 +5338,7 @@ snapshots:
       solid-presence: 0.1.8(solid-js@1.9.12)
       solid-prevent-scroll: 0.1.10(solid-js@1.9.12)
 
-  "@kobalte/solidbase@0.6.4(@solidjs/start@2.0.0-rc.5(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
+  "@kobalte/solidbase@0.6.4(@solidjs/start@2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
     dependencies:
       "@alloc/quick-lru": 5.2.0
       "@bprogress/core": 1.3.4
@@ -5620,83 +5362,7 @@ snapshots:
       "@solid-primitives/storage": 4.3.4(solid-js@1.9.12)
       "@solidjs/meta": 0.29.4(solid-js@1.9.12)
       "@solidjs/router": 0.16.1(solid-js@1.9.12)
-      "@solidjs/start": 2.0.0-rc.5(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
-      cross-spawn: 7.0.6
-      diff: 8.0.4
-      esast-util-from-js: 2.0.1
-      estree-util-value-to-estree: 3.5.0
-      expressive-code: 0.41.7
-      expressive-code-twoslash: 0.4.0(@expressive-code/core@0.41.7)(expressive-code@0.41.7)(typescript@5.9.3)
-      gray-matter: 4.0.3
-      hastscript: 9.0.1
-      magic-string: 0.30.21
-      mdast-util-find-and-replace: 3.0.2
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-to-string: 4.0.0
-      mdast-util-toc: 7.1.0
-      parse-numeric-range: 1.3.0
-      prettier: 4.0.0-alpha.13
-      rehype-autolink-headings: 7.1.0
-      rehype-expressive-code: 0.41.7
-      rehype-raw: 7.0.0
-      rehype-slug: 6.0.0
-      remark: 15.0.1
-      remark-directive: 3.0.1
-      remark-frontmatter: 5.0.0
-      remark-gfm: 4.0.1
-      remark-mdx: 3.1.1
-      remark-parse: 11.0.0
-      remark-stringify: 11.0.0
-      solid-js: 1.9.12
-      source-map: 0.7.6
-      toml: 3.0.0
-      typescript: 5.9.3
-      unified: 11.0.5
-      unist-builder: 4.0.0
-      unist-util-mdx-define: 1.1.2
-      unist-util-visit: 5.1.0
-      unplugin-auto-import: 19.3.0
-      unplugin-icons: 22.5.0
-      vite: 8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
-      yaml: 2.9.0
-    transitivePeerDependencies:
-      - "@nuxt/kit"
-      - "@svgr/core"
-      - "@svgx/core"
-      - "@tauri-apps/plugin-store"
-      - "@vue/compiler-sfc"
-      - "@vueuse/core"
-      - solid-start
-      - supports-color
-      - svelte
-      - vue-template-compiler
-      - vue-template-es2015-compiler
-
-  "@kobalte/solidbase@0.6.4(@solidjs/start@2.0.0-rc.5(crossws@0.4.10(srvx@0.12.4))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
-    dependencies:
-      "@alloc/quick-lru": 5.2.0
-      "@bprogress/core": 1.3.4
-      "@docsearch/css": 3.9.0
-      "@expressive-code/core": 0.41.7
-      "@expressive-code/plugin-collapsible-sections": 0.41.7
-      "@expressive-code/plugin-frames": 0.41.7
-      "@expressive-code/plugin-line-numbers": 0.41.7
-      "@fontsource-variable/inter": 5.2.8
-      "@fontsource-variable/jetbrains-mono": 5.2.8
-      "@fontsource-variable/lexend": 5.2.11
-      "@kobalte/core": 0.13.11(solid-js@1.9.12)
-      "@mdx-js/mdx": 3.1.1
-      "@solid-primitives/clipboard": 1.6.4(solid-js@1.9.12)
-      "@solid-primitives/context": 0.2.3(solid-js@1.9.12)
-      "@solid-primitives/event-listener": 2.4.5(solid-js@1.9.12)
-      "@solid-primitives/keyboard": 1.3.5(solid-js@1.9.12)
-      "@solid-primitives/media": 2.3.5(solid-js@1.9.12)
-      "@solid-primitives/platform": 0.1.2(solid-js@1.9.12)
-      "@solid-primitives/scroll": 2.1.5(solid-js@1.9.12)
-      "@solid-primitives/storage": 4.3.4(solid-js@1.9.12)
-      "@solidjs/meta": 0.29.4(solid-js@1.9.12)
-      "@solidjs/router": 0.16.1(solid-js@1.9.12)
-      "@solidjs/start": 2.0.0-rc.5(crossws@0.4.10(srvx@0.12.4))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      "@solidjs/start": 2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       cross-spawn: 7.0.6
       diff: 8.0.4
       esast-util-from-js: 2.0.1
@@ -5800,13 +5466,6 @@ snapshots:
       "@tybys/wasm-util": 0.10.3
     optional: true
 
-  "@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)":
-    dependencies:
-      "@emnapi/core": 1.11.2
-      "@emnapi/runtime": 1.11.2
-      "@tybys/wasm-util": 0.10.3
-    optional: true
-
   "@noble/hashes@1.8.0": {}
 
   "@nodelib/fs.scandir@2.1.5":
@@ -5837,73 +5496,73 @@ snapshots:
 
   "@orama/oramacore-events-parser@0.0.5": {}
 
-  "@oxc-parser/binding-android-arm-eabi@0.141.0":
+  "@oxc-parser/binding-android-arm-eabi@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-android-arm64@0.141.0":
+  "@oxc-parser/binding-android-arm64@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-darwin-arm64@0.141.0":
+  "@oxc-parser/binding-darwin-arm64@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-darwin-x64@0.141.0":
+  "@oxc-parser/binding-darwin-x64@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-freebsd-x64@0.141.0":
+  "@oxc-parser/binding-freebsd-x64@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-linux-arm-gnueabihf@0.141.0":
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-linux-arm-musleabihf@0.141.0":
+  "@oxc-parser/binding-linux-arm-musleabihf@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-linux-arm64-gnu@0.141.0":
+  "@oxc-parser/binding-linux-arm64-gnu@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-linux-arm64-musl@0.141.0":
+  "@oxc-parser/binding-linux-arm64-musl@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-linux-ppc64-gnu@0.141.0":
+  "@oxc-parser/binding-linux-ppc64-gnu@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-linux-riscv64-gnu@0.141.0":
+  "@oxc-parser/binding-linux-riscv64-gnu@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-linux-riscv64-musl@0.141.0":
+  "@oxc-parser/binding-linux-riscv64-musl@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-linux-s390x-gnu@0.141.0":
+  "@oxc-parser/binding-linux-s390x-gnu@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-linux-x64-gnu@0.141.0":
+  "@oxc-parser/binding-linux-x64-gnu@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-linux-x64-musl@0.141.0":
+  "@oxc-parser/binding-linux-x64-musl@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-openharmony-arm64@0.141.0":
+  "@oxc-parser/binding-openharmony-arm64@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-wasm32-wasi@0.141.0":
+  "@oxc-parser/binding-wasm32-wasi@0.139.0":
     dependencies:
-      "@emnapi/core": 1.11.2
-      "@emnapi/runtime": 1.11.2
-      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      "@emnapi/core": 1.11.1
+      "@emnapi/runtime": 1.11.1
+      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  "@oxc-parser/binding-win32-arm64-msvc@0.141.0":
+  "@oxc-parser/binding-win32-arm64-msvc@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-win32-ia32-msvc@0.141.0":
+  "@oxc-parser/binding-win32-ia32-msvc@0.139.0":
     optional: true
 
-  "@oxc-parser/binding-win32-x64-msvc@0.141.0":
+  "@oxc-parser/binding-win32-x64-msvc@0.139.0":
     optional: true
 
   "@oxc-project/types@0.137.0": {}
 
-  "@oxc-project/types@0.141.0": {}
+  "@oxc-project/types@0.139.0": {}
 
   "@rolldown/binding-android-arm64@1.1.3":
     optional: true
@@ -5956,6 +5615,15 @@ snapshots:
 
   "@rolldown/pluginutils@1.0.1": {}
 
+  "@shikijs/core@1.29.2":
+    dependencies:
+      "@shikijs/engine-javascript": 1.29.2
+      "@shikijs/engine-oniguruma": 1.29.2
+      "@shikijs/types": 1.29.2
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
+      hast-util-to-html: 9.0.5
+
   "@shikijs/core@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
@@ -5963,13 +5631,11 @@ snapshots:
       "@types/hast": 3.0.4
       hast-util-to-html: 9.0.5
 
-  "@shikijs/core@4.3.1":
+  "@shikijs/engine-javascript@1.29.2":
     dependencies:
-      "@shikijs/primitive": 4.3.1
-      "@shikijs/types": 4.3.1
+      "@shikijs/types": 1.29.2
       "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
-      hast-util-to-html: 9.0.5
+      oniguruma-to-es: 2.3.0
 
   "@shikijs/engine-javascript@3.23.0":
     dependencies:
@@ -5977,50 +5643,38 @@ snapshots:
       "@shikijs/vscode-textmate": 10.0.2
       oniguruma-to-es: 4.3.6
 
-  "@shikijs/engine-javascript@4.3.1":
+  "@shikijs/engine-oniguruma@1.29.2":
     dependencies:
-      "@shikijs/types": 4.3.1
+      "@shikijs/types": 1.29.2
       "@shikijs/vscode-textmate": 10.0.2
-      oniguruma-to-es: 4.3.6
 
   "@shikijs/engine-oniguruma@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
       "@shikijs/vscode-textmate": 10.0.2
 
-  "@shikijs/engine-oniguruma@4.3.1":
+  "@shikijs/langs@1.29.2":
     dependencies:
-      "@shikijs/types": 4.3.1
-      "@shikijs/vscode-textmate": 10.0.2
+      "@shikijs/types": 1.29.2
 
   "@shikijs/langs@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
 
-  "@shikijs/langs@4.3.1":
+  "@shikijs/themes@1.29.2":
     dependencies:
-      "@shikijs/types": 4.3.1
-
-  "@shikijs/primitive@4.3.1":
-    dependencies:
-      "@shikijs/types": 4.3.1
-      "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
+      "@shikijs/types": 1.29.2
 
   "@shikijs/themes@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
 
-  "@shikijs/themes@4.3.1":
-    dependencies:
-      "@shikijs/types": 4.3.1
-
-  "@shikijs/types@3.23.0":
+  "@shikijs/types@1.29.2":
     dependencies:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
 
-  "@shikijs/types@4.3.1":
+  "@shikijs/types@3.23.0":
     dependencies:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
@@ -6134,75 +5788,38 @@ snapshots:
     dependencies:
       solid-js: 1.9.12
 
-  "@solidjs/meta@0.29.4(solid-js@1.9.14)":
-    dependencies:
-      solid-js: 1.9.14
-
   "@solidjs/router@0.16.1(solid-js@1.9.12)":
     dependencies:
       solid-js: 1.9.12
 
-  "@solidjs/start@2.0.0-rc.5(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
+  "@solidjs/start@2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/traverse": 7.29.7
-      "@babel/types": 7.29.7
-      "@solidjs/meta": 0.29.4(solid-js@1.9.14)
+      "@babel/core": 7.29.0
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.29.0
+      "@solidjs/meta": 0.29.4(solid-js@1.9.12)
       "@types/babel__traverse": 7.28.0
       "@types/micromatch": 4.0.10
-      cookie-es: 3.1.1
+      cookie-es: 2.0.1
       defu: 6.1.7
       error-stack-parser: 2.1.4
       fast-glob: 3.3.3
-      h3: 2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22))
+      h3: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
       html-to-image: 1.11.13
       micromatch: 4.0.8
-      oxc-parser: 0.141.0
+      oxc-parser: 0.139.0
       path-to-regexp: 8.4.2
       pathe: 2.0.3
       radix3: 1.1.2
-      seroval: 1.5.6
-      seroval-plugins: 1.5.6(seroval@1.5.6)
-      shiki: 4.3.1
-      solid-js: 1.9.14
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+      shiki: 1.29.2
+      solid-js: 1.9.12
       source-map-js: 1.2.1
-      srvx: 0.12.4
-      terracotta: 1.1.1(solid-js@1.9.14)
+      srvx: 0.11.22
+      terracotta: 1.1.0(solid-js@1.9.12)
       vite: 8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
-      vite-plugin-solid: 2.11.13(solid-js@1.9.14)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - "@testing-library/jest-dom"
-      - crossws
-      - supports-color
-
-  "@solidjs/start@2.0.0-rc.5(crossws@0.4.10(srvx@0.12.4))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
-    dependencies:
-      "@babel/core": 7.29.7
-      "@babel/traverse": 7.29.7
-      "@babel/types": 7.29.7
-      "@solidjs/meta": 0.29.4(solid-js@1.9.14)
-      "@types/babel__traverse": 7.28.0
-      "@types/micromatch": 4.0.10
-      cookie-es: 3.1.1
-      defu: 6.1.7
-      error-stack-parser: 2.1.4
-      fast-glob: 3.3.3
-      h3: 2.0.1-rc.26(crossws@0.4.10(srvx@0.12.4))
-      html-to-image: 1.11.13
-      micromatch: 4.0.8
-      oxc-parser: 0.141.0
-      path-to-regexp: 8.4.2
-      pathe: 2.0.3
-      radix3: 1.1.2
-      seroval: 1.5.6
-      seroval-plugins: 1.5.6(seroval@1.5.6)
-      shiki: 4.3.1
-      solid-js: 1.9.14
-      source-map-js: 1.2.1
-      srvx: 0.12.4
-      terracotta: 1.1.1(solid-js@1.9.14)
-      vite: 8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
-      vite-plugin-solid: 2.11.13(solid-js@1.9.14)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      vite-plugin-solid: 2.11.12(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - "@testing-library/jest-dom"
       - crossws
@@ -6532,12 +6149,12 @@ snapshots:
       html-entities: 2.3.3
       parse5: 7.3.0
 
-  babel-preset-solid@1.9.12(@babel/core@7.29.0)(solid-js@1.9.14):
+  babel-preset-solid@1.9.12(@babel/core@7.29.0)(solid-js@1.9.12):
     dependencies:
       "@babel/core": 7.29.0
       babel-plugin-jsx-dom-expressions: 0.40.6(@babel/core@7.29.0)
     optionalDependencies:
-      solid-js: 1.9.14
+      solid-js: 1.9.12
 
   bail@2.0.2: {}
 
@@ -6608,7 +6225,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie-es@3.1.1: {}
+  cookie-es@2.0.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6619,11 +6236,6 @@ snapshots:
   crossws@0.4.10(srvx@0.11.22):
     optionalDependencies:
       srvx: 0.11.22
-
-  crossws@0.4.10(srvx@0.12.4):
-    optionalDependencies:
-      srvx: 0.12.4
-    optional: true
 
   css-select@5.2.2:
     dependencies:
@@ -6688,6 +6300,8 @@ snapshots:
   dotenv@17.4.2: {}
 
   electron-to-chromium@1.5.349: {}
+
+  emoji-regex-xs@1.0.0: {}
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -6989,19 +6603,12 @@ snapshots:
     optionalDependencies:
       crossws: 0.4.10(srvx@0.11.22)
 
-  h3@2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22)):
+  h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)):
     dependencies:
       rou3: 0.9.1
-      srvx: 0.12.4
+      srvx: 0.11.22
     optionalDependencies:
       crossws: 0.4.10(srvx@0.11.22)
-
-  h3@2.0.1-rc.26(crossws@0.4.10(srvx@0.12.4)):
-    dependencies:
-      rou3: 0.9.1
-      srvx: 0.12.4
-    optionalDependencies:
-      crossws: 0.4.10(srvx@0.12.4)
 
   hasown@2.0.3:
     dependencies:
@@ -7906,6 +7513,12 @@ snapshots:
 
   oniguruma-parser@0.12.2: {}
 
+  oniguruma-to-es@2.3.0:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 5.1.1
+      regex-recursion: 5.1.1
+
   oniguruma-to-es@4.3.6:
     dependencies:
       oniguruma-parser: 0.12.2
@@ -7921,30 +7534,30 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  oxc-parser@0.141.0:
+  oxc-parser@0.139.0:
     dependencies:
-      "@oxc-project/types": 0.141.0
+      "@oxc-project/types": 0.139.0
     optionalDependencies:
-      "@oxc-parser/binding-android-arm-eabi": 0.141.0
-      "@oxc-parser/binding-android-arm64": 0.141.0
-      "@oxc-parser/binding-darwin-arm64": 0.141.0
-      "@oxc-parser/binding-darwin-x64": 0.141.0
-      "@oxc-parser/binding-freebsd-x64": 0.141.0
-      "@oxc-parser/binding-linux-arm-gnueabihf": 0.141.0
-      "@oxc-parser/binding-linux-arm-musleabihf": 0.141.0
-      "@oxc-parser/binding-linux-arm64-gnu": 0.141.0
-      "@oxc-parser/binding-linux-arm64-musl": 0.141.0
-      "@oxc-parser/binding-linux-ppc64-gnu": 0.141.0
-      "@oxc-parser/binding-linux-riscv64-gnu": 0.141.0
-      "@oxc-parser/binding-linux-riscv64-musl": 0.141.0
-      "@oxc-parser/binding-linux-s390x-gnu": 0.141.0
-      "@oxc-parser/binding-linux-x64-gnu": 0.141.0
-      "@oxc-parser/binding-linux-x64-musl": 0.141.0
-      "@oxc-parser/binding-openharmony-arm64": 0.141.0
-      "@oxc-parser/binding-wasm32-wasi": 0.141.0
-      "@oxc-parser/binding-win32-arm64-msvc": 0.141.0
-      "@oxc-parser/binding-win32-ia32-msvc": 0.141.0
-      "@oxc-parser/binding-win32-x64-msvc": 0.141.0
+      "@oxc-parser/binding-android-arm-eabi": 0.139.0
+      "@oxc-parser/binding-android-arm64": 0.139.0
+      "@oxc-parser/binding-darwin-arm64": 0.139.0
+      "@oxc-parser/binding-darwin-x64": 0.139.0
+      "@oxc-parser/binding-freebsd-x64": 0.139.0
+      "@oxc-parser/binding-linux-arm-gnueabihf": 0.139.0
+      "@oxc-parser/binding-linux-arm-musleabihf": 0.139.0
+      "@oxc-parser/binding-linux-arm64-gnu": 0.139.0
+      "@oxc-parser/binding-linux-arm64-musl": 0.139.0
+      "@oxc-parser/binding-linux-ppc64-gnu": 0.139.0
+      "@oxc-parser/binding-linux-riscv64-gnu": 0.139.0
+      "@oxc-parser/binding-linux-riscv64-musl": 0.139.0
+      "@oxc-parser/binding-linux-s390x-gnu": 0.139.0
+      "@oxc-parser/binding-linux-x64-gnu": 0.139.0
+      "@oxc-parser/binding-linux-x64-musl": 0.139.0
+      "@oxc-parser/binding-openharmony-arm64": 0.139.0
+      "@oxc-parser/binding-wasm32-wasi": 0.139.0
+      "@oxc-parser/binding-win32-arm64-msvc": 0.139.0
+      "@oxc-parser/binding-win32-ia32-msvc": 0.139.0
+      "@oxc-parser/binding-win32-x64-msvc": 0.139.0
 
   p-limit@3.1.0:
     dependencies:
@@ -8075,11 +7688,20 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  regex-recursion@5.1.1:
+    dependencies:
+      regex: 5.1.1
+      regex-utilities: 2.3.0
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
 
   regex-utilities@2.3.0: {}
+
+  regex@5.1.1:
+    dependencies:
+      regex-utilities: 2.3.0
 
   regex@6.1.0:
     dependencies:
@@ -8243,19 +7865,24 @@ snapshots:
     dependencies:
       seroval: 1.5.4
 
-  seroval-plugins@1.5.6(seroval@1.5.6):
-    dependencies:
-      seroval: 1.5.6
-
   seroval@1.5.4: {}
-
-  seroval@1.5.6: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki@1.29.2:
+    dependencies:
+      "@shikijs/core": 1.29.2
+      "@shikijs/engine-javascript": 1.29.2
+      "@shikijs/engine-oniguruma": 1.29.2
+      "@shikijs/langs": 1.29.2
+      "@shikijs/themes": 1.29.2
+      "@shikijs/types": 1.29.2
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
 
   shiki@3.23.0:
     dependencies:
@@ -8268,17 +7895,6 @@ snapshots:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
 
-  shiki@4.3.1:
-    dependencies:
-      "@shikijs/core": 4.3.1
-      "@shikijs/engine-javascript": 4.3.1
-      "@shikijs/engine-oniguruma": 4.3.1
-      "@shikijs/langs": 4.3.1
-      "@shikijs/themes": 4.3.1
-      "@shikijs/types": 4.3.1
-      "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
-
   slugify@1.6.6: {}
 
   solid-heroicons@3.2.4(solid-js@1.9.12):
@@ -8286,12 +7902,6 @@ snapshots:
       solid-js: 1.9.12
 
   solid-js@1.9.12:
-    dependencies:
-      csstype: 3.2.3
-      seroval: 1.5.4
-      seroval-plugins: 1.5.4(seroval@1.5.4)
-
-  solid-js@1.9.14:
     dependencies:
       csstype: 3.2.3
       seroval: 1.5.4
@@ -8312,18 +7922,18 @@ snapshots:
       "@corvu/utils": 0.4.2(solid-js@1.9.12)
       solid-js: 1.9.12
 
-  solid-refresh@0.6.3(solid-js@1.9.14):
+  solid-refresh@0.6.3(solid-js@1.9.12):
     dependencies:
       "@babel/generator": 7.29.1
       "@babel/helper-module-imports": 7.28.6
       "@babel/types": 7.29.0
-      solid-js: 1.9.14
+      solid-js: 1.9.12
     transitivePeerDependencies:
       - supports-color
 
-  solid-use@0.9.1(solid-js@1.9.14):
+  solid-use@0.9.1(solid-js@1.9.12):
     dependencies:
-      solid-js: 1.9.14
+      solid-js: 1.9.12
 
   source-map-js@1.2.1: {}
 
@@ -8336,8 +7946,6 @@ snapshots:
   srvx@0.11.15: {}
 
   srvx@0.11.22: {}
-
-  srvx@0.12.4: {}
 
   stackframe@1.3.4: {}
 
@@ -8366,10 +7974,10 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terracotta@1.1.1(solid-js@1.9.14):
+  terracotta@1.1.0(solid-js@1.9.12):
     dependencies:
-      solid-js: 1.9.14
-      solid-use: 0.9.1(solid-js@1.9.14)
+      solid-js: 1.9.12
+      solid-use: 0.9.1(solid-js@1.9.12)
 
   tinyexec@1.2.4: {}
 
@@ -8567,14 +8175,14 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-solid@2.11.13(solid-js@1.9.14)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)):
+  vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       "@babel/core": 7.29.0
       "@types/babel__core": 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.14)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.12)
       merge-anything: 5.1.7
-      solid-js: 1.9.14
-      solid-refresh: 0.6.3(solid-js@1.9.14)
+      solid-js: 1.9.12
+      solid-refresh: 0.6.3(solid-js@1.9.12)
       vite: 8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 0.13.11(solid-js@1.9.12)
       "@kobalte/solidbase":
         specifier: "catalog:"
-        version: 0.6.4(@solidjs/start@2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.6.4(@solidjs/start@2.0.0-rc.5(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       "@solidjs/meta":
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.9.12)
@@ -29,8 +29,8 @@ importers:
         specifier: ^0.16.1
         version: 0.16.1(solid-js@1.9.12)
       "@solidjs/start":
-        specifier: 2.0.0-rc.1
-        version: 2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        specifier: 2.0.0-rc.5
+        version: 2.0.0-rc.5(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       "@tailwindcss/vite":
         specifier: ^4.3.0
         version: 4.3.1(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
@@ -121,7 +121,7 @@ importers:
         version: 0.13.11(solid-js@1.9.12)
       "@kobalte/solidbase":
         specifier: "catalog:"
-        version: 0.6.4(@solidjs/start@2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.6.4(@solidjs/start@2.0.0-rc.5(crossws@0.4.10(srvx@0.12.4))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       "@kobalte/tailwindcss":
         specifier: ^0.9.0
         version: 0.9.0(tailwindcss@4.3.1)
@@ -177,10 +177,24 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/code-frame@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/compat-data@7.29.3":
     resolution:
       {
         integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/compat-data@7.29.7":
+    resolution:
+      {
+        integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -191,10 +205,24 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/core@7.29.7":
+    resolution:
+      {
+        integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/generator@7.29.1":
     resolution:
       {
         integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/generator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -205,10 +233,24 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/helper-compilation-targets@7.29.7":
+    resolution:
+      {
+        integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/helper-globals@7.28.0":
     resolution:
       {
         integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-globals@7.29.7":
+    resolution:
+      {
+        integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -226,10 +268,26 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/helper-module-imports@7.29.7":
+    resolution:
+      {
+        integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/helper-module-transforms@7.28.6":
     resolution:
       {
         integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/helper-module-transforms@7.29.7":
+    resolution:
+      {
+        integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==,
       }
     engines: { node: ">=6.9.0" }
     peerDependencies:
@@ -249,10 +307,24 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/helper-string-parser@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/helper-validator-identifier@7.28.5":
     resolution:
       {
         integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-validator-identifier@7.29.7":
+    resolution:
+      {
+        integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -263,6 +335,13 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/helper-validator-option@7.29.7":
+    resolution:
+      {
+        integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/helpers@7.29.2":
     resolution:
       {
@@ -270,10 +349,25 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/helpers@7.29.7":
+    resolution:
+      {
+        integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/parser@7.29.3":
     resolution:
       {
         integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==,
+      }
+    engines: { node: ">=6.0.0" }
+    hasBin: true
+
+  "@babel/parser@7.29.7":
+    resolution:
+      {
+        integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==,
       }
     engines: { node: ">=6.0.0" }
     hasBin: true
@@ -294,6 +388,13 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/template@7.29.7":
+    resolution:
+      {
+        integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/traverse@7.29.0":
     resolution:
       {
@@ -301,10 +402,24 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/traverse@7.29.7":
+    resolution:
+      {
+        integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/types@7.29.0":
     resolution:
       {
         integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/types@7.29.7":
+    resolution:
+      {
+        integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -341,10 +456,22 @@ packages:
         integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==,
       }
 
+  "@emnapi/core@1.11.2":
+    resolution:
+      {
+        integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==,
+      }
+
   "@emnapi/runtime@1.11.1":
     resolution:
       {
         integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==,
+      }
+
+  "@emnapi/runtime@1.11.2":
+    resolution:
+      {
+        integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==,
       }
 
   "@emnapi/wasi-threads@1.2.2":
@@ -926,188 +1053,188 @@ packages:
         integrity: sha512-yAuSwog+HQBAXgZ60TNKEwu04y81/09mpbYBCmz1RCxnr4ObNY2JnPZI7HmALbjAhLJ8t5p+wc2JHRK93ubO4w==,
       }
 
-  "@oxc-parser/binding-android-arm-eabi@0.139.0":
+  "@oxc-parser/binding-android-arm-eabi@0.141.0":
     resolution:
       {
-        integrity: sha512-22EsXTA3Vc7OvrF4bfT48PFln2UbxkVgrp/Tm32qLw76Dv7SmcInfClJe6yPYamnli6HiqasnESZ5ezN+X4ybg==,
+        integrity: sha512-jk7086MFvR/T4DG9IY7MKBVt1PMxvSZoz/TvnifodvS0pjghVwJHRttnAExhlwdMOgHv1TmLdENnbNpYk2zjvA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [android]
 
-  "@oxc-parser/binding-android-arm64@0.139.0":
+  "@oxc-parser/binding-android-arm64@0.141.0":
     resolution:
       {
-        integrity: sha512-uASQkZV+CUQ6xXvoMzDQyfhd8OMusdv2FyCPfAi5ZDYptesapJlw7erhpGi1Lc+U8QjQV2JUrIh7d/3su2LzmQ==,
+        integrity: sha512-a4XDQ27ZT7e7zwAlxJDTiCA7IBGWDuy2+MhFq85Of7XlBSmpkfcBFml11q0Zx6f7RMuI0B4xCtt2ytBS4yOptg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [android]
 
-  "@oxc-parser/binding-darwin-arm64@0.139.0":
+  "@oxc-parser/binding-darwin-arm64@0.141.0":
     resolution:
       {
-        integrity: sha512-vuQOv2WF5pZCkdSPEExul98o853M3MCR24DpWsGrUoPJu5KcnGE34kLXY2yFwBwZwT+eN1x40Tt4q6ZzlEdNUA==,
+        integrity: sha512-m/kVk6rzYmBeHYnz+1Y5fod00AVTTxMbC71azFfm/zjx1j9XxwKtA0+VfkKuVMC8rbghb9TtfevnuWZa9OuPEg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [darwin]
 
-  "@oxc-parser/binding-darwin-x64@0.139.0":
+  "@oxc-parser/binding-darwin-x64@0.141.0":
     resolution:
       {
-        integrity: sha512-zxZB8ChS+7XactZhcyxQ292P/DNiiBaPPKYiVUlb3RC0V/hme5bokNubjcmEmbW9uTfmqLTpveAdkbe66H3pGg==,
+        integrity: sha512-o0X+6KZlfucWU/v5oKRQPwdFXsXAjW8jmpo/Gpw/qyKsbKtlfkHoeH9Bjp/m13TwjewvJnCkwF0DWzgpC4HjTQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [darwin]
 
-  "@oxc-parser/binding-freebsd-x64@0.139.0":
+  "@oxc-parser/binding-freebsd-x64@0.141.0":
     resolution:
       {
-        integrity: sha512-iw2MsoCPBQwdJqywRAGsF1jEAcGoZ+DeG2LVzt5pdUvRHqajsMF46BH0rHiWoWtMwcMSia+oQYga7fHo7u7Bcw==,
+        integrity: sha512-W5KbTnNkTMMMylqj6dYqnsXvkmESVPodPKYLJ5zdzIPdl9fUJtolkpUeSzYEbGGYB4a4A4avl3EePnZ/wLIdJg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [freebsd]
 
-  "@oxc-parser/binding-linux-arm-gnueabihf@0.139.0":
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.141.0":
     resolution:
       {
-        integrity: sha512-SwjD/k3Y5bwGJWOH313VyaDrAuaYg1Pe+4AAXCgUKvSO5IHkj+mZ0oFcOWmB5nTuOM3uwdT+leL8h4OnFlI5hw==,
+        integrity: sha512-g3dtbJa8zeOGK36Sr9cQavsdi5H/ie2hVjrSjIxsNAR1qZA40ZYVXnfdfoMAlq8CmB9qFL1yhsSCUHeNmdmt8w==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@oxc-parser/binding-linux-arm-musleabihf@0.139.0":
+  "@oxc-parser/binding-linux-arm-musleabihf@0.141.0":
     resolution:
       {
-        integrity: sha512-qbeygDkcvailKFhphb2YGMMXsaZIynHlPtoOrcx4NZB/tRbUKraCCMbw8dPeFtEKasfS2qWh1VnReY+Lcys1zA==,
+        integrity: sha512-e6hwQqd+3lvP13G2jxvFpoA7dzHcFLN+Mq47JCVMtdNHbbyBRo756JCtbbJH6ca8inTfyqZoqBmS3vhQlzAK2w==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@oxc-parser/binding-linux-arm64-gnu@0.139.0":
+  "@oxc-parser/binding-linux-arm64-gnu@0.141.0":
     resolution:
       {
-        integrity: sha512-SrlL02KeImKlvx/9rCeopOLH7qKI3rqKKEguK6KBwVwEGLhV/A47dW4DNigf6/LFhrwoovaiayEQryjYAI86dQ==,
+        integrity: sha512-vXz2BLAuypA+4MLyBg94pzEo6THVnzYnCtAjXoihIIQo0t2pnp/AmW+SH1EI+4VbuJnC//KplIJ5yyaCGua4jA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@oxc-parser/binding-linux-arm64-musl@0.139.0":
+  "@oxc-parser/binding-linux-arm64-musl@0.141.0":
     resolution:
       {
-        integrity: sha512-u9e884ChAVRmIZ1jr/m46S96FoDQnruFjISLi4Y0i6Wu/JUUmIiw7+umLyXILJsPfUuqnN5BJLe23t07+Y6+IA==,
+        integrity: sha512-jMkS/EztNW34HKsXIaT/SoHcmtocq/vWhwFOVduF9kduuuRIVwfwQ6uxzIO+qPKSXdd2TXt54of0BJ2zFMXnmw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@oxc-parser/binding-linux-ppc64-gnu@0.139.0":
+  "@oxc-parser/binding-linux-ppc64-gnu@0.141.0":
     resolution:
       {
-        integrity: sha512-Z9tU2b3GJfAXOdirQmz4gZQkQkVjy53i77gf91l0733MQKa/qtk73KQQE2GzDtMqim+HyjpzvemmqzBtH2IJUA==,
+        integrity: sha512-vo+MR+n3zQJ6Mq92hiP084NZcgDv5iJlVR02gMf28neMvVT1tKVm7VeiW/DxhdqOi3QLeaXIk9cUcLL1qrkngw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@oxc-parser/binding-linux-riscv64-gnu@0.139.0":
+  "@oxc-parser/binding-linux-riscv64-gnu@0.141.0":
     resolution:
       {
-        integrity: sha512-RyUbr7hzPK84YDWKs77PRYk9VBwWbsbuYsQzQWiSmLnARXTg2zntLPGfCH/1wpfUYdmGkp/6SsqTXSsYdw9Jgw==,
+        integrity: sha512-oh80w+7RuiO5gBp9Jnoa/H8Qlt3JsHL2MkW+0dwEdlDMdslVZX/YsekSK6EeyEenY66/mhCfypsNATQ7Ph3qlQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@oxc-parser/binding-linux-riscv64-musl@0.139.0":
+  "@oxc-parser/binding-linux-riscv64-musl@0.141.0":
     resolution:
       {
-        integrity: sha512-dcQhjtcDvtR8BgkUpt03Yz5SzxdzYvTigenIJOEsiSX6G2t6yybEMxGWjp0dOuYGror0BaqcZfTyXR58amCEig==,
+        integrity: sha512-LOyEmFA8sCnYbEXP1+iQvCC/P1YXHMA/t6x1Ksp0Y9VwhLFsiBJFzV1zIxrOIE2LKaGGhDjQ29xq9cbq6omDXA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  "@oxc-parser/binding-linux-s390x-gnu@0.139.0":
+  "@oxc-parser/binding-linux-s390x-gnu@0.141.0":
     resolution:
       {
-        integrity: sha512-iuGrxysV4rGUymdKpn7bgZQ6Vix8Bi/6D/rp71HYIzphq6NKrsBhsGOYsSZte+uBFL43tXh7Xr7TM72sGliJNA==,
+        integrity: sha512-3wnwk/l1CvszVE5TJR1wSl/zSEfydRqrNhn6s7Vr9IzSJpUQIroqVsIoPARHRFA+FQwkxAFDAHDAasa7v8OobQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@oxc-parser/binding-linux-x64-gnu@0.139.0":
+  "@oxc-parser/binding-linux-x64-gnu@0.141.0":
     resolution:
       {
-        integrity: sha512-NxJdZZyaa2JLLvNfH/iJQXfCNfKcPMylwY4ObMpBVmW4Nq+RyUpVVQXrMMelcQ6rwx3nuhF1Iga8n+eoAKGCIA==,
+        integrity: sha512-qtyQVAAebFq57B2tifTlel3TgGqUtsYNI/e+p6aya9rN9lOZVTDvr215fGYSA9XWooxzMxDiVxkBLk2jQHbsOQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@oxc-parser/binding-linux-x64-musl@0.139.0":
+  "@oxc-parser/binding-linux-x64-musl@0.141.0":
     resolution:
       {
-        integrity: sha512-ePxBvvtzISmSsJ0RIj8FNikSCn58i1jtccj7XR4U9Li4iSzhkFyYlnJ51cQTUwkairz8WMTD4SpKoot8RyTnQA==,
+        integrity: sha512-SkGV1nKw40roEc94pv5EaaeH2ay14G6+roe8Q0wIUC1LcEKxzKW921h7+ZuZX0D3q2Mb/7aSFmxEVqnko3lPRw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@oxc-parser/binding-openharmony-arm64@0.139.0":
+  "@oxc-parser/binding-openharmony-arm64@0.141.0":
     resolution:
       {
-        integrity: sha512-b/c2+mPXMOxG5x16n8yf9cjor/ntQQScmYnSmLEWIWJ4rfXd5dokMxx0kliSLA+YAGq6DD3K9BWi+aFXHiiV1w==,
+        integrity: sha512-cVgDM7n8QziQqOaP5hNgUYfMG7S/ZeuPxFWXnnHRv7rh025COk0rfQ6eEdKG3j/GaUuyvNZN4ifF1J8KmuXLLA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [openharmony]
 
-  "@oxc-parser/binding-wasm32-wasi@0.139.0":
+  "@oxc-parser/binding-wasm32-wasi@0.141.0":
     resolution:
       {
-        integrity: sha512-rNU0pO+/CVPC2qZ+xtX5R2cOje9Q75q3UkfgwUCPlplqxMv6Iffd5tMPGVMCLGnPINxPlmi0WPsW94HltbYvfQ==,
+        integrity: sha512-HggH++Fkn3OilBn+bs3jpgIFQa34oMAyUUHy0vpGum+gt1Eb5nyLc8dNU/RAPSw6lsLrx7ncKtHSZE+3Sp0l2g==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [wasm32]
 
-  "@oxc-parser/binding-win32-arm64-msvc@0.139.0":
+  "@oxc-parser/binding-win32-arm64-msvc@0.141.0":
     resolution:
       {
-        integrity: sha512-JPEmfncZfqAFiGsAN6UZSMIBqnG8wn8buywRacFOWjP+9dZwcs03SsBp4tmyjM/4l/VoH/IuThrW1Jof3OyQUw==,
+        integrity: sha512-KLSEH9GwgbrqbJOjtGHt9STw96s+78yDzp7IDN8Lno+7Ut9sNBfZ4jYZIz4mD50qmWUjoOI7i9I6UENbhNbMZQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [win32]
 
-  "@oxc-parser/binding-win32-ia32-msvc@0.139.0":
+  "@oxc-parser/binding-win32-ia32-msvc@0.141.0":
     resolution:
       {
-        integrity: sha512-c06dWBwEnFHof5JN7T9/ts23uATXS9czPEBO60d4xnjH2Am29Bo7OGKdVHRmcWQnw0OBxlTg9fIEXAvtcwOBfw==,
+        integrity: sha512-9UVWUOOCI/1YkiSSNjg2zyBJYM9E/t1A/8GNobd48JDn/fQ6mzxcVO3H08jb3rAaW/B1VBf8eCORTvSsO9T08g==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ia32]
     os: [win32]
 
-  "@oxc-parser/binding-win32-x64-msvc@0.139.0":
+  "@oxc-parser/binding-win32-x64-msvc@0.141.0":
     resolution:
       {
-        integrity: sha512-bI3/44urQjW/D495JPXe+c9d+4Q+ONi3DvDNnzwRZYTWHZ3hAlFdmirYK4mzhTfCZiAly02EbMYir7QGU+9O2Q==,
+        integrity: sha512-HI/wsvbWT5RHHw5c37D0fEgeTd8/1Q4OJs5jUmEBc17VZFG6SsCIe4barq7NsAPPks/JW+3ayi3Rp+PQI5h4Kg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -1119,10 +1246,10 @@ packages:
         integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==,
       }
 
-  "@oxc-project/types@0.139.0":
+  "@oxc-project/types@0.141.0":
     resolution:
       {
-        integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==,
+        integrity: sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==,
       }
 
   "@rolldown/binding-android-arm64@1.1.3":
@@ -1271,23 +1398,18 @@ packages:
         integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
       }
 
-  "@shikijs/core@1.29.2":
-    resolution:
-      {
-        integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==,
-      }
-
   "@shikijs/core@3.23.0":
     resolution:
       {
         integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==,
       }
 
-  "@shikijs/engine-javascript@1.29.2":
+  "@shikijs/core@4.3.1":
     resolution:
       {
-        integrity: sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==,
+        integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==,
       }
+    engines: { node: ">=20" }
 
   "@shikijs/engine-javascript@3.23.0":
     resolution:
@@ -1295,11 +1417,12 @@ packages:
         integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==,
       }
 
-  "@shikijs/engine-oniguruma@1.29.2":
+  "@shikijs/engine-javascript@4.3.1":
     resolution:
       {
-        integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==,
+        integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==,
       }
+    engines: { node: ">=20" }
 
   "@shikijs/engine-oniguruma@3.23.0":
     resolution:
@@ -1307,11 +1430,12 @@ packages:
         integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==,
       }
 
-  "@shikijs/langs@1.29.2":
+  "@shikijs/engine-oniguruma@4.3.1":
     resolution:
       {
-        integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==,
+        integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==,
       }
+    engines: { node: ">=20" }
 
   "@shikijs/langs@3.23.0":
     resolution:
@@ -1319,11 +1443,19 @@ packages:
         integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==,
       }
 
-  "@shikijs/themes@1.29.2":
+  "@shikijs/langs@4.3.1":
     resolution:
       {
-        integrity: sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==,
+        integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==,
       }
+    engines: { node: ">=20" }
+
+  "@shikijs/primitive@4.3.1":
+    resolution:
+      {
+        integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/themes@3.23.0":
     resolution:
@@ -1331,17 +1463,25 @@ packages:
         integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==,
       }
 
-  "@shikijs/types@1.29.2":
+  "@shikijs/themes@4.3.1":
     resolution:
       {
-        integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==,
+        integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==,
       }
+    engines: { node: ">=20" }
 
   "@shikijs/types@3.23.0":
     resolution:
       {
         integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==,
       }
+
+  "@shikijs/types@4.3.1":
+    resolution:
+      {
+        integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/vscode-textmate@10.0.2":
     resolution:
@@ -1532,10 +1672,10 @@ packages:
     peerDependencies:
       solid-js: ^1.8.6
 
-  "@solidjs/start@2.0.0-rc.1":
+  "@solidjs/start@2.0.0-rc.5":
     resolution:
       {
-        integrity: sha512-T+rVcD4Si6wyUsgwpxka8pGph8OLrIrxWK7wb4b/JyLDaCrx+q6dxTJ3TxCljCgw58NWY+grmGllEgAcTm783g==,
+        integrity: sha512-utQ94yp83gd/Th6IXQq+jgGTAIZEHQIFlwBEmFeLZS4jI3qZyY5DMV0iQDwQ4ZU0ZsYHKRmMzUhQm1TQI9jtZQ==,
       }
     engines: { node: ">=24" }
     peerDependencies:
@@ -2171,10 +2311,10 @@ packages:
         integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
       }
 
-  cookie-es@2.0.1:
+  cookie-es@3.1.1:
     resolution:
       {
-        integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==,
+        integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==,
       }
 
   cross-spawn@7.0.6:
@@ -2354,12 +2494,6 @@ packages:
     resolution:
       {
         integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==,
-      }
-
-  emoji-regex-xs@1.0.0:
-    resolution:
-      {
-        integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==,
       }
 
   enhanced-resolve@5.21.6:
@@ -2792,10 +2926,10 @@ packages:
       crossws:
         optional: true
 
-  h3@2.0.1-rc.25:
+  h3@2.0.1-rc.26:
     resolution:
       {
-        integrity: sha512-uIK++Up28xDt4n0+bSWfVssRivNXpUmMmA6CCiK6j9+utLcBMcFK97Gn9PlSZwAPW9oLy3CjGJ4ag40CY9YYtQ==,
+        integrity: sha512-GDxlvDsKxgjRvG5UBRJYyGJTMWLV30CJ4cV+e7QCTgftDHihrvio1fVPbNembhEr6J4WNm8IWy3fookgyTweLw==,
       }
     engines: { node: ">=20.11.1" }
     hasBin: true
@@ -3777,12 +3911,6 @@ packages:
         integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==,
       }
 
-  oniguruma-to-es@2.3.0:
-    resolution:
-      {
-        integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==,
-      }
-
   oniguruma-to-es@4.3.6:
     resolution:
       {
@@ -3796,10 +3924,10 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  oxc-parser@0.139.0:
+  oxc-parser@0.141.0:
     resolution:
       {
-        integrity: sha512-cf1TKZN+zc0lwqigeyXKzKVk5+vNRe99Or2+wVJsXLdlhJgC+gsIniYDfj/ZEBzCJ8Xm21ZG6YtMbR262CcS2w==,
+        integrity: sha512-uFkGGr1KMWd6aWv9UAqooYrN78trw8MWWmoPvgWokfBEUq1+eiIQ+qfj3wokhy0fxtZWZk+0dHoS7/yRTJtd6w==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
 
@@ -4079,12 +4207,6 @@ packages:
         integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==,
       }
 
-  regex-recursion@5.1.1:
-    resolution:
-      {
-        integrity: sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==,
-      }
-
   regex-recursion@6.0.2:
     resolution:
       {
@@ -4095,12 +4217,6 @@ packages:
     resolution:
       {
         integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==,
-      }
-
-  regex@5.1.1:
-    resolution:
-      {
-        integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==,
       }
 
   regex@6.1.0:
@@ -4273,10 +4389,26 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
+  seroval-plugins@1.5.6:
+    resolution:
+      {
+        integrity: sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==,
+      }
+    engines: { node: ">=10" }
+    peerDependencies:
+      seroval: ^1.0
+
   seroval@1.5.4:
     resolution:
       {
         integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==,
+      }
+    engines: { node: ">=10" }
+
+  seroval@1.5.6:
+    resolution:
+      {
+        integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==,
       }
     engines: { node: ">=10" }
 
@@ -4294,17 +4426,18 @@ packages:
       }
     engines: { node: ">=8" }
 
-  shiki@1.29.2:
-    resolution:
-      {
-        integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==,
-      }
-
   shiki@3.23.0:
     resolution:
       {
         integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==,
       }
+
+  shiki@4.3.1:
+    resolution:
+      {
+        integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==,
+      }
+    engines: { node: ">=20" }
 
   slugify@1.6.6:
     resolution:
@@ -4325,6 +4458,12 @@ packages:
     resolution:
       {
         integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==,
+      }
+
+  solid-js@1.9.14:
+    resolution:
+      {
+        integrity: sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==,
       }
 
   solid-list@0.3.0:
@@ -4410,6 +4549,14 @@ packages:
     engines: { node: ">=20.16.0" }
     hasBin: true
 
+  srvx@0.12.4:
+    resolution:
+      {
+        integrity: sha512-RixzFlMn3dvzDTpKIAXhXrqL4cy6vScNCP0VVwgVbUBU94o+DiXLsFnAZetbyKAEnK6Ox3hzHXWGsyv/Iibv7g==,
+      }
+    engines: { node: ">=20.16.0" }
+    hasBin: true
+
   stackframe@1.3.4:
     resolution:
       {
@@ -4467,10 +4614,10 @@ packages:
       }
     engines: { node: ">=6" }
 
-  terracotta@1.1.0:
+  terracotta@1.1.1:
     resolution:
       {
-        integrity: sha512-kfQciWUBUBgYkXu7gh3CK3FAJng/iqZslAaY08C+k1Hdx17aVEpcFFb/WPaysxAfcupNH3y53s/pc53xxZauww==,
+        integrity: sha512-Sa6wnvkGMFmPq8N/wQb2aKkIW2eXH0LJvUOEk6QZLBEjqy+LsbzAOpDuqEfOmfA/hexssE6eQve2i1IIOeOh4g==,
       }
     engines: { node: ">=10" }
     peerDependencies:
@@ -4833,15 +4980,15 @@ packages:
         integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
       }
 
-  vite-plugin-solid@2.11.12:
+  vite-plugin-solid@2.11.13:
     resolution:
       {
-        integrity: sha512-FgjPcx2OwX9h6f28jli7A4bG7PP3te8uyakE5iqsmpq3Jqi1TWLgSroC9N6cMfGRU2zXsl4Q6ISvTr2VL0QHpA==,
+        integrity: sha512-YaCNMzwIawUO8K16uj5jaxUJIYCstBEjkUppC5OKElBz/K2+R7Q7MWycHDgqzjBca5WWy/2ZQQ45IHexaabYew==,
       }
     peerDependencies:
       "@testing-library/jest-dom": ^5.16.6 || ^5.17.0 || ^6.*
       solid-js: ^1.7.2
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
     peerDependenciesMeta:
       "@testing-library/jest-dom":
         optional: true
@@ -4977,7 +5124,15 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  "@babel/code-frame@7.29.7":
+    dependencies:
+      "@babel/helper-validator-identifier": 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   "@babel/compat-data@7.29.3": {}
+
+  "@babel/compat-data@7.29.7": {}
 
   "@babel/core@7.29.0":
     dependencies:
@@ -4999,10 +5154,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@babel/core@7.29.7":
+    dependencies:
+      "@babel/code-frame": 7.29.7
+      "@babel/generator": 7.29.7
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+      "@babel/helpers": 7.29.7
+      "@babel/parser": 7.29.7
+      "@babel/template": 7.29.7
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
+      "@jridgewell/remapping": 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   "@babel/generator@7.29.1":
     dependencies:
       "@babel/parser": 7.29.3
       "@babel/types": 7.29.0
+      "@jridgewell/gen-mapping": 0.3.13
+      "@jridgewell/trace-mapping": 0.3.31
+      jsesc: 3.1.0
+
+  "@babel/generator@7.29.7":
+    dependencies:
+      "@babel/parser": 7.29.7
+      "@babel/types": 7.29.7
       "@jridgewell/gen-mapping": 0.3.13
       "@jridgewell/trace-mapping": 0.3.31
       jsesc: 3.1.0
@@ -5015,7 +5198,17 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  "@babel/helper-compilation-targets@7.29.7":
+    dependencies:
+      "@babel/compat-data": 7.29.7
+      "@babel/helper-validator-option": 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
   "@babel/helper-globals@7.28.0": {}
+
+  "@babel/helper-globals@7.29.7": {}
 
   "@babel/helper-module-imports@7.18.6":
     dependencies:
@@ -5028,6 +5221,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@babel/helper-module-imports@7.29.7":
+    dependencies:
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   "@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)":
     dependencies:
       "@babel/core": 7.29.0
@@ -5037,22 +5237,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-module-imports": 7.29.7
+      "@babel/helper-validator-identifier": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   "@babel/helper-plugin-utils@7.28.6": {}
 
   "@babel/helper-string-parser@7.27.1": {}
 
+  "@babel/helper-string-parser@7.29.7": {}
+
   "@babel/helper-validator-identifier@7.28.5": {}
 
+  "@babel/helper-validator-identifier@7.29.7": {}
+
   "@babel/helper-validator-option@7.27.1": {}
+
+  "@babel/helper-validator-option@7.29.7": {}
 
   "@babel/helpers@7.29.2":
     dependencies:
       "@babel/template": 7.28.6
       "@babel/types": 7.29.0
 
+  "@babel/helpers@7.29.7":
+    dependencies:
+      "@babel/template": 7.29.7
+      "@babel/types": 7.29.7
+
   "@babel/parser@7.29.3":
     dependencies:
       "@babel/types": 7.29.0
+
+  "@babel/parser@7.29.7":
+    dependencies:
+      "@babel/types": 7.29.7
 
   "@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)":
     dependencies:
@@ -5064,6 +5288,12 @@ snapshots:
       "@babel/code-frame": 7.29.0
       "@babel/parser": 7.29.3
       "@babel/types": 7.29.0
+
+  "@babel/template@7.29.7":
+    dependencies:
+      "@babel/code-frame": 7.29.7
+      "@babel/parser": 7.29.7
+      "@babel/types": 7.29.7
 
   "@babel/traverse@7.29.0":
     dependencies:
@@ -5077,10 +5307,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@babel/traverse@7.29.7":
+    dependencies:
+      "@babel/code-frame": 7.29.7
+      "@babel/generator": 7.29.7
+      "@babel/helper-globals": 7.29.7
+      "@babel/parser": 7.29.7
+      "@babel/template": 7.29.7
+      "@babel/types": 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   "@babel/types@7.29.0":
     dependencies:
       "@babel/helper-string-parser": 7.27.1
       "@babel/helper-validator-identifier": 7.28.5
+
+  "@babel/types@7.29.7":
+    dependencies:
+      "@babel/helper-string-parser": 7.29.7
+      "@babel/helper-validator-identifier": 7.29.7
 
   "@bprogress/core@1.3.4": {}
 
@@ -5099,7 +5346,18 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  "@emnapi/core@1.11.2":
+    dependencies:
+      "@emnapi/wasi-threads": 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   "@emnapi/runtime@1.11.1":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/runtime@1.11.2":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5338,7 +5596,7 @@ snapshots:
       solid-presence: 0.1.8(solid-js@1.9.12)
       solid-prevent-scroll: 0.1.10(solid-js@1.9.12)
 
-  "@kobalte/solidbase@0.6.4(@solidjs/start@2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
+  "@kobalte/solidbase@0.6.4(@solidjs/start@2.0.0-rc.5(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
     dependencies:
       "@alloc/quick-lru": 5.2.0
       "@bprogress/core": 1.3.4
@@ -5362,7 +5620,83 @@ snapshots:
       "@solid-primitives/storage": 4.3.4(solid-js@1.9.12)
       "@solidjs/meta": 0.29.4(solid-js@1.9.12)
       "@solidjs/router": 0.16.1(solid-js@1.9.12)
-      "@solidjs/start": 2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      "@solidjs/start": 2.0.0-rc.5(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      esast-util-from-js: 2.0.1
+      estree-util-value-to-estree: 3.5.0
+      expressive-code: 0.41.7
+      expressive-code-twoslash: 0.4.0(@expressive-code/core@0.41.7)(expressive-code@0.41.7)(typescript@5.9.3)
+      gray-matter: 4.0.3
+      hastscript: 9.0.1
+      magic-string: 0.30.21
+      mdast-util-find-and-replace: 3.0.2
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-to-string: 4.0.0
+      mdast-util-toc: 7.1.0
+      parse-numeric-range: 1.3.0
+      prettier: 4.0.0-alpha.13
+      rehype-autolink-headings: 7.1.0
+      rehype-expressive-code: 0.41.7
+      rehype-raw: 7.0.0
+      rehype-slug: 6.0.0
+      remark: 15.0.1
+      remark-directive: 3.0.1
+      remark-frontmatter: 5.0.0
+      remark-gfm: 4.0.1
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      solid-js: 1.9.12
+      source-map: 0.7.6
+      toml: 3.0.0
+      typescript: 5.9.3
+      unified: 11.0.5
+      unist-builder: 4.0.0
+      unist-util-mdx-define: 1.1.2
+      unist-util-visit: 5.1.0
+      unplugin-auto-import: 19.3.0
+      unplugin-icons: 22.5.0
+      vite: 8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - "@nuxt/kit"
+      - "@svgr/core"
+      - "@svgx/core"
+      - "@tauri-apps/plugin-store"
+      - "@vue/compiler-sfc"
+      - "@vueuse/core"
+      - solid-start
+      - supports-color
+      - svelte
+      - vue-template-compiler
+      - vue-template-es2015-compiler
+
+  "@kobalte/solidbase@0.6.4(@solidjs/start@2.0.0-rc.5(crossws@0.4.10(srvx@0.12.4))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
+    dependencies:
+      "@alloc/quick-lru": 5.2.0
+      "@bprogress/core": 1.3.4
+      "@docsearch/css": 3.9.0
+      "@expressive-code/core": 0.41.7
+      "@expressive-code/plugin-collapsible-sections": 0.41.7
+      "@expressive-code/plugin-frames": 0.41.7
+      "@expressive-code/plugin-line-numbers": 0.41.7
+      "@fontsource-variable/inter": 5.2.8
+      "@fontsource-variable/jetbrains-mono": 5.2.8
+      "@fontsource-variable/lexend": 5.2.11
+      "@kobalte/core": 0.13.11(solid-js@1.9.12)
+      "@mdx-js/mdx": 3.1.1
+      "@solid-primitives/clipboard": 1.6.4(solid-js@1.9.12)
+      "@solid-primitives/context": 0.2.3(solid-js@1.9.12)
+      "@solid-primitives/event-listener": 2.4.5(solid-js@1.9.12)
+      "@solid-primitives/keyboard": 1.3.5(solid-js@1.9.12)
+      "@solid-primitives/media": 2.3.5(solid-js@1.9.12)
+      "@solid-primitives/platform": 0.1.2(solid-js@1.9.12)
+      "@solid-primitives/scroll": 2.1.5(solid-js@1.9.12)
+      "@solid-primitives/storage": 4.3.4(solid-js@1.9.12)
+      "@solidjs/meta": 0.29.4(solid-js@1.9.12)
+      "@solidjs/router": 0.16.1(solid-js@1.9.12)
+      "@solidjs/start": 2.0.0-rc.5(crossws@0.4.10(srvx@0.12.4))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       cross-spawn: 7.0.6
       diff: 8.0.4
       esast-util-from-js: 2.0.1
@@ -5466,6 +5800,13 @@ snapshots:
       "@tybys/wasm-util": 0.10.3
     optional: true
 
+  "@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)":
+    dependencies:
+      "@emnapi/core": 1.11.2
+      "@emnapi/runtime": 1.11.2
+      "@tybys/wasm-util": 0.10.3
+    optional: true
+
   "@noble/hashes@1.8.0": {}
 
   "@nodelib/fs.scandir@2.1.5":
@@ -5496,73 +5837,73 @@ snapshots:
 
   "@orama/oramacore-events-parser@0.0.5": {}
 
-  "@oxc-parser/binding-android-arm-eabi@0.139.0":
+  "@oxc-parser/binding-android-arm-eabi@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-android-arm64@0.139.0":
+  "@oxc-parser/binding-android-arm64@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-darwin-arm64@0.139.0":
+  "@oxc-parser/binding-darwin-arm64@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-darwin-x64@0.139.0":
+  "@oxc-parser/binding-darwin-x64@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-freebsd-x64@0.139.0":
+  "@oxc-parser/binding-freebsd-x64@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-linux-arm-gnueabihf@0.139.0":
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-linux-arm-musleabihf@0.139.0":
+  "@oxc-parser/binding-linux-arm-musleabihf@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-linux-arm64-gnu@0.139.0":
+  "@oxc-parser/binding-linux-arm64-gnu@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-linux-arm64-musl@0.139.0":
+  "@oxc-parser/binding-linux-arm64-musl@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-linux-ppc64-gnu@0.139.0":
+  "@oxc-parser/binding-linux-ppc64-gnu@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-linux-riscv64-gnu@0.139.0":
+  "@oxc-parser/binding-linux-riscv64-gnu@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-linux-riscv64-musl@0.139.0":
+  "@oxc-parser/binding-linux-riscv64-musl@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-linux-s390x-gnu@0.139.0":
+  "@oxc-parser/binding-linux-s390x-gnu@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-linux-x64-gnu@0.139.0":
+  "@oxc-parser/binding-linux-x64-gnu@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-linux-x64-musl@0.139.0":
+  "@oxc-parser/binding-linux-x64-musl@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-openharmony-arm64@0.139.0":
+  "@oxc-parser/binding-openharmony-arm64@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-wasm32-wasi@0.139.0":
+  "@oxc-parser/binding-wasm32-wasi@0.141.0":
     dependencies:
-      "@emnapi/core": 1.11.1
-      "@emnapi/runtime": 1.11.1
-      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      "@emnapi/core": 1.11.2
+      "@emnapi/runtime": 1.11.2
+      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  "@oxc-parser/binding-win32-arm64-msvc@0.139.0":
+  "@oxc-parser/binding-win32-arm64-msvc@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-win32-ia32-msvc@0.139.0":
+  "@oxc-parser/binding-win32-ia32-msvc@0.141.0":
     optional: true
 
-  "@oxc-parser/binding-win32-x64-msvc@0.139.0":
+  "@oxc-parser/binding-win32-x64-msvc@0.141.0":
     optional: true
 
   "@oxc-project/types@0.137.0": {}
 
-  "@oxc-project/types@0.139.0": {}
+  "@oxc-project/types@0.141.0": {}
 
   "@rolldown/binding-android-arm64@1.1.3":
     optional: true
@@ -5615,15 +5956,6 @@ snapshots:
 
   "@rolldown/pluginutils@1.0.1": {}
 
-  "@shikijs/core@1.29.2":
-    dependencies:
-      "@shikijs/engine-javascript": 1.29.2
-      "@shikijs/engine-oniguruma": 1.29.2
-      "@shikijs/types": 1.29.2
-      "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
-      hast-util-to-html: 9.0.5
-
   "@shikijs/core@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
@@ -5631,11 +5963,13 @@ snapshots:
       "@types/hast": 3.0.4
       hast-util-to-html: 9.0.5
 
-  "@shikijs/engine-javascript@1.29.2":
+  "@shikijs/core@4.3.1":
     dependencies:
-      "@shikijs/types": 1.29.2
+      "@shikijs/primitive": 4.3.1
+      "@shikijs/types": 4.3.1
       "@shikijs/vscode-textmate": 10.0.2
-      oniguruma-to-es: 2.3.0
+      "@types/hast": 3.0.4
+      hast-util-to-html: 9.0.5
 
   "@shikijs/engine-javascript@3.23.0":
     dependencies:
@@ -5643,38 +5977,50 @@ snapshots:
       "@shikijs/vscode-textmate": 10.0.2
       oniguruma-to-es: 4.3.6
 
-  "@shikijs/engine-oniguruma@1.29.2":
+  "@shikijs/engine-javascript@4.3.1":
     dependencies:
-      "@shikijs/types": 1.29.2
+      "@shikijs/types": 4.3.1
       "@shikijs/vscode-textmate": 10.0.2
+      oniguruma-to-es: 4.3.6
 
   "@shikijs/engine-oniguruma@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
       "@shikijs/vscode-textmate": 10.0.2
 
-  "@shikijs/langs@1.29.2":
+  "@shikijs/engine-oniguruma@4.3.1":
     dependencies:
-      "@shikijs/types": 1.29.2
+      "@shikijs/types": 4.3.1
+      "@shikijs/vscode-textmate": 10.0.2
 
   "@shikijs/langs@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
 
-  "@shikijs/themes@1.29.2":
+  "@shikijs/langs@4.3.1":
     dependencies:
-      "@shikijs/types": 1.29.2
+      "@shikijs/types": 4.3.1
+
+  "@shikijs/primitive@4.3.1":
+    dependencies:
+      "@shikijs/types": 4.3.1
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
 
   "@shikijs/themes@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
 
-  "@shikijs/types@1.29.2":
+  "@shikijs/themes@4.3.1":
+    dependencies:
+      "@shikijs/types": 4.3.1
+
+  "@shikijs/types@3.23.0":
     dependencies:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
 
-  "@shikijs/types@3.23.0":
+  "@shikijs/types@4.3.1":
     dependencies:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
@@ -5788,38 +6134,75 @@ snapshots:
     dependencies:
       solid-js: 1.9.12
 
+  "@solidjs/meta@0.29.4(solid-js@1.9.14)":
+    dependencies:
+      solid-js: 1.9.14
+
   "@solidjs/router@0.16.1(solid-js@1.9.12)":
     dependencies:
       solid-js: 1.9.12
 
-  "@solidjs/start@2.0.0-rc.1(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
+  "@solidjs/start@2.0.0-rc.5(crossws@0.4.10(srvx@0.11.22))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
     dependencies:
-      "@babel/core": 7.29.0
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.29.0
-      "@solidjs/meta": 0.29.4(solid-js@1.9.12)
+      "@babel/core": 7.29.7
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
+      "@solidjs/meta": 0.29.4(solid-js@1.9.14)
       "@types/babel__traverse": 7.28.0
       "@types/micromatch": 4.0.10
-      cookie-es: 2.0.1
+      cookie-es: 3.1.1
       defu: 6.1.7
       error-stack-parser: 2.1.4
       fast-glob: 3.3.3
-      h3: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
+      h3: 2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22))
       html-to-image: 1.11.13
       micromatch: 4.0.8
-      oxc-parser: 0.139.0
+      oxc-parser: 0.141.0
       path-to-regexp: 8.4.2
       pathe: 2.0.3
       radix3: 1.1.2
-      seroval: 1.5.4
-      seroval-plugins: 1.5.4(seroval@1.5.4)
-      shiki: 1.29.2
-      solid-js: 1.9.12
+      seroval: 1.5.6
+      seroval-plugins: 1.5.6(seroval@1.5.6)
+      shiki: 4.3.1
+      solid-js: 1.9.14
       source-map-js: 1.2.1
-      srvx: 0.11.22
-      terracotta: 1.1.0(solid-js@1.9.12)
+      srvx: 0.12.4
+      terracotta: 1.1.1(solid-js@1.9.14)
       vite: 8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
-      vite-plugin-solid: 2.11.12(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      vite-plugin-solid: 2.11.13(solid-js@1.9.14)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - "@testing-library/jest-dom"
+      - crossws
+      - supports-color
+
+  "@solidjs/start@2.0.0-rc.5(crossws@0.4.10(srvx@0.12.4))(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
+      "@solidjs/meta": 0.29.4(solid-js@1.9.14)
+      "@types/babel__traverse": 7.28.0
+      "@types/micromatch": 4.0.10
+      cookie-es: 3.1.1
+      defu: 6.1.7
+      error-stack-parser: 2.1.4
+      fast-glob: 3.3.3
+      h3: 2.0.1-rc.26(crossws@0.4.10(srvx@0.12.4))
+      html-to-image: 1.11.13
+      micromatch: 4.0.8
+      oxc-parser: 0.141.0
+      path-to-regexp: 8.4.2
+      pathe: 2.0.3
+      radix3: 1.1.2
+      seroval: 1.5.6
+      seroval-plugins: 1.5.6(seroval@1.5.6)
+      shiki: 4.3.1
+      solid-js: 1.9.14
+      source-map-js: 1.2.1
+      srvx: 0.12.4
+      terracotta: 1.1.1(solid-js@1.9.14)
+      vite: 8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
+      vite-plugin-solid: 2.11.13(solid-js@1.9.14)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - "@testing-library/jest-dom"
       - crossws
@@ -6149,12 +6532,12 @@ snapshots:
       html-entities: 2.3.3
       parse5: 7.3.0
 
-  babel-preset-solid@1.9.12(@babel/core@7.29.0)(solid-js@1.9.12):
+  babel-preset-solid@1.9.12(@babel/core@7.29.0)(solid-js@1.9.14):
     dependencies:
       "@babel/core": 7.29.0
       babel-plugin-jsx-dom-expressions: 0.40.6(@babel/core@7.29.0)
     optionalDependencies:
-      solid-js: 1.9.12
+      solid-js: 1.9.14
 
   bail@2.0.2: {}
 
@@ -6225,7 +6608,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie-es@2.0.1: {}
+  cookie-es@3.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6236,6 +6619,11 @@ snapshots:
   crossws@0.4.10(srvx@0.11.22):
     optionalDependencies:
       srvx: 0.11.22
+
+  crossws@0.4.10(srvx@0.12.4):
+    optionalDependencies:
+      srvx: 0.12.4
+    optional: true
 
   css-select@5.2.2:
     dependencies:
@@ -6300,8 +6688,6 @@ snapshots:
   dotenv@17.4.2: {}
 
   electron-to-chromium@1.5.349: {}
-
-  emoji-regex-xs@1.0.0: {}
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -6603,12 +6989,19 @@ snapshots:
     optionalDependencies:
       crossws: 0.4.10(srvx@0.11.22)
 
-  h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)):
+  h3@2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22)):
     dependencies:
       rou3: 0.9.1
-      srvx: 0.11.22
+      srvx: 0.12.4
     optionalDependencies:
       crossws: 0.4.10(srvx@0.11.22)
+
+  h3@2.0.1-rc.26(crossws@0.4.10(srvx@0.12.4)):
+    dependencies:
+      rou3: 0.9.1
+      srvx: 0.12.4
+    optionalDependencies:
+      crossws: 0.4.10(srvx@0.12.4)
 
   hasown@2.0.3:
     dependencies:
@@ -7513,12 +7906,6 @@ snapshots:
 
   oniguruma-parser@0.12.2: {}
 
-  oniguruma-to-es@2.3.0:
-    dependencies:
-      emoji-regex-xs: 1.0.0
-      regex: 5.1.1
-      regex-recursion: 5.1.1
-
   oniguruma-to-es@4.3.6:
     dependencies:
       oniguruma-parser: 0.12.2
@@ -7534,30 +7921,30 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  oxc-parser@0.139.0:
+  oxc-parser@0.141.0:
     dependencies:
-      "@oxc-project/types": 0.139.0
+      "@oxc-project/types": 0.141.0
     optionalDependencies:
-      "@oxc-parser/binding-android-arm-eabi": 0.139.0
-      "@oxc-parser/binding-android-arm64": 0.139.0
-      "@oxc-parser/binding-darwin-arm64": 0.139.0
-      "@oxc-parser/binding-darwin-x64": 0.139.0
-      "@oxc-parser/binding-freebsd-x64": 0.139.0
-      "@oxc-parser/binding-linux-arm-gnueabihf": 0.139.0
-      "@oxc-parser/binding-linux-arm-musleabihf": 0.139.0
-      "@oxc-parser/binding-linux-arm64-gnu": 0.139.0
-      "@oxc-parser/binding-linux-arm64-musl": 0.139.0
-      "@oxc-parser/binding-linux-ppc64-gnu": 0.139.0
-      "@oxc-parser/binding-linux-riscv64-gnu": 0.139.0
-      "@oxc-parser/binding-linux-riscv64-musl": 0.139.0
-      "@oxc-parser/binding-linux-s390x-gnu": 0.139.0
-      "@oxc-parser/binding-linux-x64-gnu": 0.139.0
-      "@oxc-parser/binding-linux-x64-musl": 0.139.0
-      "@oxc-parser/binding-openharmony-arm64": 0.139.0
-      "@oxc-parser/binding-wasm32-wasi": 0.139.0
-      "@oxc-parser/binding-win32-arm64-msvc": 0.139.0
-      "@oxc-parser/binding-win32-ia32-msvc": 0.139.0
-      "@oxc-parser/binding-win32-x64-msvc": 0.139.0
+      "@oxc-parser/binding-android-arm-eabi": 0.141.0
+      "@oxc-parser/binding-android-arm64": 0.141.0
+      "@oxc-parser/binding-darwin-arm64": 0.141.0
+      "@oxc-parser/binding-darwin-x64": 0.141.0
+      "@oxc-parser/binding-freebsd-x64": 0.141.0
+      "@oxc-parser/binding-linux-arm-gnueabihf": 0.141.0
+      "@oxc-parser/binding-linux-arm-musleabihf": 0.141.0
+      "@oxc-parser/binding-linux-arm64-gnu": 0.141.0
+      "@oxc-parser/binding-linux-arm64-musl": 0.141.0
+      "@oxc-parser/binding-linux-ppc64-gnu": 0.141.0
+      "@oxc-parser/binding-linux-riscv64-gnu": 0.141.0
+      "@oxc-parser/binding-linux-riscv64-musl": 0.141.0
+      "@oxc-parser/binding-linux-s390x-gnu": 0.141.0
+      "@oxc-parser/binding-linux-x64-gnu": 0.141.0
+      "@oxc-parser/binding-linux-x64-musl": 0.141.0
+      "@oxc-parser/binding-openharmony-arm64": 0.141.0
+      "@oxc-parser/binding-wasm32-wasi": 0.141.0
+      "@oxc-parser/binding-win32-arm64-msvc": 0.141.0
+      "@oxc-parser/binding-win32-ia32-msvc": 0.141.0
+      "@oxc-parser/binding-win32-x64-msvc": 0.141.0
 
   p-limit@3.1.0:
     dependencies:
@@ -7688,20 +8075,11 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
-  regex-recursion@5.1.1:
-    dependencies:
-      regex: 5.1.1
-      regex-utilities: 2.3.0
-
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
 
   regex-utilities@2.3.0: {}
-
-  regex@5.1.1:
-    dependencies:
-      regex-utilities: 2.3.0
 
   regex@6.1.0:
     dependencies:
@@ -7865,24 +8243,19 @@ snapshots:
     dependencies:
       seroval: 1.5.4
 
+  seroval-plugins@1.5.6(seroval@1.5.6):
+    dependencies:
+      seroval: 1.5.6
+
   seroval@1.5.4: {}
+
+  seroval@1.5.6: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
-
-  shiki@1.29.2:
-    dependencies:
-      "@shikijs/core": 1.29.2
-      "@shikijs/engine-javascript": 1.29.2
-      "@shikijs/engine-oniguruma": 1.29.2
-      "@shikijs/langs": 1.29.2
-      "@shikijs/themes": 1.29.2
-      "@shikijs/types": 1.29.2
-      "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
 
   shiki@3.23.0:
     dependencies:
@@ -7895,6 +8268,17 @@ snapshots:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
 
+  shiki@4.3.1:
+    dependencies:
+      "@shikijs/core": 4.3.1
+      "@shikijs/engine-javascript": 4.3.1
+      "@shikijs/engine-oniguruma": 4.3.1
+      "@shikijs/langs": 4.3.1
+      "@shikijs/themes": 4.3.1
+      "@shikijs/types": 4.3.1
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
+
   slugify@1.6.6: {}
 
   solid-heroicons@3.2.4(solid-js@1.9.12):
@@ -7902,6 +8286,12 @@ snapshots:
       solid-js: 1.9.12
 
   solid-js@1.9.12:
+    dependencies:
+      csstype: 3.2.3
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  solid-js@1.9.14:
     dependencies:
       csstype: 3.2.3
       seroval: 1.5.4
@@ -7922,18 +8312,18 @@ snapshots:
       "@corvu/utils": 0.4.2(solid-js@1.9.12)
       solid-js: 1.9.12
 
-  solid-refresh@0.6.3(solid-js@1.9.12):
+  solid-refresh@0.6.3(solid-js@1.9.14):
     dependencies:
       "@babel/generator": 7.29.1
       "@babel/helper-module-imports": 7.28.6
       "@babel/types": 7.29.0
-      solid-js: 1.9.12
+      solid-js: 1.9.14
     transitivePeerDependencies:
       - supports-color
 
-  solid-use@0.9.1(solid-js@1.9.12):
+  solid-use@0.9.1(solid-js@1.9.14):
     dependencies:
-      solid-js: 1.9.12
+      solid-js: 1.9.14
 
   source-map-js@1.2.1: {}
 
@@ -7946,6 +8336,8 @@ snapshots:
   srvx@0.11.15: {}
 
   srvx@0.11.22: {}
+
+  srvx@0.12.4: {}
 
   stackframe@1.3.4: {}
 
@@ -7974,10 +8366,10 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terracotta@1.1.0(solid-js@1.9.12):
+  terracotta@1.1.1(solid-js@1.9.14):
     dependencies:
-      solid-js: 1.9.12
-      solid-use: 0.9.1(solid-js@1.9.12)
+      solid-js: 1.9.14
+      solid-use: 0.9.1(solid-js@1.9.14)
 
   tinyexec@1.2.4: {}
 
@@ -8175,14 +8567,14 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)):
+  vite-plugin-solid@2.11.13(solid-js@1.9.14)(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       "@babel/core": 7.29.0
       "@types/babel__core": 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.12)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.14)
       merge-anything: 5.1.7
-      solid-js: 1.9.12
-      solid-refresh: 0.6.3(solid-js@1.9.12)
+      solid-js: 1.9.14
+      solid-refresh: 0.6.3(solid-js@1.9.14)
       vite: 8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.1.3(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:

--- a/src/routes/solid-start/v2/(0)building-your-application/(2)css-and-styling.mdx
+++ b/src/routes/solid-start/v2/(0)building-your-application/(2)css-and-styling.mdx
@@ -1,0 +1,112 @@
+---
+title: CSS and styling
+use_cases: >-
+  styling components, css modules, scoped styles, component styling, design
+  system setup, visual customization
+tags:
+  - css
+  - styling
+  - modules
+  - components
+  - design
+  - vite
+version: "2.0"
+description: >-
+  Style your SolidStart components with CSS, CSS modules, and other styling
+  solutions. Implement scoped styles and design systems.
+---
+
+SolidStart is a standards-based framework that, instead of modifying the behavior of the [`<style>` tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style), strives to build on top of it.
+
+## Styling components
+
+Vite provides a simple way to [manage CSS for complex web applications](https://vitejs.dev/guide/features.html#css).
+It does this by allowing users to import CSS using ESM syntax anywhere within the component tree.
+For example, you can write CSS in a file accompanying your component file:
+
+```
+src/
+├── components/
+│   ├── Card.tsx
+│   ├── Card.css
+```
+
+To use the CSS in the component, you can define the CSS in the `Card.css` file and import it in the `Card.tsx` file:
+
+```css title="Card.css"
+.card {
+	background-color: #446b9e;
+}
+
+h1 {
+	font-size: 1.5em;
+	font-weight: bold;
+}
+
+p {
+	font-size: 1em;
+	font-weight: normal;
+}
+```
+
+```tsx title="Card.tsx"
+import "./Card.css";
+
+const Card = (props) => {
+	return (
+		<div class="card">
+			<h1>{props.title}</h1>
+			<p>{props.text}</p>
+		</div>
+	);
+};
+```
+
+### CSS modules for scoped styles
+
+SolidStart also supports [vite's CSS modules](https://vitejs.dev/guide/features.html#css-modules).
+Through [CSS modules](https://github.com/css-modules/css-modules), you can scope certain CSS to a component and use the CSS class in multiple components to style them differently.
+
+For this feature to work, the `.css` file must be named with the `.module.css` extension.
+This convention also works for `.scss` and `.sass` files, which can be named with the `.module.scss` and `.module.sass` extensions, respectively.
+
+```css title="Card.module.css"
+.card {
+	background-color: #446b9e;
+}
+
+div.card > h1 {
+	font-size: 1.5em;
+	font-weight: bold;
+}
+
+div.card > p {
+	font-size: 1em;
+	font-weight: normal;
+}
+```
+
+When first using CSS modules, you will encounter an error when trying to use the class attribute in your components.
+This is because, behind the scenes, classes defined in CSS modules are renamed to a series of random letters.
+When classes are hard coded using the class attribute (`class="card"`), Solid is not aware that it should rename `card` to something different.
+
+To fix this, you can import classes used in your CSS module.
+The import object can be thought of as `humanClass: generatedClass` and within the component, the key (ie. the class on the element) is used to get the unique, generated class name.
+
+```jsx
+import styles from "./Card.module.css";
+
+const Card = (props) => {
+	return (
+		<div class={styles.card}>
+			<h1>{props.title}</h1>
+			<p>{props.text}</p>
+		</div>
+	);
+};
+```
+
+## Other ways to style components
+
+SolidStart is built on top of Solid, meaning styling is not limited to CSS.
+To see other ways to style components, see the [styling section in the Solid documentation](/guides/styling-your-components).

--- a/src/routes/solid-start/v2/(0)building-your-application/(5)head-and-metadata.mdx
+++ b/src/routes/solid-start/v2/(0)building-your-application/(5)head-and-metadata.mdx
@@ -1,0 +1,99 @@
+---
+title: Head and metadata
+use_cases: >-
+  seo optimization, page titles, meta tags, og tags, social sharing, search
+  engine visibility, dynamic metadata
+tags:
+  - seo
+  - metadata
+  - head
+  - title
+  - meta
+  - og-tags
+version: "2.0"
+description: >-
+  Manage SEO and metadata in SolidStart with dynamic titles, meta tags, and Open
+  Graph tags.
+---
+
+SolidStart does not bundle a metadata API. Use [`@solidjs/meta`](/solid-meta) to manage document titles, metadata, links, styles, and other elements in `<head>`.
+
+```package-install
+@solidjs/meta
+```
+
+## Add the provider
+
+Place `MetaProvider` in the router root so route metadata is collected during server rendering and updated during client navigation.
+
+```tsx title="src/app.tsx" {8,12}
+import { MetaProvider } from "@solidjs/meta";
+import { Router } from "@solidjs/router";
+import { FileRoutes } from "@solidjs/start/router";
+import { Suspense } from "solid-js";
+
+export default function App() {
+	return (
+		<Router
+			root={(props) => (
+				<MetaProvider>
+					<Suspense>{props.children}</Suspense>
+				</MetaProvider>
+			)}
+		>
+			<FileRoutes />
+		</Router>
+	);
+}
+```
+
+## Set route metadata
+
+Metadata components can be rendered from any route below `MetaProvider`. They are removed or updated when the route changes.
+
+```tsx title="src/routes/about.tsx"
+import { Meta, Title } from "@solidjs/meta";
+
+export default function About() {
+	return (
+		<>
+			<Title>About | My site</Title>
+			<Meta name="description" content="Learn more about my site." />
+			<Meta property="og:title" content="About my site" />
+			<h1>About</h1>
+		</>
+	);
+}
+```
+
+## Use asynchronous data
+
+Metadata can read the same query result as the route. Wrap the rendered data in `Suspense` or `Show` when it may not be available immediately.
+
+```tsx title="src/routes/users/[id].tsx"
+import { Title } from "@solidjs/meta";
+import { createAsync, query, type RouteSectionProps } from "@solidjs/router";
+import { Show } from "solid-js";
+
+const getUser = query(async (id: string) => {
+	"use server";
+	return { id, name: `User ${id}` };
+}, "user");
+
+export default function User(props: RouteSectionProps) {
+	const user = createAsync(() => getUser(props.params.id));
+
+	return (
+		<Show when={user()}>
+			{(value) => (
+				<>
+					<Title>{value().name}</Title>
+					<h1>{value().name}</h1>
+				</>
+			)}
+		</Show>
+	);
+}
+```
+
+See the [`@solidjs/meta` documentation](/solid-meta) for all supported head elements and provider behavior.

--- a/src/routes/solid-start/v2/(0)building-your-application/(6)route-prerendering.mdx
+++ b/src/routes/solid-start/v2/(0)building-your-application/(6)route-prerendering.mdx
@@ -1,0 +1,57 @@
+---
+title: Route pre-rendering
+use_cases: >-
+  static site generation, ssg, blog sites, documentation, marketing pages,
+  performance optimization, seo improvement
+tags:
+  - prerender
+  - ssg
+  - static
+  - performance
+  - build
+  - seo
+version: "2.0"
+description: >-
+  Pre-render SolidStart routes to static HTML with Nitro v3.
+---
+
+Route pre-rendering produces static HTML during `vite build`. Nitro writes the generated files to `.output/public`, where a CDN or server can serve them without rendering the route on each request.
+
+Configure prerendering through Nitro's top-level Vite configuration.
+
+## Pre-render selected routes
+
+```tsx title="vite.config.ts"
+import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+import { solidStart } from "@solidjs/start/config";
+
+export default defineConfig({
+	plugins: [solidStart(), nitro()],
+	nitro: {
+		prerender: {
+			routes: ["/", "/about"],
+		},
+	},
+});
+```
+
+## Crawl links
+
+Set `crawlLinks` to start at `/` and follow links found in rendered HTML. Add `routes` when the crawler needs additional entry points.
+
+```tsx title="vite.config.ts"
+export default defineConfig({
+	plugins: [solidStart(), nitro()],
+	nitro: {
+		prerender: {
+			crawlLinks: true,
+			failOnError: true,
+		},
+	},
+});
+```
+
+Dynamic routes that are not linked from a crawled page must be listed explicitly or discovered from another entry route.
+
+For retry, concurrency, ignore, and output-path options, see [Nitro's prerender configuration](https://nitro.build/config#prerender).

--- a/src/routes/solid-start/v2/(0)building-your-application/(7)static-assets.mdx
+++ b/src/routes/solid-start/v2/(0)building-your-application/(7)static-assets.mdx
@@ -1,0 +1,93 @@
+---
+title: Static assets
+use_cases: >-
+  images, fonts, documents, favicon, robots.txt, service workers, media files,
+  public resources
+tags:
+  - assets
+  - images
+  - public
+  - static
+  - media
+  - files
+version: "2.0"
+description: >-
+  Manage static assets in SolidStart using the public directory or imports.
+  Serve images, fonts, documents, and media files.
+---
+
+Within SolidStart there are two ways to import static assets into your project: using the public directory and using imports.
+
+## Public directory
+
+Rich web applications use assets to create visuals.
+In SolidStart, the `/public` directory can be used to store static assets.
+These assets are served at the exact path they are in, relative to the public directory:
+
+```
+|-- public
+|   favicon.ico                   ->  /favicon.ico
+|   |-- images
+|   |   |-- logo.png              ->  /images/logo.png
+|   |   |-- background.png        ->  /images/background.png
+|   |-- models
+|   |   |-- player.gltf           ->  /models/player.gltf
+|   |-- documents
+|   |   |-- report.pdf            ->  /documents/report.pdf
+```
+
+If you would like to reference an asset in the public directory, you can use the absolute path to the asset:
+
+```tsx { 5 }
+export default function About() {
+	return (
+		<>
+			<h1>About</h1>
+			<img src="/images/logo.png" alt="Solid logo" />
+		</>
+	);
+}
+```
+
+This is ideal when you want to have human-readable, stable references to static assets.
+This can be useful for assets such as:
+
+- documents
+- service workers
+- images, audio, and video
+- manifest files
+- metadata files (e.g., `robots.txt`, sitemaps)
+- favicon
+
+## Importing assets
+
+Vite provides a way to import assets directly into your Solid components:
+
+```tsx
+import logo from "./solid.png";
+
+export default function About() {
+	return (
+		<>
+			<h1>About</h1>
+			<img src={logo} alt="Solid logo" />
+			// Renders
+			<img src="/assets/solid.2d8efhg.png" alt="Solid logo" />
+		</>
+	);
+}
+```
+
+When you use imports, Vite will create a hashed filename.
+For example, `solid.png` will become `solid.2d8efhg.png`.
+
+## Public directory versus imports
+
+The public directory and imports are both valid ways to include static assets in your project.
+The driver to use one over the other is based on your use case.
+
+For dynamic updates to your assets, using the public directory is the best choice.
+It allows you to maintain full control over the asset URL paths, ensuring that the links remain consistent even when the assets are updated.
+
+When using imports, the filename is hashed and therefore will not be predictable over time.
+This can be beneficial for cache busting but detrimental if you want to send someone a link to the asset.

--- a/src/routes/solid-start/v2/(0)index.mdx
+++ b/src/routes/solid-start/v2/(0)index.mdx
@@ -16,7 +16,7 @@ description: >-
   Vite-based configuration.
 ---
 
-SolidStart 2.0 builds a full-stack app on top of [Solid](/) and [Solid Router](/solid-router), with file-based routing, server functions, and Vite-based configuration.
+SolidStart v2 builds a full-stack app on top of [Solid v1](/), [Solid Router](/solid-router), and [Vite 8+](https://vite.dev). It uses Vite's Environment API for client and server builds and works with deployment Vite plugins such as [Nitro v3](https://nitro.build) and the [Cloudflare Vite plugin](https://www.npmjs.com/package/@cloudflare/vite-plugin).
 
 The framework is split into a handful of entry points:
 
@@ -25,6 +25,8 @@ The framework is split into a handful of entry points:
 - `@solidjs/start/server` for server rendering helpers and server-side types
 - `@solidjs/start/http` for request, response, cookie, and session helpers
 - `@solidjs/start/middleware` for middleware composition
+
+SolidStart v2 requires Node.js 24 or newer and Vite 8 or 9.
 
 ## What v2 keeps
 
@@ -37,6 +39,6 @@ The core model carries over from v1:
 
 ## What changed from v1
 
-Configuration moved from `app.config.ts` to `vite.config.ts` through `solidStart()`.
+Configuration moved from `app.config.ts` to `vite.config.ts`. The `solidStart()` plugin configures the application, while a deployment Vite plugin configures the server runtime and deployment target.
 
 If you are upgrading an existing app, start with the [migration guide](/solid-start/v2/migrating-from-v1).

--- a/src/routes/solid-start/v2/(1)advanced/(0)middleware.mdx
+++ b/src/routes/solid-start/v2/(1)advanced/(0)middleware.mdx
@@ -1,0 +1,155 @@
+---
+title: Middleware
+use_cases: >-
+  request interception, header management, global data sharing, request
+  preprocessing, logging, redirects
+tags:
+  - middleware
+  - headers
+  - interceptors
+  - logging
+  - preprocessing
+  - locals
+version: "2.0"
+description: >-
+  Compose H3 v2 middleware for authentication, logging, headers, and
+  request-scoped data in SolidStart.
+---
+
+Middleware runs around SolidStart's request handler. It is useful for logging, redirects, request preprocessing, response headers, and initializing request-scoped data.
+
+Do not rely on middleware alone for authorization. Client-side navigation can reuse data and server functions independently of a page request, so authorization must also be enforced close to each protected query, action, or API route.
+
+## Configure middleware
+
+Create a middleware module and pass its path to `solidStart()`.
+
+```ts title="src/middleware/index.ts"
+import { createMiddleware } from "@solidjs/start/middleware";
+
+export default createMiddleware([
+	async (event, next) => {
+		console.log("Request received:", event.req.url);
+		const startedAt = Date.now();
+
+		const response = await next();
+
+		console.log(`Request took ${Date.now() - startedAt}ms`);
+		return response;
+	},
+]);
+```
+
+```tsx title="vite.config.ts" {7}
+import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+import { solidStart } from "@solidjs/start/config";
+
+export default defineConfig({
+	plugins: [solidStart({ middleware: "./src/middleware/index.ts" }), nitro()],
+});
+```
+
+Each entry is an [H3 middleware](https://h3.dev/guide/basics/middleware). Code before `await next()` runs before the downstream handler. Code after it runs as the response unwinds.
+
+## Request-scoped locals
+
+SolidStart decorates configured middleware with its request context. Use `getRequestEvent()` to read or update `event.locals` for later server code.
+
+```ts title="src/middleware/index.ts"
+import { createMiddleware } from "@solidjs/start/middleware";
+import { getRequestEvent } from "solid-js/web";
+
+export default createMiddleware([
+	async (_event, next) => {
+		const requestEvent = getRequestEvent();
+		if (requestEvent) {
+			requestEvent.locals.requestId = crypto.randomUUID();
+		}
+		return next();
+	},
+]);
+```
+
+Augment `App.RequestEventLocals` to type custom fields. See [Request events](/solid-start/v2/advanced/request-events#locals).
+
+## Headers and cookies
+
+H3 v2 uses Web standard `Request`, `Response`, and `Headers` objects. You can access them through the H3 event or use SolidStart's context-aware HTTP helpers.
+
+```ts title="src/middleware/index.ts"
+import { getCookie, setCookie } from "@solidjs/start/http";
+import { createMiddleware } from "@solidjs/start/middleware";
+
+export default createMiddleware([
+	async (event, next) => {
+		const theme = getCookie("theme") ?? "system";
+		setCookie("theme", theme, {
+			httpOnly: true,
+			secure: true,
+			sameSite: "lax",
+		});
+
+		const response = await next();
+		event.res.headers.set("x-theme", theme);
+		return response;
+	},
+]);
+```
+
+`@solidjs/start/http` and `@solidjs/start/middleware` are server-only entrypoints. Importing them from client-reachable code causes a clear development or build error.
+
+## Short-circuit the request
+
+Return a `Response` before calling `next()` to stop the chain.
+
+```ts
+import { createMiddleware } from "@solidjs/start/middleware";
+
+export default createMiddleware([
+	(event, next) => {
+		if (!event.req.headers.get("authorization")) {
+			return new Response("Unauthorized", { status: 401 });
+		}
+		return next();
+	},
+]);
+```
+
+Redirect responses from Solid Router work the same way:
+
+```ts
+import { redirect } from "@solidjs/router";
+import { createMiddleware } from "@solidjs/start/middleware";
+
+export default createMiddleware([
+	(event, next) => {
+		if (new URL(event.req.url).pathname === "/login") {
+			return redirect("/auth/login", 301);
+		}
+		return next();
+	},
+]);
+```
+
+## Middleware order
+
+Middleware uses an onion model. Before-`next()` logic runs in declaration order; after-`next()` logic runs in reverse order.
+
+The v1 object form with `onRequest` and `onBeforeResponse` remains available for migration but is deprecated. In `2.0.0-rc.1`, deprecated `onBeforeResponse` arrays run in their declared order. Remove any manual reversal added as a workaround for earlier prereleases.
+
+## Custom H3 handlers
+
+The experimental `decorateHandler` and `decorateMiddleware` exports from `@solidjs/start/server` provide Solid's request context to custom H3 code that runs outside the configured middleware chain.
+
+```ts
+import { decorateHandler } from "@solidjs/start/server";
+import { defineHandler } from "nitro";
+
+export default defineHandler(
+	decorateHandler(() => {
+		// getRequestEvent() is available here
+		return { ok: true };
+	})
+);
+```

--- a/src/routes/solid-start/v2/(1)advanced/(1)session.mdx
+++ b/src/routes/solid-start/v2/(1)advanced/(1)session.mdx
@@ -1,0 +1,87 @@
+---
+title: Sessions
+use_cases: >-
+  user sessions, authentication state, preferences storage, stateful
+  interactions, login persistence
+tags:
+  - sessions
+  - cookies
+  - authentication
+  - state
+  - storage
+  - persistence
+version: "2.0"
+description: >-
+  Manage encrypted cookie sessions with the SolidStart HTTP helpers.
+---
+
+Sessions let the server associate state with multiple requests from the same browser. SolidStart exposes H3 v2's encrypted cookie-session helpers through `@solidjs/start/http`.
+
+Session helpers are server-only. Use them from server functions, API routes, middleware, or other server-only modules.
+
+## Create a session helper
+
+`useSession` reads the current session and returns methods for updating or clearing it.
+
+```ts title="src/lib/session.ts"
+import { useSession } from "@solidjs/start/http";
+
+type SessionData = {
+	userId?: string;
+	theme?: "light" | "dark";
+};
+
+export function useAppSession() {
+	"use server";
+
+	return useSession<SessionData>({
+		name: "app-session",
+		password: process.env.SESSION_SECRET as string,
+		cookie: {
+			httpOnly: true,
+			secure: process.env.NODE_ENV === "production",
+			sameSite: "lax",
+		},
+	});
+}
+```
+
+Use a secret of at least 32 characters and store it in a private environment variable. Generate one with:
+
+```sh frame="none"
+openssl rand -base64 32
+```
+
+## Read session data
+
+```ts
+export async function getCurrentUserId() {
+	"use server";
+	const session = await useAppSession();
+	return session.data.userId ?? null;
+}
+```
+
+## Update session data
+
+```ts
+export async function setTheme(theme: "light" | "dark") {
+	"use server";
+	const session = await useAppSession();
+	await session.update({ theme });
+}
+```
+
+## Clear a session
+
+```ts
+export async function logout() {
+	"use server";
+	const session = await useAppSession();
+	await session.clear();
+}
+```
+
+In addition to `useSession`, `@solidjs/start/http` exports `getSession`, `updateSession`, `clearSession`, `sealSession`, and `unsealSession` for lower-level workflows.
+
+Cookie sessions should contain small, non-sensitive identifiers and preferences. For revocation, device management, or larger data, store the session record in a database and keep only its opaque ID in the cookie.

--- a/src/routes/solid-start/v2/(1)advanced/(2)request-events.mdx
+++ b/src/routes/solid-start/v2/(1)advanced/(2)request-events.mdx
@@ -1,0 +1,56 @@
+---
+title: Request events
+use_cases: >-
+  server context access, local data storage, request handling, server functions,
+  event access
+tags:
+  - events
+  - server
+  - context
+  - locals
+  - requests
+  - functions
+version: "2.0"
+description: >-
+  Access request events, typed locals, and the native H3 v2 event in SolidStart.
+---
+
+Call [`getRequestEvent`](/reference/server-utilities/get-request-event) from `solid-js/web` to access the current request in server-rendering, API, middleware, query, and action code.
+
+```tsx
+import { getRequestEvent } from "solid-js/web";
+
+const event = getRequestEvent();
+const request = event?.request;
+```
+
+`getRequestEvent()` returns `undefined` outside a request context.
+
+## Locals
+
+`event.locals` is request-scoped storage shared by SolidStart middleware and server code. Add your fields to the global `App.RequestEventLocals` interface:
+
+```tsx title="src/env.d.ts"
+declare namespace App {
+	interface RequestEventLocals {
+		user?: { id: string };
+		requestId: string;
+	}
+}
+```
+
+The `@solidjs/start/env` type entry provides the base namespace and should be included in `tsconfig.json`.
+
+```json title="tsconfig.json"
+{
+	"compilerOptions": {
+		"types": ["@solidjs/start/env"]
+	}
+}
+```
+
+## Native event
+
+`event.nativeEvent` is the underlying H3 v2 event. It exposes Web standard request and response objects as `event.nativeEvent.req` and `event.nativeEvent.res`.
+
+Most application code does not need the native event. Prefer `event.request`, `event.response`, or a helper from `@solidjs/start/http`. The HTTP entrypoint is server-only, so import it only from server code or inside a function marked with `"use server"`.

--- a/src/routes/solid-start/v2/(1)advanced/(3)return-responses.mdx
+++ b/src/routes/solid-start/v2/(1)advanced/(3)return-responses.mdx
@@ -1,0 +1,62 @@
+---
+title: Returning responses
+use_cases: >-
+  server function responses, error handling, response types, api responses,
+  typescript typing
+tags:
+  - responses
+  - server
+  - functions
+  - typescript
+  - errors
+  - api
+version: "2.0"
+description: >-
+  Return typed Response objects from server functions. Handle redirects,
+  reloads, and JSON responses with proper TypeScript support.
+---
+
+In SolidStart, it is possible to return a Response object from a server function.
+[`solid-router`](/solid-router) knows how to handle certain responses with its [`query`](/solid-router/reference/data-apis/query) and [`action`](/solid-router/reference/data-apis/action) APIs.
+For TypeScript, when returning a response using `solid-router`'s `redirect`, `reload`, or `json` helpers, they will not impact the return value of the server function.
+
+While we suggest depending on the type of the function to handle errors differently, you can always return or throw a response.
+
+## Examples
+
+In the following example, the `hello` function will return a value of type `Promise<{ hello: string }>`:
+
+```tsx
+import { json } from "@solidjs/router";
+import { GET } from "@solidjs/start";
+
+const hello = GET(async (name: string) => {
+	"use server";
+	return json(
+		{ hello: new Promise<string>((r) => setTimeout(() => r(name), 1000)) },
+		{ headers: { "cache-control": "max-age=60" } }
+	);
+});
+```
+
+However, in this example, since `redirect` and `reload` return `never` as their type, `getUser` can only return a value of type `Promise<User>`:
+
+```tsx { 4, 10, 14}
+export async function getUser() {
+	"use server";
+
+	const session = await getSession();
+	const userId = session.data.userId;
+	if (userId === undefined) return redirect("/login");
+
+	try {
+		const user: User = await db.user.findUnique({ where: { id: userId } });
+		// throwing can be awkward.
+		if (!user) return redirect("/login");
+		return user;
+	} catch {
+		// do stuff
+		throw redirect("/login");
+	}
+}
+```

--- a/src/routes/solid-start/v2/(1)advanced/(4)serialization.mdx
+++ b/src/routes/solid-start/v2/(1)advanced/(4)serialization.mdx
@@ -1,7 +1,8 @@
 ---
 title: Serialization
 use_cases: >-
-  server function payloads, data transfer, csp, security, performance
+  server function payloads, data transfer, custom types, seroval plugins, csp,
+  security, performance
 tags:
   - serialization
   - server-functions
@@ -39,6 +40,57 @@ export default defineConfig({
 - `js`: a smaller binary format that needs `eval` on the client, which a strong CSP blocks.
 
 If your app enforces a Content Security Policy, keep `json`.
+
+## Custom types
+
+Use a custom Seroval plugin when a server function needs to accept or return a value that Seroval does not support, such as a database identifier, decimal type, or another custom class.
+
+Set `serialization.plugins` to a module whose default export is an array of plugins:
+
+```tsx title="vite.config.ts"
+import { defineConfig } from "vite";
+import { solidStart } from "@solidjs/start/config";
+
+export default defineConfig({
+	plugins: [
+		solidStart({
+			serialization: {
+				plugins: "src/seroval-plugins.ts",
+			},
+		}),
+	],
+});
+```
+
+Create plugins with the API exported by `@solidjs/start/serialization`. The entrypoint exports `createPlugin`, `OpaqueReference`, and the related plugin types. Importing from it keeps the plugin on the same Seroval version that SolidStart uses.
+
+```ts title="src/seroval-plugins.ts"
+import { createPlugin } from "@solidjs/start/serialization";
+import { Money } from "./lib/money";
+
+const moneyPlugin = createPlugin<Money, { cents: any }>({
+	tag: "app/Money",
+	test: (value) => value instanceof Money,
+	parse: {
+		sync: (value, ctx) => ({ cents: ctx.parse(value.cents) }),
+		async: async (value, ctx) => ({
+			cents: await ctx.parse(value.cents),
+		}),
+		stream: (value, ctx) => ({ cents: ctx.parse(value.cents) }),
+	},
+	serialize: (node, ctx) =>
+		`new globalThis.Money(${ctx.serialize(node.cents)})`,
+	deserialize: (node, ctx) => new Money(ctx.deserialize(node.cents) as number),
+});
+
+export default [moneyPlugin];
+```
+
+SolidStart bundles the plugin module into both the client and server builds, so it must not import server-only code. Built-in SolidStart plugins run before custom plugins.
+
+Custom plugins apply to server function and action payloads. They do not affect the hydration payload produced by `solid-js/web`.
+
+With the default `json` mode, `deserialize` rebuilds the value. If you use `js` mode, the code returned by `serialize` can only refer to globals available in the client. In the example above, `Money` must be assigned to `globalThis.Money` before deserialization.
 
 ## Server function payloads
 

--- a/src/routes/solid-start/v2/(1)advanced/(5)auth.mdx
+++ b/src/routes/solid-start/v2/(1)advanced/(5)auth.mdx
@@ -1,0 +1,61 @@
+---
+title: Auth
+use_cases: >-
+  user authentication, protected routes, authorization checks, secure data
+  access, login systems
+tags:
+  - authentication
+  - authorization
+  - security
+  - protected
+  - login
+  - users
+version: "2.0"
+description: >-
+  Implement authentication and protected routes in SolidStart. Secure sensitive
+  resources and handle user authorization properly.
+---
+
+Server functions can be used to protect sensitive resources like user data.
+
+```tsx
+"use server";
+
+async function getPrivatePosts() {
+	const user = await getUser();
+	if (!user) {
+		return null; // or throw an error
+	}
+
+	return db.getPosts({ userId: user.id, private: true });
+}
+```
+
+The `getUser` function can be [implemented using sessions](/solid-start/v2/advanced/session).
+
+## Protected Routes
+
+Routes can be protected by checking the user or session object during data fetching.
+This example uses [Solid Router](/solid-router).
+
+```tsx
+const getPrivatePosts = query(async function () {
+	"use server";
+	const user = await getUser();
+	if (!user) {
+		throw redirect("/login");
+	}
+
+	return db.getPosts({ userId: user.id, private: true });
+});
+
+export default function Page() {
+	const posts = createAsync(() => getPrivatePosts(), { deferStream: true });
+}
+```
+
+Once the user hits this route, the router will attempt to fetch `getPrivatePosts` data.
+If the user is not signed in, `getPrivatePosts` will throw and the router will redirect to the login page.
+
+To prevent errors when opening the page directly, set `deferStream: true`.
+This would ensure `getPrivatePosts` resolves before the page loads since server-side redirects cannot occur after streaming has started.

--- a/src/routes/solid-start/v2/(1)advanced/(6)websocket.mdx
+++ b/src/routes/solid-start/v2/(1)advanced/(6)websocket.mdx
@@ -1,0 +1,72 @@
+---
+title: WebSocket endpoint
+use_cases: >-
+  real-time updates, chat applications, live notifications, multiplayer games,
+  collaborative editing, streaming data
+tags:
+  - websocket
+  - real-time
+  - streaming
+  - server
+  - events
+version: "2.0"
+description: >-
+  Add a Nitro v3 WebSocket endpoint to a SolidStart application.
+---
+
+SolidStart v2 uses Nitro v3's cross-platform WebSocket support. Enable the feature in Nitro's Vite configuration and define the endpoint as a Nitro server route.
+
+## Enable WebSockets
+
+```tsx title="vite.config.ts"
+import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+import { solidStart } from "@solidjs/start/config";
+
+export default defineConfig({
+	plugins: [solidStart(), nitro()],
+	nitro: {
+		serverDir: "./server",
+		features: {
+			websocket: true,
+		},
+	},
+});
+```
+
+## Create an endpoint
+
+Files in `server/routes` use Nitro's file-based server routing. This example handles connections at `/ws`.
+
+```ts title="server/routes/ws.ts"
+import { defineWebSocketHandler } from "nitro";
+
+export default defineWebSocketHandler({
+	open(peer) {
+		console.log("open", peer.id);
+		peer.send("Connected");
+	},
+	message(peer, message) {
+		console.log("message", peer.id, message.text());
+		peer.send(message.text());
+	},
+	close(peer, details) {
+		console.log("close", peer.id, details.code, details.reason);
+	},
+	error(peer, error) {
+		console.error("websocket error", peer.id, error);
+	},
+});
+```
+
+Connect with the browser WebSocket API:
+
+```ts
+const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+const socket = new WebSocket(`${protocol}//${location.host}/ws`);
+
+socket.addEventListener("open", () => socket.send("Hello"));
+socket.addEventListener("message", (event) => console.log(event.data));
+```
+
+Nitro also supports upgrade hooks, peer context, topics, namespaces, and pub/sub. See the [Nitro WebSocket guide](https://nitro.build/docs/websocket).

--- a/src/routes/solid-start/v2/(1)getting-started.mdx
+++ b/src/routes/solid-start/v2/(1)getting-started.mdx
@@ -16,7 +16,7 @@ description: >-
 ---
 
 The easiest way to start a new SolidStart project is with `create-solid`.
-It can scaffold a new app from the SolidStart template or from one of the official examples.
+SolidStart v2 requires Node.js 24 or newer.
 
 ## Create a project
 
@@ -26,7 +26,7 @@ Create a new app with the Solid scaffolding tool:
 solid
 ```
 
-Follow the interactive prompts and choose the SolidStart template or an official example that matches your use case.
+Follow the interactive prompts, choose **SolidStart**, and then choose **v2**. You can skip the version prompt with the `--solidstart --v2` flags.
 
 After the project is created, install dependencies:
 
@@ -42,14 +42,15 @@ dev
 
 ## Configuration
 
-Configuration lives in `vite.config.ts`, where the `solidStart()` plugin from `@solidjs/start/config` does the work.
+Configuration lives in `vite.config.ts`. SolidStart configures the application and Nitro v3 supplies the server and deployment integration.
 
 ```tsx title="vite.config.ts"
 import { defineConfig } from "vite";
+import { nitro } from "nitro/vite";
 import { solidStart } from "@solidjs/start/config";
 
 export default defineConfig({
-	plugins: [solidStart()],
+	plugins: [solidStart(), nitro()],
 });
 ```
 
@@ -57,12 +58,15 @@ If your app already has middleware, `solidStart()` also accepts a `middleware` o
 
 ```tsx title="vite.config.ts"
 import { defineConfig } from "vite";
+import { nitro } from "nitro/vite";
 import { solidStart } from "@solidjs/start/config";
 
 export default defineConfig({
-	plugins: [solidStart({ middleware: "./src/middleware/index.ts" })],
+	plugins: [solidStart({ middleware: "./src/middleware/index.ts" }), nitro()],
 });
 ```
+
+Use the top-level `nitro` property for Nitro options such as deployment presets, prerendering, tasks, and WebSockets.
 
 ## Start adding routes
 

--- a/src/routes/solid-start/v2/(1)getting-started.mdx
+++ b/src/routes/solid-start/v2/(1)getting-started.mdx
@@ -26,7 +26,7 @@ Create a new app with the Solid scaffolding tool:
 solid
 ```
 
-Follow the interactive prompts, choose **SolidStart**, and then choose **v2**. You can skip the version prompt with the `--solidstart --v2` flags.
+Follow the interactive prompts and choose the SolidStart template or an official example that matches your use case.
 
 After the project is created, install dependencies:
 

--- a/src/routes/solid-start/v2/(1)getting-started.mdx
+++ b/src/routes/solid-start/v2/(1)getting-started.mdx
@@ -68,6 +68,16 @@ export default defineConfig({
 
 Use the top-level `nitro` property for Nitro options such as deployment presets, prerendering, tasks, and WebSockets.
 
+## Development toolbar
+
+During development, SolidStart adds a toolbar for inspecting application errors and server function calls. The toolbar is not included in production builds.
+
+To hide it during development, set `devOverlay` to `false`:
+
+```tsx title="vite.config.ts"
+solidStart({ devOverlay: false });
+```
+
 ## Start adding routes
 
 The filesystem router reads files from your routes directory and turns them into UI routes or API routes.

--- a/src/routes/solid-start/v2/(2)guides/(0)security.mdx
+++ b/src/routes/solid-start/v2/(2)guides/(0)security.mdx
@@ -1,0 +1,220 @@
+---
+title: Security
+use_cases: >-
+  production apps, user input handling, authentication, public apis, preventing
+  attacks, secure deployments, compliance
+tags:
+  - security
+  - xss
+  - csrf
+  - cors
+  - csp
+  - middleware
+  - protection
+version: "2.0"
+description: >-
+  Secure your SolidStart apps against XSS, CSRF attacks. Configure CSP headers,
+  CORS policies, and implement security best practices.
+---
+
+## XSS (Cross Site Scripting)
+
+Solid automatically escapes values passed to JSX expressions to reduce the risk of XSS attacks.
+However, this protection does not apply when using [`innerHTML`](/reference/jsx-attributes/innerhtml).
+
+To protect your application from XSS attacks:
+
+- Set a [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+- Validate and sanitize user inputs, especially form inputs on the server and client.
+- Avoid using `innerHTML` when possible.
+  If necessary, make sure to sanitize user-supplied data with libraries such as [DOMPurify](https://github.com/cure53/DOMPurify).
+- Sanitize attributes containing user-supplied data within `<noscript>` elements.
+  This includes both the attributes of the `<noscript>` element itself and its children.
+- When URLs are provided or constructed via user input validate its `origin` and `protocol` (to avoid evaluating code via `javascript:` URLs) using the [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) API.
+
+It is highly recommended to read the [Cross Site Scripting Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html) for further guidance.
+
+## Content Security Policy (CSP)
+
+To configure the `Content-Security-Policy` HTTP header, a [middleware](/solid-start/v2/advanced/middleware) can be used.
+
+SolidStart v2 defaults to JSON serialization, which avoids an `unsafe-eval` requirement. Keep that default for a strict CSP. See [`solidStart` serialization](/solid-start/v2/reference/config/solid-start#serialization).
+
+### With nonce (recommended)
+
+If you want to use a [strict CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP#strict_csp) with nonces:
+
+1. Create middleware that generates a nonce and configures the CSP header before calling `next()`.
+2. Create a nonce using a cryptographic random value generator, such as the [`randomBytes`](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) function from the `crypto` module.
+3. Store the nonce in the [`locals`](/solid-start/v2/advanced/middleware#locals) object.
+4. Configure SolidStart to use the nonce in your [`entry-server.tsx`](/solid-start/v2/reference/entrypoints/entry-server) file.
+
+```tsx tab title="Middleware"
+import { createMiddleware } from "@solidjs/start/middleware";
+import { randomBytes } from "node:crypto";
+import { getRequestEvent } from "solid-js/web";
+
+export default createMiddleware([
+	(event, next) => {
+		const nonce = randomBytes(16).toString("base64");
+		const requestEvent = getRequestEvent();
+		if (requestEvent) requestEvent.locals.nonce = nonce;
+
+		const csp = `
+      default-src 'self';
+      script-src 'nonce-${nonce}' 'strict-dynamic';
+      object-src 'none';
+      base-uri 'none';
+      frame-ancestors 'none';
+      form-action 'self';
+    `.replace(/\s+/g, " ");
+
+		event.res.headers.set("Content-Security-Policy", csp);
+		return next();
+	},
+]);
+```
+
+```tsx tab title="entry-server.tsx" {7}
+// src/entry-server.tsx
+// @refresh reload
+import { createHandler, StartServer } from "@solidjs/start/server";
+
+export default createHandler(
+	() => <StartServer /* ... */ />,
+	(event) => ({ nonce: event.locals.nonce })
+);
+```
+
+### Without nonce
+
+To configure CSP without a nonce, set the header after the downstream handler returns:
+
+```tsx
+import { createMiddleware } from "@solidjs/start/middleware";
+
+export default createMiddleware([
+	async (event, next) => {
+		const response = await next();
+		const csp = `
+      default-src 'self';
+      font-src 'self'  ;
+      object-src 'none';
+      base-uri 'none';
+      frame-ancestors 'none';
+      form-action 'self';
+    `.replace(/\s+/g, " ");
+
+		event.res.headers.set("Content-Security-Policy", csp);
+		return response;
+	},
+]);
+```
+
+## CORS (Cross-Origin Resource Sharing)
+
+When other applications need access to API endpoints, a middleware that configures the CORS headers is needed:
+
+```tsx
+import { createMiddleware } from "@solidjs/start/middleware";
+
+const TRUSTED_ORIGINS = ["https://my-app.com", "https://another-app.com"];
+
+export default createMiddleware([
+	async (event, next) => {
+		const origin = event.req.headers.get("Origin");
+		const requestUrl = new URL(event.req.url);
+		const isApiRequest = requestUrl && requestUrl.pathname.startsWith("/api");
+
+		if (isApiRequest && origin && TRUSTED_ORIGINS.includes(origin)) {
+			if (
+				event.req.method === "OPTIONS" &&
+				event.req.headers.get("Access-Control-Request-Method")
+			) {
+				return new Response(null, {
+					headers: {
+						"Access-Control-Allow-Origin": origin,
+						"Access-Control-Allow-Methods": "OPTIONS, POST, PUT, PATCH, DELETE",
+						"Access-Control-Allow-Headers": "Authorization, Content-Type",
+						Vary: "Origin, Access-Control-Request-Method",
+					},
+				});
+			}
+
+			event.res.headers.set("Access-Control-Allow-Origin", origin);
+		}
+
+		event.res.headers.append("Vary", "Origin, Access-Control-Request-Method");
+		return next();
+	},
+]);
+```
+
+## CSRF (Cross-Site Request Forgery)
+
+To prevent basic CSRF attacks, a middleware can be used to block untrusted requests:
+
+```tsx
+import { createMiddleware } from "@solidjs/start/middleware";
+
+const SAFE_METHODS = ["GET", "HEAD", "OPTIONS", "TRACE"];
+const TRUSTED_ORIGINS = ["https://another-app.com"];
+
+export default createMiddleware([
+	(event, next) => {
+		const request = event.req;
+
+		if (!SAFE_METHODS.includes(request.method)) {
+			const requestUrl = new URL(request.url);
+			const origin = request.headers.get("Origin");
+
+			// If we have an Origin header, check it against our allowlist.
+			if (origin) {
+				const parsedOrigin = new URL(origin);
+
+				if (
+					parsedOrigin.origin !== requestUrl.origin &&
+					!TRUSTED_ORIGINS.includes(parsedOrigin.host)
+				) {
+					return Response.json({ error: "origin invalid" }, { status: 403 });
+				}
+			}
+
+			// If we are serving via TLS and have no Origin header, prevent against
+			// CSRF via HTTP man-in-the-middle attacks by enforcing strict Referer
+			// origin checks.
+			if (!origin && requestUrl.protocol === "https:") {
+				const referer = request.headers.get("Referer");
+
+				if (!referer) {
+					return Response.json(
+						{ error: "referer not supplied" },
+						{ status: 403 }
+					);
+				}
+
+				const parsedReferer = new URL(referer);
+
+				if (parsedReferer.protocol !== "https:") {
+					return Response.json({ error: "referer invalid" }, { status: 403 });
+				}
+
+				if (
+					parsedReferer.host !== requestUrl.host &&
+					!TRUSTED_ORIGINS.includes(parsedReferer.host)
+				) {
+					return Response.json({ error: "referer invalid" }, { status: 403 });
+				}
+			}
+		}
+
+		return next();
+	},
+]);
+```
+
+This example demonstrates a basic CSRF protection that verifies the `Origin` and `Referer` headers, blocking requests from untrusted origins.
+**Please note both of these headers can be forged.**
+Additionally, consider implementing a more robust CSRF protection mechanism, such as the [Double-Submit Cookie Pattern](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#alternative-using-a-double-submit-cookie-pattern).
+
+For further guidance, you can look at the [Cross-Site Request Forgery Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).

--- a/src/routes/solid-start/v2/(2)guides/(1)data-fetching.mdx
+++ b/src/routes/solid-start/v2/(2)guides/(1)data-fetching.mdx
@@ -1,0 +1,396 @@
+---
+title: Data fetching
+use_cases: >-
+  api calls, database queries, loading states, error handling, preloading data,
+  client fetching, orm integration
+tags:
+  - fetch
+  - data
+  - api
+  - async
+  - loading
+  - query
+  - database
+version: "2.0"
+description: >-
+  Master data fetching in SolidStart with practical examples. Handle loading
+  states, errors, preloading, and database queries.
+---
+
+This guide provides practical examples of common data-fetching tasks in SolidStart.
+
+Here's an example showing how to create a [`query`](/solid-router/reference/data-apis/query) and access its data with the [`createAsync` primitive](/solid-router/reference/data-apis/create-async):
+
+```tsx tab title="TypeScript"
+// src/routes/index.tsx
+import { For } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/posts");
+	return await posts.json();
+}, "posts");
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+		</ul>
+	);
+}
+```
+
+```jsx tab title="JavaScript"
+// src/routes/index.jsx
+import { For } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/posts");
+	return await posts.json();
+}, "posts");
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+		</ul>
+	);
+}
+```
+
+## Showing loading UI
+
+To show a loading UI during data fetching:
+
+1. Import [`Suspense`](/reference/components/suspense) from `solid-js`.
+2. Wrap your data rendering in `<Suspense>`, and use the `fallback` prop to show a component during data fetching.
+
+```tsx tab title="TypeScript" {14} {16}
+// src/routes/index.tsx
+import { Suspense, For } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/posts");
+	return await posts.json();
+}, "posts");
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<Suspense fallback={<div>Loading...</div>}>
+				<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+			</Suspense>
+		</ul>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {14} {16}
+// src/routes/index.jsx
+import { Suspense, For } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/posts");
+	return await posts.json();
+}, "posts");
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<Suspense fallback={<div>Loading...</div>}>
+				<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+			</Suspense>
+		</ul>
+	);
+}
+```
+
+## Handling errors
+
+To show a fallback UI if the data fetching fails:
+
+1. Import [`ErrorBoundary`](/reference/components/error-boundary) from `solid-js`.
+2. Wrap the data rendering in `<ErrorBoundary>`, and use the `fallback` prop to show a component if an error occurs.
+
+```tsx tab title="TypeScript" {14} {18}
+// src/routes/index.tsx
+import { ErrorBoundary, Suspense, For } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/posts");
+	return await posts.json();
+}, "posts");
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<Suspense fallback={<div>Loading...</div>}>
+					<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+				</Suspense>
+			</ErrorBoundary>
+		</ul>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {14} {18}
+// src/routes/index.jsx
+import { ErrorBoundary, Suspense, For } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/posts");
+	return await posts.json();
+}, "posts");
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<Suspense fallback={<div>Loading...</div>}>
+					<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+				</Suspense>
+			</ErrorBoundary>
+		</ul>
+	);
+}
+```
+
+## Preloading data
+
+To preload data before a route renders:
+
+1. Export a `route` object with a [`preload`](/solid-router/reference/preload-functions/preload) function.
+2. Run your query inside the `preload` function.
+3. Use the query as usual in your component.
+
+```tsx tab title="TypeScript" {10-12}
+// src/routes/index.tsx
+import { ErrorBoundary } from "solid-js";
+import { query, createAsync, type RouteDefinition } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/posts");
+	return await posts.json();
+}, "posts");
+
+export const route = {
+	preload: () => getPosts(),
+} satisfies RouteDefinition;
+
+export default function Page() {
+	const post = createAsync(() => getPosts());
+	return (
+		<div>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<h1>{post().title}</h1>
+			</ErrorBoundary>
+		</div>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {10-12}
+// src/routes/index.jsx
+import { ErrorBoundary } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/posts");
+	return await posts.json();
+}, "posts");
+
+export const route = {
+	preload: () => getPosts(),
+};
+
+export default function Page() {
+	const post = createAsync(() => getPosts());
+	return (
+		<div>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<h1>{post().title}</h1>
+			</ErrorBoundary>
+		</div>
+	);
+}
+```
+
+## Passing parameters to queries
+
+When creating a query that accepts parameters, define your query function to take any number of parameters:
+
+```tsx tab title="TypeScript" {5} {11} {16}
+// src/routes/posts/[id]/index.tsx
+import { ErrorBoundary } from "solid-js";
+import { query, createAsync, type RouteDefinition } from "@solidjs/router";
+
+const getPost = query(async (id: string) => {
+	const post = await fetch(`https://my-api.com/posts/${id}`);
+	return await post.json();
+}, "post");
+
+export const route = {
+	preload: ({ params }) => getPost(params.id),
+} satisfies RouteDefinition;
+
+export default function Page() {
+	const postId = 1;
+	const post = createAsync(() => getPost(postId));
+	return (
+		<div>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<h1>{post().title}</h1>
+			</ErrorBoundary>
+		</div>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {5} {11} {16}
+// src/routes/posts/[id]/index.jsx
+import { ErrorBoundary } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+
+const getPost = query(async (id) => {
+	const post = await fetch(`https://my-api.com/posts/${id}`);
+	return await post.json();
+}, "post");
+
+export const route = {
+	preload: ({ params }) => getPost(params.id),
+};
+
+export default function Page() {
+	const postId = 1;
+	const post = createAsync(() => getPost(postId));
+	return (
+		<div>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<h1>{post().title}</h1>
+			</ErrorBoundary>
+		</div>
+	);
+}
+```
+
+## Using a database or an ORM
+
+To safely interact with your database or ORM in a query, use a [server function](/solid-start/v2/reference/server/use-server):
+
+```tsx tab title="TypeScript" {7-8}
+// src/routes/index.tsx
+import { For, ErrorBoundary } from "solid-js";
+import { query, createAsync, type RouteDefinition } from "@solidjs/router";
+import { db } from "~/lib/db";
+
+const getPosts = query(async () => {
+	"use server";
+	return await db.from("posts").select();
+}, "posts");
+
+export const route = {
+	preload: () => getPosts(),
+} satisfies RouteDefinition;
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+			</ErrorBoundary>
+		</ul>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {7-8}
+// src/routes/index.jsx
+import { For, ErrorBoundary } from "solid-js";
+import { query, createAsync } from "@solidjs/router";
+import { db } from "~/lib/db";
+
+const getPosts = query(async () => {
+	"use server";
+	return await db.from("posts").select();
+}, "posts");
+
+export const route = {
+	preload: () => getPosts(),
+};
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	return (
+		<ul>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+			</ErrorBoundary>
+		</ul>
+	);
+}
+```
+
+## Fetching data on the client
+
+To fetch data only on the client, use the [`createResource`](/reference/basic-reactivity/create-resource) primitive:
+
+```tsx tab title="TypeScript" {5-8} {13}
+// src/routes/index.tsx
+import { createResource, ErrorBoundary, Suspense, For } from "solid-js";
+
+export default function Page() {
+	const [posts] = createResource(async () => {
+		const posts = await fetch("https://my-api.com/posts");
+		return await posts.json();
+	});
+	return (
+		<ul>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<Suspense fallback={<div>Loading...</div>}>
+					<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+				</Suspense>
+			</ErrorBoundary>
+		</ul>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {5-8} {13}
+// src/routes/index.jsx
+import { createResource, ErrorBoundary, Suspense, For } from "solid-js";
+
+export default function Page() {
+	const [posts] = createResource(async () => {
+		const posts = await fetch("https://my-api.com/posts");
+		return await posts.json();
+	});
+	return (
+		<ul>
+			<ErrorBoundary fallback={<div>Something went wrong!</div>}>
+				<Suspense fallback={<div>Loading...</div>}>
+					<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+				</Suspense>
+			</ErrorBoundary>
+		</ul>
+	);
+}
+```
+
+See the [`createResource`](/reference/basic-reactivity/create-resource) API reference for more information.
+
+:::note[Advanced Data Handling]
+For advanced features like automatic background re-fetching or infinite queries, you can use [TanStack Query](https://tanstack.com/query/latest/docs/framework/solid/overview).
+:::

--- a/src/routes/solid-start/v2/(2)guides/(2)data-mutation.mdx
+++ b/src/routes/solid-start/v2/(2)guides/(2)data-mutation.mdx
@@ -1,0 +1,557 @@
+---
+title: Data mutation
+use_cases: >-
+  form submission, data updates, crud operations, user input handling, database
+  writes, api posts, validation, optimistic ui
+tags:
+  - forms
+  - actions
+  - mutations
+  - validation
+  - database
+  - api
+  - crud
+version: "2.0"
+description: >-
+  Learn how to handle form submissions, validate data, and perform mutations
+  with SolidStart actions. Complete guide with examples.
+---
+
+This guide provides practical examples of using actions to mutate data in SolidStart.
+
+## Handling form submission
+
+To handle [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) submissions with an action:
+
+1. Ensure the action has a unique name.
+   See the [Action API reference](/solid-router/reference/data-apis/action#notes-of-form-implementation-and-ssr) for more information.
+2. Pass the action to the `<form>` element using the `action` prop.
+3. Ensure the `<form>` element uses the `post` method for submission.
+4. Use the [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData/FormData) object in the action to extract field data using the native `FormData` methods.
+
+```tsx tab title="TypeScript" {4-10} {14}
+// src/routes/index.tsx
+import { action } from "@solidjs/router";
+
+const addPost = action(async (formData: FormData) => {
+	const title = formData.get("title") as string;
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	return (
+		<form action={addPost} method="post">
+			<input name="title" />
+			<button>Add Post</button>
+		</form>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {4-10} {14}
+// src/routes/index.jsx
+import { action } from "@solidjs/router";
+
+const addPost = action(async (formData) => {
+	const title = formData.get("title");
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	return (
+		<form action={addPost} method="post">
+			<input name="title" />
+			<button>Add Post</button>
+		</form>
+	);
+}
+```
+
+## Passing additional arguments
+
+To pass additional arguments to your action, use the `with` method:
+
+```tsx tab title="TypeScript" {4} {15}
+// src/routes/index.tsx
+import { action } from "@solidjs/router";
+
+const addPost = action(async (userId: number, formData: FormData) => {
+	const title = formData.get("title") as string;
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ userId, title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	const userId = 1;
+	return (
+		<form action={addPost.with(userId)} method="post">
+			<input name="title" />
+			<button>Add Post</button>
+		</form>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {4} {15}
+// src/routes/index.jsx
+import { action } from "@solidjs/router";
+
+const addPost = action(async (userId, formData) => {
+	const title = formData.get("title");
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ userId, title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	const userId = 1;
+	return (
+		<form action={addPost.with(userId)} method="post">
+			<input name="title" />
+			<button>Add Post</button>
+		</form>
+	);
+}
+```
+
+## Showing pending UI
+
+To display a pending UI during action execution:
+
+1. Import [`useSubmission`](/solid-router/reference/data-apis/use-submission) from `@solidjs/router`.
+2. Call `useSubmission` with your action, and use the returned `pending` property to display pending UI.
+
+```tsx tab title="TypeScript" {13} {17-19}
+// src/routes/index.tsx
+import { action, useSubmission } from "@solidjs/router";
+
+const addPost = action(async (formData: FormData) => {
+	const title = formData.get("title") as string;
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	const submission = useSubmission(addPost);
+	return (
+		<form action={addPost} method="post">
+			<input name="title" />
+			<button disabled={submission.pending}>
+				{submission.pending ? "Adding..." : "Add Post"}
+			</button>
+		</form>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {13} {17-19}
+// src/routes/index.jsx
+import { action, useSubmission } from "@solidjs/router";
+
+const addPost = action(async (formData) => {
+	const title = formData.get("title");
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	const submission = useSubmission(addPost);
+	return (
+		<form action={addPost} method="post">
+			<input name="title" />
+			<button disabled={submission.pending}>
+				{submission.pending ? "Adding..." : "Add Post"}
+			</button>
+		</form>
+	);
+}
+```
+
+## Handling errors
+
+To handle errors that occur within an action:
+
+1. Import [`useSubmission`](/solid-router/reference/data-apis/use-submission) from `@solidjs/router`.
+2. Call `useSubmission` with your action, and use the returned `error` property to handle the error.
+
+```tsx tab title="TypeScript" {14} {17-19}
+// src/routes/index.tsx
+import { Show } from "solid-js";
+import { action, useSubmission } from "@solidjs/router";
+
+const addPost = action(async (formData: FormData) => {
+	const title = formData.get("title") as string;
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	const submission = useSubmission(addPost);
+	return (
+		<form action={addPost} method="post">
+			<Show when={submission.error}>
+				<p>{submission.error.message}</p>
+			</Show>
+			<input name="title" />
+			<button>Add Post</button>
+		</form>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {14} {17-19}
+// src/routes/index.jsx
+import { Show } from "solid-js";
+import { action, useSubmission } from "@solidjs/router";
+
+const addPost = action(async (formData) => {
+	const title = formData.get("title");
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	const submission = useSubmission(addPost);
+	return (
+		<form action={addPost} method="post">
+			<Show when={submission.error}>
+				<p>{submission.error.message}</p>
+			</Show>
+			<input name="title" />
+			<button>Add Post</button>
+		</form>
+	);
+}
+```
+
+## Validating form fields
+
+To validate form fields in an action:
+
+1. Add validation logic in your action and return validation errors if the data is invalid.
+2. Import [`useSubmission`](/solid-router/reference/data-apis/use-submission) from `@solidjs/router`.
+3. Call `useSubmission` with your action, and use the returned `result` property to handle the errors.
+
+```tsx tab title="TypeScript" {7-11} {19} {23-25}
+// src/routes/index.tsx
+import { Show } from "solid-js";
+import { action, useSubmission } from "@solidjs/router";
+
+const addPost = action(async (formData: FormData) => {
+	const title = formData.get("title") as string;
+	if (!title || title.length < 2) {
+		return {
+			error: "Title must be at least 2 characters",
+		};
+	}
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	const submission = useSubmission(addPost);
+	return (
+		<form action={addPost} method="post">
+			<input name="title" />
+			<Show when={submission.result?.error}>
+				<p>{submission.result?.error}</p>
+			</Show>
+			<button>Add Post</button>
+		</form>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {7-11} {19} {23-25}
+// src/routes/index.jsx
+import { Show } from "solid-js";
+import { action, useSubmission } from "@solidjs/router";
+
+const addPost = action(async (formData) => {
+	const title = formData.get("title");
+	if (!title || title.length < 2) {
+		return {
+			error: "Title must be at least 2 characters",
+		};
+	}
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	const submission = useSubmission(addPost);
+	return (
+		<form action={addPost} method="post">
+			<input name="title" />
+			<Show when={submission.result?.error}>
+				<p>{submission.result?.error}</p>
+			</Show>
+			<button>Add Post</button>
+		</form>
+	);
+}
+```
+
+## Showing optimistic UI
+
+To update the UI before the server responds:
+
+1. Import [`useSubmission`](/solid-router/reference/data-apis/use-submission) from `@solidjs/router`.
+2. Call `useSubmission` with your action, and use the returned `pending` and `input` properties to display optimistic UI.
+
+```tsx tab title="TypeScript" {20} {29-31}
+// src/routes/index.tsx
+import { For, Show } from "solid-js";
+import { action, useSubmission, query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/blog");
+	return await posts.json();
+}, "posts");
+
+const addPost = action(async (formData: FormData) => {
+	const title = formData.get("title");
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	const submission = useSubmission(addPost);
+	return (
+		<main>
+			<form action={addPost} method="post">
+				<input name="title" />
+				<button>Add Post</button>
+			</form>
+			<ul>
+				<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+				<Show when={submission.pending}>
+					{submission.input?.[0]?.get("title")?.toString()}
+				</Show>
+			</ul>
+		</main>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {20} {29-31}
+// src/routes/index.jsx
+import { For, Show } from "solid-js";
+import { action, useSubmission, query, createAsync } from "@solidjs/router";
+
+const getPosts = query(async () => {
+	const posts = await fetch("https://my-api.com/blog");
+	return await posts.json();
+}, "posts");
+
+const addPost = action(async (formData) => {
+	const title = formData.get("title");
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	const posts = createAsync(() => getPosts());
+	const submission = useSubmission(addPost);
+	return (
+		<main>
+			<form action={addPost} method="post">
+				<input name="title" />
+				<button>Add Post</button>
+			</form>
+			<ul>
+				<For each={posts()}>{(post) => <li>{post.title}</li>}</For>
+				<Show when={submission.pending}>
+					{submission.input?.[0]?.get("title")?.toString()}
+				</Show>
+			</ul>
+		</main>
+	);
+}
+```
+
+:::note[Multiple Submissions]
+If you want to display optimistic UI for multiple concurrent submissions, you can use the [`useSubmissions`](/solid-router/reference/data-apis/use-submissions) primitive.
+:::
+
+## Redirecting
+
+To redirect users to a different route within an action:
+
+1. Import [`redirect`](/solid-router/reference/response-helpers/redirect) from `@solidjs/router`.
+2. Call `redirect` with the route you want to navigate to, and throw its response.
+
+```tsx tab title="TypeScript" {11}
+// src/routes/index.tsx
+import { action, redirect } from "@solidjs/router";
+
+const addPost = action(async (formData: FormData) => {
+	const title = formData.get("title") as string;
+	const response = await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+	const post = await response.json();
+	throw redirect(`/posts/${post.id}`);
+}, "addPost");
+
+export default function Page() {
+	return (
+		<form action={addPost} method="post">
+			<input name="title" />
+			<button>Add Post</button>
+		</form>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {11}
+// src/routes/index.jsx
+import { action, redirect } from "@solidjs/router";
+
+const addPost = action(async (formData) => {
+	const title = formData.get("title");
+	const response = await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+	const post = await response.json();
+	throw redirect(`/posts/${post.id}`);
+}, "addPost");
+
+export default function Page() {
+	return (
+		<form action={addPost} method="post">
+			<input name="title" />
+			<button>Add Post</button>
+		</form>
+	);
+}
+```
+
+## Using a database or an ORM
+
+To safely interact with your database or ORM in an action, ensure it's server-only by adding [`"use server"`](/solid-start/v2/reference/server/use-server) as the first line of your action:
+
+```tsx tab title="TypeScript" {6}
+// src/routes/index.tsx
+import { action } from "@solidjs/router";
+import { db } from "~/lib/db";
+
+const addPost = action(async (formData: FormData) => {
+	"use server";
+	const title = formData.get("title") as string;
+	await db.insert("posts").values({ title });
+}, "addPost");
+
+export default function Page() {
+	return (
+		<form action={addPost} method="post">
+			<input name="title" />
+			<button>Add Post</button>
+		</form>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {6}
+// src/routes/index.jsx
+import { action } from "@solidjs/router";
+import { db } from "~/lib/db";
+
+const addPost = action(async (formData) => {
+	"use server";
+	const title = formData.get("title");
+	await db.insert("posts").values({ title });
+}, "addPost");
+
+export default function Page() {
+	return (
+		<form action={addPost} method="post">
+			<input name="title" />
+			<button>Add Post</button>
+		</form>
+	);
+}
+```
+
+## Triggering an action programmatically
+
+To programmatically trigger an action:
+
+1. Import [`useAction`](/solid-router/reference/data-apis/use-action) from `@solidjs/router`.
+2. Call `useAction` with your action, and use the returned function to trigger the action.
+
+```tsx tab title="TypeScript" {14} {18}
+// src/routes/index.tsx
+import { createSignal } from "solid-js";
+import { action, useAction } from "@solidjs/router";
+
+const addPost = action(async (title: string) => {
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	const [title, setTitle] = createSignal("");
+	const addPostAction = useAction(addPost);
+	return (
+		<div>
+			<input value={title()} onInput={(e) => setTitle(e.target.value)} />
+			<button onClick={() => addPostAction(title())}>Add Post</button>
+		</div>
+	);
+}
+```
+
+```jsx tab title="JavaScript" {14} {18}
+// src/routes/index.jsx
+import { createSignal } from "solid-js";
+import { action, useAction } from "@solidjs/router";
+
+const addPost = action(async (title) => {
+	await fetch("https://my-api.com/posts", {
+		method: "POST",
+		body: JSON.stringify({ title }),
+	});
+}, "addPost");
+
+export default function Page() {
+	const [title, setTitle] = createSignal("");
+	const addPostAction = useAction(addPost);
+	return (
+		<div>
+			<input value={title()} onInput={(e) => setTitle(e.target.value)} />
+			<button onClick={() => addPostAction(title())}>Add Post</button>
+		</div>
+	);
+}
+```

--- a/src/routes/solid-start/v2/(2)guides/(3)service-workers.mdx
+++ b/src/routes/solid-start/v2/(2)guides/(3)service-workers.mdx
@@ -1,0 +1,34 @@
+---
+title: Service workers
+use_cases: >-
+  offline support, pwa, caching, background sync, push notifications,
+  performance optimization
+tags:
+  - service-workers
+  - pwa
+  - offline
+  - caching
+  - performance
+version: "2.0"
+description: >-
+  Register and configure service workers in SolidStart for offline support,
+  caching strategies, and progressive web app features.
+---
+
+To register a service worker:
+
+1. Place your service-worker file in the `public` directory (e.g., `public/sw.js`), making it available at the root URL (`/sw.js`).
+2. Add registration logic to the `entry-client.tsx` file.
+
+```tsx {6-11} title="src/entry-client.tsx"
+// @refresh reload
+import { mount, StartClient } from "@solidjs/start/client";
+
+mount(() => <StartClient />, document.getElementById("app")!);
+
+if ("serviceWorker" in navigator && import.meta.env.PROD) {
+	window.addEventListener("load", () => {
+		navigator.serviceWorker.register("/sw.js");
+	});
+}
+```

--- a/src/routes/solid-start/v2/(2)guides/(4)background-tasks.mdx
+++ b/src/routes/solid-start/v2/(2)guides/(4)background-tasks.mdx
@@ -1,0 +1,89 @@
+---
+title: Background tasks
+use_cases: >-
+  background tasks, scheduled jobs, periodic jobs, cron, automation
+tags:
+  - tasks
+  - nitro
+  - cron
+  - scheduling
+  - server
+version: "2.0"
+description: >-
+  Define and schedule background tasks in SolidStart with Nitro v3.
+---
+
+SolidStart v2 can use Nitro v3's experimental Tasks API for on-demand and scheduled background work. Platform support depends on the deployment preset.
+
+## Enable tasks
+
+```tsx title="vite.config.ts"
+import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+import { solidStart } from "@solidjs/start/config";
+
+export default defineConfig({
+	plugins: [solidStart(), nitro()],
+	nitro: {
+		serverDir: "./server",
+		experimental: {
+			tasks: true,
+		},
+	},
+});
+```
+
+## Define a task
+
+Files under `server/tasks` are registered automatically. Nested folders become colon-separated task names, so `server/tasks/db/cleanup.ts` is named `db:cleanup`.
+
+```ts title="server/tasks/db/cleanup.ts"
+import { defineTask } from "nitro/task";
+
+export default defineTask({
+	meta: {
+		name: "db:cleanup",
+		description: "Remove expired sessions",
+	},
+	async run({ payload, context }) {
+		const cleanup = deleteExpiredSessions();
+		context.waitUntil?.(cleanup);
+		const deleted = await cleanup;
+
+		return {
+			result: { deleted, requestedBy: payload.requestedBy },
+		};
+	},
+});
+```
+
+## Schedule a task
+
+Map cron expressions to task names in the Nitro configuration.
+
+```tsx title="vite.config.ts"
+export default defineConfig({
+	plugins: [solidStart(), nitro()],
+	nitro: {
+		serverDir: "./server",
+		experimental: { tasks: true },
+		scheduledTasks: {
+			"0 * * * *": "db:cleanup",
+		},
+	},
+});
+```
+
+The `dev`, Node, Bun, and Deno presets run schedules with a cron engine. Cloudflare and Vercel presets integrate with their native scheduling features.
+
+## Run a task during development
+
+With the development server running, invoke a task through Nitro's development endpoint:
+
+```sh frame="none"
+curl http://localhost:5173/_nitro/tasks/db:cleanup
+```
+
+The endpoint can accept query parameters or a JSON body under the `payload` property. Do not expose an equivalent production endpoint without authentication and input validation.
+
+See the [Nitro Tasks guide](https://nitro.build/docs/tasks) for programmatic execution, concurrency behavior, payloads, and platform support.

--- a/src/routes/solid-start/v2/(2)migrating-from-v1.mdx
+++ b/src/routes/solid-start/v2/(2)migrating-from-v1.mdx
@@ -14,8 +14,7 @@ description: >-
   Migrate your SolidStart project from v1 to v2.
 ---
 
-This guide covers the package-level migration changes for SolidStart 2.0.
-It focuses on the parts of the upgrade that already have corresponding v2 docs in this site.
+This guide covers the changes needed to move a SolidStart v1 application from Vinxi and Nitro v2 to SolidStart v2, Vite's Environment API, and Nitro v3.
 
 Some ecosystem packages may still target v1-only APIs.
 Audit those dependencies before shipping a production upgrade.
@@ -25,14 +24,38 @@ Audit those dependencies before shipping a production upgrade.
 ### Update dependencies
 
 ```package-install
-@solidjs/start@2.0.0-alpha.3
+@solidjs/start@2.0.0-rc.1 nitro@3 vite@8
 ```
 
 ```package-remove
-vinxi
+vinxi @solidjs/vite-plugin-nitro-2 nitropack
 ```
 
-The framework plugin now comes from `@solidjs/start/config`.
+`@solidjs/vite-plugin-nitro-2` was a temporary compatibility layer for using Nitro v2 through Vite. It is deprecated and is not part of the RC setup. Use Nitro v3's own `nitro()` plugin from `nitro/vite`.
+
+SolidStart v2 requires Node.js 24 or newer. Update the `engines` field and your local, CI, and deployment runtimes before installing:
+
+```json title="package.json"
+{
+	"engines": {
+		"node": ">=24"
+	}
+}
+```
+
+Replace the Vinxi scripts with Vite scripts:
+
+```json title="package.json"
+{
+	"scripts": {
+		"dev": "vite dev",
+		"build": "vite build",
+		"preview": "vite preview"
+	}
+}
+```
+
+`vite preview` is for locally checking a production build. Run or deploy Nitro's generated output according to the selected preset in production.
 
 ### Move framework configuration into `vite.config.ts`
 
@@ -41,10 +64,29 @@ Move that setup into a Vite config that calls `solidStart()`.
 
 ```tsx title="vite.config.ts"
 import { defineConfig } from "vite";
+import { nitro } from "nitro/vite";
 import { solidStart } from "@solidjs/start/config";
 
 export default defineConfig({
-	plugins: [solidStart()],
+	plugins: [solidStart(), nitro()],
+});
+```
+
+Remove `app.config.ts` after moving its settings. SolidStart options go to `solidStart()`. Options that were nested under v1's `server` property go to the top-level `nitro` property:
+
+```tsx title="vite.config.ts"
+import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+import { solidStart } from "@solidjs/start/config";
+
+export default defineConfig({
+	plugins: [solidStart(), nitro()],
+	nitro: {
+		preset: "cloudflare_module",
+		prerender: {
+			routes: ["/", "/about"],
+		},
+	},
 });
 ```
 
@@ -52,10 +94,11 @@ If your app already has custom middleware, `solidStart()` also exposes a `middle
 
 ```tsx title="vite.config.ts"
 import { defineConfig } from "vite";
+import { nitro } from "nitro/vite";
 import { solidStart } from "@solidjs/start/config";
 
 export default defineConfig({
-	plugins: [solidStart({ middleware: "./src/middleware/index.ts" })],
+	plugins: [solidStart({ middleware: "./src/middleware/index.ts" }), nitro()],
 });
 ```
 
@@ -69,6 +112,8 @@ import { getCookie, setCookie, useSession } from "@solidjs/start/http";
 ```
 
 The HTTP entrypoint exposes helpers such as `readBody`, `getQuery`, `getRequestHeader`, `setResponseHeader`, `useSession`, and related cookie/session utilities.
+
+Nitro v3 uses H3 v2 and Web standard `Request`, `Response`, and `Headers` objects. Code that directly used `event.node`, `event.web`, or H3 v1 response helpers must follow the [Nitro v3 migration guide](https://nitro.build/docs/migration).
 
 ### Update TypeScript environment types
 
@@ -85,23 +130,45 @@ Make sure your TypeScript config includes it.
 
 ### Revisit middleware syntax
 
-The v2 middleware entrypoint exports `createMiddleware`, and its types now prefer H3 middleware arrays.
-The older `onRequest` and `onBeforeResponse` object form is still present but marked deprecated in the package types.
+The v2 middleware entrypoint exports `createMiddleware`, and its preferred form is an array of H3 v2 middleware.
+The older `onRequest` and `onBeforeResponse` object form still works but is deprecated.
 
 ```tsx
 import { createMiddleware } from "@solidjs/start/middleware";
 
 export default createMiddleware([
-	async (_event, next) => {
-		return await next();
+	async (event, next) => {
+		event.context.startedAt = Date.now();
+		const response = await next();
+		console.log(`Request took ${Date.now() - event.context.startedAt}ms`);
+		return response;
 	},
 ]);
 ```
 
-## Still in the v1 docs
+### Update Nitro v2 APIs
 
-A few topics keep their v1 guidance until the v2 pages land:
+If your app uses Nitro directly, apply these common v3 changes:
 
-- Entrypoint file replacements
-- Production `start` script names for generated apps
-- Auth, prerendering, metadata, and background tasks
+- Replace the `nitropack` package and `nitropack/*` imports with `nitro` and its documented subpath exports.
+- Replace H3 v1 `eventHandler` or `defineEventHandler` with `defineHandler` from `nitro`.
+- Return response bodies, streams, and redirects instead of calling the removed `send*` helpers.
+- Revisit renamed deployment presets, especially Cloudflare, Vercel Edge, Firebase, and the old Node middleware preset.
+
+### Check serialization
+
+SolidStart v2 defaults to JSON serialization. V1 defaulted to the smaller JavaScript format, which requires `unsafe-eval` in your Content Security Policy. Set `serialization: { mode: "js" }` on `solidStart()` only if you intentionally want the v1 behavior.
+
+### Verify the application
+
+Run the development server and production build after migrating:
+
+```package-run
+dev
+```
+
+```package-run
+build
+```
+
+Test API routes, middleware order, session cookies, prerendered routes, deployment output, and any direct Nitro or H3 integrations before shipping.

--- a/src/routes/solid-start/v2/(2)migrating-from-v1.mdx
+++ b/src/routes/solid-start/v2/(2)migrating-from-v1.mdx
@@ -24,7 +24,7 @@ Audit those dependencies before shipping a production upgrade.
 ### Update dependencies
 
 ```package-install
-@solidjs/start@2.0.0-rc.1 nitro@3 vite@8
+@solidjs/start@2.0.0-rc.5 nitro@3 vite@8
 ```
 
 ```package-remove

--- a/src/routes/solid-start/v2/reference/client/mount.mdx
+++ b/src/routes/solid-start/v2/reference/client/mount.mdx
@@ -1,0 +1,71 @@
+---
+title: mount
+use_cases: >-
+  client entry, hydration, app mounting
+tags:
+  - client
+  - hydration
+  - entry
+version: "2.0"
+description: >-
+  mount hydrates the client entry.
+---
+
+`mount` is Solid's [`hydrate`](/reference/rendering/hydrate) function re-exported for the SolidStart client entry.
+
+## Import
+
+```tsx
+import { mount } from "@solidjs/start/client";
+```
+
+## Type
+
+```tsx
+function mount(
+	fn: () => JSX.Element,
+	el: MountableElement
+): (() => void) | undefined;
+```
+
+## Parameters
+
+### `fn`
+
+- **Type:** `() => JSX.Element`
+- **Required:** Yes
+
+Function that returns the client app element.
+
+### `el`
+
+- **Type:** `MountableElement`
+- **Required:** Yes
+
+Element used as the hydration root.
+
+## Return value
+
+- **Type:** `(() => void) | undefined`
+
+Returns the value from [`hydrate`](/reference/rendering/hydrate).
+
+## Behavior
+
+- `mount` and `hydrate` are the same function.
+- The standard entry hydrates `<StartClient />` into the document's `#app` element.
+
+## Examples
+
+### Basic usage
+
+```tsx
+import { mount, StartClient } from "@solidjs/start/client";
+
+mount(() => <StartClient />, document.getElementById("app")!);
+```
+
+## Related
+
+- [`hydrate`](/reference/rendering/hydrate)
+- [`StartClient`](/solid-start/v2/reference/client/start-client)

--- a/src/routes/solid-start/v2/reference/client/start-client.mdx
+++ b/src/routes/solid-start/v2/reference/client/start-client.mdx
@@ -1,0 +1,55 @@
+---
+title: StartClient
+use_cases: >-
+  client entry, app hydration, client root
+tags:
+  - client
+  - entry
+  - component
+version: "2.0"
+description: >-
+  StartClient renders the app on the client.
+---
+
+`StartClient` is a component that renders the generated app inside the client error boundary.
+
+## Import
+
+```tsx
+import { StartClient } from "@solidjs/start/client";
+```
+
+## Type
+
+```tsx
+function StartClient(): JSX.Element;
+```
+
+## Parameters
+
+`StartClient` takes no arguments.
+
+## Return value
+
+- **Type:** `JSX.Element`
+
+Returns the client app element.
+
+## Behavior
+
+- Renders the generated `solid-start:app` module.
+- Wraps the app in the shared `ErrorBoundary`.
+
+## Examples
+
+### Basic usage
+
+```tsx
+import { mount, StartClient } from "@solidjs/start/client";
+
+mount(() => <StartClient />, document.getElementById("app")!);
+```
+
+## Related
+
+- [`mount`](/solid-start/v2/reference/client/mount)

--- a/src/routes/solid-start/v2/reference/config/solid-start.mdx
+++ b/src/routes/solid-start/v2/reference/config/solid-start.mdx
@@ -1,0 +1,144 @@
+---
+title: solidStart
+use_cases: >-
+  solidstart configuration, vite plugin, ssr mode, middleware, serialization,
+  environment variables, server functions
+tags:
+  - config
+  - vite
+  - plugin
+  - ssr
+  - middleware
+  - environment
+version: "2.0"
+description: >-
+  Configure the SolidStart v2 Vite plugin and its application options.
+---
+
+`solidStart` returns the Vite plugins that build and run a SolidStart application with Vite's Environment API.
+
+## Import
+
+```tsx
+import { solidStart } from "@solidjs/start/config";
+```
+
+## Type
+
+```tsx
+function solidStart(options?: SolidStartOptions): PluginOption[];
+```
+
+## Basic configuration
+
+Use `solidStart()` together with a server plugin such as Nitro v3.
+
+```tsx title="vite.config.ts"
+import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+import { solidStart } from "@solidjs/start/config";
+
+export default defineConfig({
+	plugins: [solidStart(), nitro()],
+});
+```
+
+Nitro settings do not belong inside `solidStart()`. Configure them with the top-level `nitro` property. See [`vite.config.ts`](/solid-start/v2/reference/entrypoints/vite-config).
+
+## Options
+
+### `ssr`
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Set to `false` for client-side rendering. SolidStart swaps its server and client entrypoints to their SPA implementations while retaining file routing and server functions.
+
+### `routeDir`
+
+- **Type:** `string`
+- **Default:** `"./routes"`
+
+Route directory relative to the application root (`./src`).
+
+### `extensions`
+
+- **Type:** `string[]`
+- **Default:** `[]`
+
+Additional file extensions that the filesystem router and Solid compiler should process.
+
+### `middleware`
+
+- **Type:** `string`
+
+Path to the module that default-exports middleware created with [`createMiddleware`](/solid-start/v2/reference/server/create-middleware).
+
+```tsx
+solidStart({ middleware: "./src/middleware/index.ts" });
+```
+
+### `serialization`
+
+- **Type:** `{ mode?: "json" | "js" }`
+- **Default:** `{ mode: "json" }`
+
+Controls server-function argument and result serialization. `json` avoids `eval` and works with a strict Content Security Policy. `js` produces a smaller payload but requires `unsafe-eval`.
+
+See [Serialization](/solid-start/v2/advanced/serialization).
+
+### `solid`
+
+- **Type:** `Partial<SolidOptions>`
+
+Options forwarded to `vite-plugin-solid`.
+
+### `serverFunctions.filter`
+
+- **Type:** `{ include?: FilterPattern; exclude?: FilterPattern }`
+
+Customizes which files the `"use server"` compiler scans. By default, it includes source JavaScript and TypeScript files under `src` and excludes `node_modules`.
+
+```tsx
+solidStart({
+	serverFunctions: {
+		filter: {
+			include: ["src/**/*.{ts,tsx}", "packages/shared/**/*.ts"],
+			exclude: ["**/*.test.ts"],
+		},
+	},
+});
+```
+
+### `env`
+
+Configures SolidStart's environment-variable virtual modules.
+
+By default:
+
+- `env:server` exposes build-time variables prefixed with `SERVER_` and fails if imported by client code.
+- `env:client` exposes build-time variables prefixed with `CLIENT_` to both environments.
+- `env:server/runtime` reads runtime variables from `process.env` and is server-only.
+
+```tsx title="vite.config.ts"
+solidStart({
+	env: {
+		server: { prefix: "PRIVATE_", runtime: "node" },
+		client: { prefix: "PUBLIC_" },
+	},
+});
+```
+
+The `server.runtime` option also accepts `"cloudflare-workers"`, `"netlify-edge"`, or custom loader source code. `server.load` and `client.load` can provide custom build-time values for the current mode.
+
+## Environment boundaries
+
+SolidStart v2 recognizes `server-only` and `client-only` marker imports. Add one to a module to make an accidental import from the wrong Vite environment fail during development or build.
+
+```ts title="src/lib/db.ts"
+import "server-only";
+
+export const db = createDatabaseClient();
+```
+
+`@solidjs/start/http` and `@solidjs/start/middleware` are already marked server-only.

--- a/src/routes/solid-start/v2/reference/config/solid-start.mdx
+++ b/src/routes/solid-start/v2/reference/config/solid-start.mdx
@@ -2,7 +2,7 @@
 title: solidStart
 use_cases: >-
   solidstart configuration, vite plugin, ssr mode, middleware, serialization,
-  environment variables, server functions
+  environment variables, server functions, app root, development toolbar
 tags:
   - config
   - vite
@@ -47,6 +47,13 @@ Nitro settings do not belong inside `solidStart()`. Configure them with the top-
 
 ## Options
 
+### `appRoot`
+
+- **Type:** `string`
+- **Default:** `"./src"`
+
+Path to the directory that contains `app.tsx` or `app.jsx`. Relative paths such as `routeDir` are resolved from this directory.
+
 ### `ssr`
 
 - **Type:** `boolean`
@@ -54,12 +61,26 @@ Nitro settings do not belong inside `solidStart()`. Configure them with the top-
 
 Set to `false` for client-side rendering. SolidStart swaps its server and client entrypoints to their SPA implementations while retaining file routing and server functions.
 
+### `devOverlay`
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Controls the development toolbar, which shows application errors and server function calls. Set it to `false` to hide the toolbar during development.
+
+### `experimental.islands`
+
+- **Type:** `false`
+- **Default:** `false`
+
+Reserved for islands architecture support. Islands are not currently supported, so this option only accepts `false`.
+
 ### `routeDir`
 
 - **Type:** `string`
 - **Default:** `"./routes"`
 
-Route directory relative to the application root (`./src`).
+Route directory relative to `appRoot`.
 
 ### `extensions`
 
@@ -80,10 +101,12 @@ solidStart({ middleware: "./src/middleware/index.ts" });
 
 ### `serialization`
 
-- **Type:** `{ mode?: "json" | "js" }`
+- **Type:** `{ mode?: "json" | "js"; plugins?: string }`
 - **Default:** `{ mode: "json" }`
 
 Controls server-function argument and result serialization. `json` avoids `eval` and works with a strict Content Security Policy. `js` produces a smaller payload but requires `unsafe-eval`.
+
+The `plugins` option points to a module containing custom Seroval plugins for values that Seroval does not support by default.
 
 See [Serialization](/solid-start/v2/advanced/serialization).
 

--- a/src/routes/solid-start/v2/reference/entrypoints/(0)vite-config.mdx
+++ b/src/routes/solid-start/v2/reference/entrypoints/(0)vite-config.mdx
@@ -1,0 +1,57 @@
+---
+title: vite.config.ts
+use_cases: >-
+  app config, solidstart config, vite config, nitro config, deployment config
+tags:
+  - config
+  - vite
+  - nitro
+  - entrypoint
+version: "2.0"
+description: >-
+  Configure SolidStart v2, Vite, and Nitro from vite.config.ts.
+---
+
+`vite.config.ts` is the configuration entrypoint for a SolidStart v2 application. It replaces v1's `app.config.ts`.
+
+```tsx title="vite.config.ts"
+import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+import { solidStart } from "@solidjs/start/config";
+
+export default defineConfig({
+	plugins: [solidStart(), nitro()],
+});
+```
+
+## Responsibilities
+
+- Pass application, routing, middleware, environment, and serialization settings to [`solidStart()`](/solid-start/v2/reference/config/solid-start).
+- Add ordinary Vite plugins and options at the Vite config level.
+- Pass server, deployment, prerendering, task, and WebSocket settings through the top-level `nitro` property.
+
+```tsx title="vite.config.ts"
+import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+import { solidStart } from "@solidjs/start/config";
+
+export default defineConfig({
+	plugins: [
+		solidStart({
+			middleware: "./src/middleware/index.ts",
+			serialization: { mode: "json" },
+		}),
+		nitro(),
+	],
+	nitro: {
+		preset: "node_server",
+		prerender: {
+			routes: ["/"],
+		},
+	},
+});
+```
+
+SolidStart v2 requires Vite 8 or 9. The default scripts are `vite dev` and `vite build`; `vite preview` locally serves a completed production build.
+
+For the available server options and deployment presets, see the [Nitro configuration reference](https://nitro.build/config).

--- a/src/routes/solid-start/v2/reference/entrypoints/app.mdx
+++ b/src/routes/solid-start/v2/reference/entrypoints/app.mdx
@@ -1,0 +1,60 @@
+---
+title: app.tsx
+use_cases: >-
+  app root, routes, root component
+tags:
+  - entrypoint
+  - app
+  - routes
+version: "2.0"
+description: >-
+  app.tsx is the app root module.
+---
+
+`app.tsx` is the resolved app root module.
+
+## Import
+
+`app.tsx` is loaded as the virtual app module.
+
+## Type
+
+```tsx
+export default function App(): JSX.Element;
+```
+
+## Parameters
+
+The default app component takes no required arguments.
+
+## Return value
+
+- **Type:** `JSX.Element`
+
+Returns the root app element.
+
+## Behavior
+
+- The Vite plugin resolves `solid-start:app` to `src/app.tsx` or `src/app.jsx`.
+- The app filename determines whether the default entry files use `.tsx` or `.jsx`.
+
+## Examples
+
+### Basic usage
+
+```tsx
+import { Router } from "@solidjs/router";
+import { FileRoutes } from "@solidjs/start/router";
+
+export default function App() {
+	return (
+		<Router>
+			<FileRoutes />
+		</Router>
+	);
+}
+```
+
+## Related
+
+- [`FileRoutes`](/solid-start/v2/reference/routing/file-routes)

--- a/src/routes/solid-start/v2/reference/entrypoints/entry-client.mdx
+++ b/src/routes/solid-start/v2/reference/entrypoints/entry-client.mdx
@@ -1,0 +1,54 @@
+---
+title: entry-client.tsx
+use_cases: >-
+  client entry, hydration entry, browser entry
+tags:
+  - entrypoint
+  - client
+  - hydration
+version: "2.0"
+description: >-
+  entry-client.tsx mounts StartClient in the browser.
+---
+
+`entry-client.tsx` is the client entry module.
+
+## Import
+
+```tsx
+import { mount, StartClient } from "@solidjs/start/client";
+```
+
+## Type
+
+```tsx
+mount(() => <StartClient />, element);
+```
+
+## Parameters
+
+`entry-client.tsx` passes a `StartClient` render function and DOM element to [`mount`](/solid-start/v2/reference/client/mount).
+
+## Return value
+
+The entry module does not need to export a value.
+
+## Behavior
+
+- `solidStart()` uses `src/entry-client.tsx` as the client entry for a TypeScript app.
+- A JavaScript app whose root is `src/app.jsx` uses `src/entry-client.jsx`.
+
+## Examples
+
+### Basic usage
+
+```tsx
+import { mount, StartClient } from "@solidjs/start/client";
+
+mount(() => <StartClient />, document.getElementById("app")!);
+```
+
+## Related
+
+- [`mount`](/solid-start/v2/reference/client/mount)
+- [`StartClient`](/solid-start/v2/reference/client/start-client)

--- a/src/routes/solid-start/v2/reference/entrypoints/entry-server.mdx
+++ b/src/routes/solid-start/v2/reference/entrypoints/entry-server.mdx
@@ -1,0 +1,67 @@
+---
+title: entry-server.tsx
+use_cases: >-
+  server entry, request handler, document rendering
+tags:
+  - entrypoint
+  - server
+  - rendering
+version: "2.0"
+description: >-
+  entry-server.tsx exports the server handler.
+---
+
+`entry-server.tsx` is the server entry module.
+
+## Import
+
+```tsx
+import { createHandler, StartServer } from "@solidjs/start/server";
+```
+
+## Type
+
+```tsx
+export default createHandler((event) => <StartServer document={Document} />);
+```
+
+## Parameters
+
+The handler callback receives a `PageEvent`.
+
+## Return value
+
+The default export is the event handler returned by [`createHandler`](/solid-start/v2/reference/server/create-handler).
+
+## Behavior
+
+- `solidStart()` uses `src/entry-server.tsx` as the server entry for a TypeScript app.
+- A JavaScript app whose root is `src/app.jsx` uses `src/entry-server.jsx`.
+- For setting different SSR modes (sync | async | stream), see [`createHandler`](/solid-start/v2/reference/server/create-handler).
+
+## Examples
+
+### Basic usage
+
+```tsx
+import { createHandler, StartServer } from "@solidjs/start/server";
+
+function Document(props) {
+	return (
+		<html>
+			<head>{props.assets}</head>
+			<body>
+				<div id="app">{props.children}</div>
+				{props.scripts}
+			</body>
+		</html>
+	);
+}
+
+export default createHandler((event) => <StartServer document={Document} />);
+```
+
+## Related
+
+- [`createHandler`](/solid-start/v2/reference/server/create-handler)
+- [`StartServer`](/solid-start/v2/reference/server/start-server)

--- a/src/routes/solid-start/v2/reference/server/create-handler.mdx
+++ b/src/routes/solid-start/v2/reference/server/create-handler.mdx
@@ -1,0 +1,96 @@
+---
+title: createHandler
+use_cases: >-
+  server entry, request handler, rendering mode
+tags:
+  - server
+  - handler
+  - rendering
+version: "2.0"
+description: >-
+  createHandler creates the server handler.
+---
+
+`createHandler` creates the handler used by the server entry.
+
+## Import
+
+```tsx
+import { createHandler } from "@solidjs/start/server";
+```
+
+## Type
+
+```tsx
+type HandlerOptions = {
+	mode?: "sync" | "async" | "stream";
+	nonce?: string;
+	renderId?: string;
+	onCompleteAll?: (options: { write: (value: any) => void }) => void;
+	onCompleteShell?: (options: { write: (value: any) => void }) => void;
+};
+
+function createHandler(
+	fn: (context: PageEvent) => unknown,
+	options?:
+		| HandlerOptions
+		| ((context: PageEvent) => HandlerOptions | Promise<HandlerOptions>)
+): H3;
+```
+
+## Parameters
+
+### `fn`
+
+- **Type:** `(context: PageEvent) => unknown`
+- **Required:** Yes
+
+Function that returns the server-rendered document.
+
+### `options`
+
+- **Type:** `HandlerOptions | ((context: PageEvent) => HandlerOptions | Promise<HandlerOptions>)`
+- **Default:** `{}`
+- **Required:** No
+
+Rendering options or a function that returns rendering options.
+The supported options are:
+
+The `options` object supports these fields:
+
+| Name              | Type                                                 | Required | Default    | Description                                     |
+| ----------------- | ---------------------------------------------------- | -------- | ---------- | ----------------------------------------------- |
+| `mode`            | `"sync" \| "async" \| "stream"`                      | No       | `"stream"` | Rendering mode.                                 |
+| `nonce`           | `string`                                             | No       | None       | Nonce assigned to the page event.               |
+| `renderId`        | `string`                                             | No       | None       | Render identifier passed to the render context. |
+| `onCompleteAll`   | `(options: { write: (value: any) => void }) => void` | No       | None       | Callback used when all stream content is ready. |
+| `onCompleteShell` | `(options: { write: (value: any) => void }) => void` | No       | None       | Callback used when the shell stream is ready.   |
+
+## Return value
+
+- **Type:** `H3`
+
+Returns the H3 application used by the server entry.
+
+## Behavior
+
+- Creates a page event for matched UI routes.
+- Matching API routes run before page rendering. For `HEAD` requests, the route `HEAD` export is used, with fallback to `GET`.
+- Synchronous mode and disabled SSR render with `renderToString` and return the HTML string.
+- Async mode returns the `renderToStream` result.
+- Stream mode is the default and returns a readable stream.
+- If page rendering sets a `Location` response header, the handler sends or writes a redirect response depending on the render phase.
+
+## Examples
+
+### Basic usage
+
+```tsx
+import { createHandler, StartServer } from "@solidjs/start/server";
+
+export default createHandler((event) => <StartServer document={Document} />);
+```
+
+## Related
+
+- [`StartServer`](/solid-start/v2/reference/server/start-server)

--- a/src/routes/solid-start/v2/reference/server/create-handler.mdx
+++ b/src/routes/solid-start/v2/reference/server/create-handler.mdx
@@ -31,18 +31,19 @@ type HandlerOptions = {
 };
 
 function createHandler(
-	fn: (context: PageEvent) => unknown,
+	fn: (context: PageEvent) => JSX.Element,
 	options?:
 		| HandlerOptions
-		| ((context: PageEvent) => HandlerOptions | Promise<HandlerOptions>)
-): H3;
+		| ((context: PageEvent) => HandlerOptions | Promise<HandlerOptions>),
+	routerLoad?: (event: FetchEvent) => Promise<void>
+): StartHandler;
 ```
 
 ## Parameters
 
 ### `fn`
 
-- **Type:** `(context: PageEvent) => unknown`
+- **Type:** `(context: PageEvent) => JSX.Element`
 - **Required:** Yes
 
 Function that returns the server-rendered document.
@@ -54,7 +55,6 @@ Function that returns the server-rendered document.
 - **Required:** No
 
 Rendering options or a function that returns rendering options.
-The supported options are:
 
 The `options` object supports these fields:
 
@@ -66,11 +66,18 @@ The `options` object supports these fields:
 | `onCompleteAll`   | `(options: { write: (value: any) => void }) => void` | No       | None       | Callback used when all stream content is ready. |
 | `onCompleteShell` | `(options: { write: (value: any) => void }) => void` | No       | None       | Callback used when the shell stream is ready.   |
 
+### `routerLoad`
+
+- **Type:** `(event: FetchEvent) => Promise<void>`
+- **Required:** No
+
+Optional setup function for a custom router. SolidStart calls it before creating the page event and rendering the route. Router integrations such as TanStack Router can use it to load their server-side routing state.
+
 ## Return value
 
-- **Type:** `H3`
+- **Type:** `StartHandler`
 
-Returns the H3 application used by the server entry.
+Returns the H3 application used by the server entry. `StartHandler` extends H3's `H3` type while keeping generated declaration files portable.
 
 ## Behavior
 

--- a/src/routes/solid-start/v2/reference/server/start-server.mdx
+++ b/src/routes/solid-start/v2/reference/server/start-server.mdx
@@ -1,0 +1,77 @@
+---
+title: StartServer
+use_cases: >-
+  server entry, document rendering, html shell
+tags:
+  - server
+  - rendering
+  - component
+version: "2.0"
+description: >-
+  StartServer renders the app inside a document component.
+---
+
+`StartServer` is a component that renders the generated app inside the provided document component.
+
+## Import
+
+```tsx
+import { StartServer } from "@solidjs/start/server";
+```
+
+## Type
+
+```tsx
+type DocumentComponentProps = {
+	assets?: JSX.Element;
+	scripts: JSX.Element;
+	children?: JSX.Element;
+};
+
+function StartServer(props: {
+	document: Component<DocumentComponentProps>;
+}): JSX.Element;
+```
+
+## Props
+
+### `document`
+
+- **Type:** `Component<DocumentComponentProps>`
+- **Optional:** No
+
+Document component rendered around the app.
+
+## Behavior
+
+- Reads the current request event as a `PageEvent`.
+- Registers page assets with `useAssets`.
+- Renders `<!DOCTYPE html>` before the document component.
+- Passes `assets`, `scripts`, and `children` to the document component.
+- Wraps the app with error boundaries.
+
+## Examples
+
+### Basic usage
+
+```tsx
+import { createHandler, StartServer } from "@solidjs/start/server";
+
+function Document(props) {
+	return (
+		<html>
+			<head>{props.assets}</head>
+			<body>
+				<div id="app">{props.children}</div>
+				{props.scripts}
+			</body>
+		</html>
+	);
+}
+
+export default createHandler((event) => <StartServer document={Document} />);
+```
+
+## Related
+
+- [`createHandler`](/solid-start/v2/reference/server/create-handler)

--- a/src/routes/solid-start/v2/reference/server/use-server.mdx
+++ b/src/routes/solid-start/v2/reference/server/use-server.mdx
@@ -60,7 +60,7 @@ export async function logMessage(message: string) {
 ```
 
 :::note[Using with query]
-When wrapping a server function with [`query`](/solid-router/reference/data-apis/query), place `"use server"` inside the inner function rather than at the file level. A file-level directive turns the whole module — including the `query` wrapper that also runs on the client — into a server reference.
+When wrapping a server function with [`query`](/solid-router/reference/data-apis/query), place `"use server"` inside the inner function rather than at the file level. A file-level directive turns the whole module, including the `query` wrapper that also runs on the client, into a server reference.
 
 ```tsx
 export const logMessage = query(async (message: string) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -95,10 +95,6 @@ export default defineConfig({
 					project: "start",
 					title: "SolidStart",
 					themeConfig: {
-						versionLabels: {
-							latest: "v1 (Latest)",
-							v2: "v2 (RC)",
-						},
 						sidebar: {
 							"/solid-start": createFilesystemSidebar(
 								"./src/routes/solid-start",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -95,6 +95,10 @@ export default defineConfig({
 					project: "start",
 					title: "SolidStart",
 					themeConfig: {
+						versionLabels: {
+							latest: "v1 (Latest)",
+							v2: "v2 (RC)",
+						},
 						sidebar: {
 							"/solid-start": createFilesystemSidebar(
 								"./src/routes/solid-start",


### PR DESCRIPTION
Start v2 is in Release Candidate.

This adds the same coverage to Start v2 as Start v1 has, and adapt if according to the changes in the changelog.

**Before**

<img width="1466" height="852" alt="Screenshot 2026-07-21 at 22 11 29" src="https://github.com/user-attachments/assets/5a440f98-102e-43e1-afcb-ee2e584bfa35" />


**After**

<img width="1462" height="1241" alt="Screenshot 2026-07-21 at 21 40 48" src="https://github.com/user-attachments/assets/9767e7b7-bff0-42c6-8141-4b30d016d759" />
