### PR TITLE
SolidBase Reproduction - Project-specific labels

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,6 +62,8 @@ export default defineConfig({
 					values: {
 						latest: { path: "", label: "Latest" },
 						v2: { path: "v2", label: "v2" },
+						startLatest: { path: "", label: "v1 (Latest)" },
+						startV2: { path: "v2", label: "v2 (RC)" },
 					},
 				},
 				include: [
@@ -71,7 +73,7 @@ export default defineConfig({
 					},
 					{
 						project: "start",
-						version: ["latest", "v2"],
+						version: ["startLatest", "startV2"],
 					},
 					{
 						project: ["router", "meta"],
@@ -107,7 +109,7 @@ export default defineConfig({
 				},
 				{
 					project: "start",
-					version: "v2",
+					version: "startV2",
 					title: "SolidStart",
 					themeConfig: {
 						sidebar: {


### PR DESCRIPTION
I'm trying to set the SolidStart version dropdown labels to 

- `v1 (Latest)`
- `v2 (RC)`

But I hit a SolidBase limitation here. I need labels that are project (Start) specific. I'd like to not change Solid core's labels from `Latest` and `v2` (although they could benefit from similar imrpovemnts, but it's out of scope for this PR) - I would just like to have SolidStart show `v1 (Latest)` and `v2 (RC)`, to make that distinction clear.

The existing `routes.version.values` metadata is shared by every project. I tried adding separate Start version values with the same paths, but then `/solid-start` no longer matches because an empty version segment only resolves to the axis default. This broke the SolidStart top-nav link.

An override mechanism can also solve it.