### PR TITLE
Fix sidebar tab defaulting to "learn" on reference pages

### DIFF
--- a/osmium/src/ui/layout/main-navigation.tsx
+++ b/osmium/src/ui/layout/main-navigation.tsx
@@ -1,5 +1,5 @@
 import { createMemo, createSignal, For, Show } from "solid-js";
-import { useBeforeLeave, useLocation, useMatch } from "@solidjs/router";
+import { useBeforeLeave, useLocation } from "@solidjs/router";
 import { Icon } from "solid-heroicons";
 import { chevronDown } from "solid-heroicons/solid";
 import { setIsOpen } from "./mobile-navigation";
@@ -89,8 +89,8 @@ function DirList(props: { items: SidebarItem[] }) {
 }
 
 export function MainNavigation(_props: MainNavigationProps) {
-	const isReference = useMatch(() => "*/reference/*?");
-
+	const location = useLocation();
+	const isReference = () => location.pathname.includes("/reference/");
 	const initialTab = () => (isReference() ? "reference" : "learn");
 
 	const [selectedTab, setSelectedTab] = createSignal(initialTab());


### PR DESCRIPTION
The learn/reference tab indicator always defaulted to "learn", even when viewing a reference page.

The `useMatch` pattern was invalid: `*` wildcards are only allowed as the last segment of a path pattern.

Since `useMatch`'s pattern syntax can't express "contains this segment at any depth" (wildcards can't trail more literal segments), switched to plain substring matching against `useLocation().pathname`. This is more resilient to future changes in the number or order of segments before `/reference`.

- Closes #1592