### PR TITLE
fix: select reference sidebar on direct loads

### DIFF
--- a/osmium/src/ui/layout/main-navigation.tsx
+++ b/osmium/src/ui/layout/main-navigation.tsx
@@ -1,5 +1,5 @@
 import { createMemo, createSignal, For, Show } from "solid-js";
-import { useBeforeLeave, useLocation, useMatch } from "@solidjs/router";
+import { useBeforeLeave, useLocation } from "@solidjs/router";
 import { Icon } from "solid-heroicons";
 import { chevronDown } from "solid-heroicons/solid";
 import { setIsOpen } from "./mobile-navigation";
@@ -12,6 +12,7 @@ import {
 import { Collapsible } from "@kobalte/core/collapsible";
 import { Tabs } from "@kobalte/core/tabs";
 import VersionSelector from "./version-selector";
+import { getNavigationTabForPath } from "./navigation-tab";
 
 interface MainNavigationProps {}
 
@@ -89,9 +90,8 @@ function DirList(props: { items: SidebarItem[] }) {
 }
 
 export function MainNavigation(_props: MainNavigationProps) {
-	const isReference = useMatch(() => "*/reference/*?");
-
-	const initialTab = () => (isReference() ? "reference" : "learn");
+	const location = useLocation();
+	const initialTab = () => getNavigationTabForPath(location.pathname);
 
 	const [selectedTab, setSelectedTab] = createSignal(initialTab());
 
@@ -110,11 +110,7 @@ export function MainNavigation(_props: MainNavigationProps) {
 	useBeforeLeave(({ to }) => {
 		if (typeof to === "number") return;
 
-		if (to.includes("/reference/")) {
-			setSelectedTab("reference");
-		} else {
-			setSelectedTab("learn");
-		}
+		setSelectedTab(getNavigationTabForPath(to));
 	});
 
 	return (

--- a/osmium/src/ui/layout/navigation-tab.test.ts
+++ b/osmium/src/ui/layout/navigation-tab.test.ts
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { getNavigationTabForPath } from "./navigation-tab";
+
+test("selects reference tab for direct reference page loads", () => {
+	assert.equal(
+		getNavigationTabForPath("/reference/secondary-primitives/create-selector"),
+		"reference"
+	);
+});
+
+test("selects reference tab for localized direct reference page loads", () => {
+	assert.equal(
+		getNavigationTabForPath(
+			"/fr/reference/secondary-primitives/create-selector"
+		),
+		"reference"
+	);
+});
+
+test("selects learn tab for non-reference page loads", () => {
+	assert.equal(getNavigationTabForPath("/learn/quick-start"), "learn");
+});

--- a/osmium/src/ui/layout/navigation-tab.ts
+++ b/osmium/src/ui/layout/navigation-tab.ts
@@ -1,0 +1,5 @@
+export type NavigationTab = "learn" | "reference";
+
+export function getNavigationTabForPath(pathname: string): NavigationTab {
+	return /(^|\/)reference(\/|$)/.test(pathname) ? "reference" : "learn";
+}


### PR DESCRIPTION
## Summary
- Select the Reference sidebar tab from the current pathname on direct page loads.
- Reuse the same pathname classification for route transitions.
- Add regression coverage for direct `/reference/...` and localized `/fr/reference/...` paths.

## Why
Directly opening reference pages could initialize the sidebar on the Learn tab because the previous `useMatch(() => "*/reference/*?")` route pattern did not reliably classify direct reference-page loads. This keeps direct loads and client-side navigation on the same tab-selection logic.

Closes #1592.

## Test plan
- [x] Added regression test and confirmed RED failure before implementation (`ERR_MODULE_NOT_FOUND` for the new helper module).
- [x] `pnpm exec tsx --test osmium/src/ui/layout/navigation-tab.test.ts` — 3 passed
- [x] `pnpm exec eslint --flag unstable_native_nodejs_ts_config osmium/src/ui/layout/main-navigation.tsx osmium/src/ui/layout/navigation-tab.ts osmium/src/ui/layout/navigation-tab.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm run build` — built successfully
- [x] `pnpm exec prettier --check osmium/src/ui/layout/main-navigation.tsx osmium/src/ui/layout/navigation-tab.ts osmium/src/ui/layout/navigation-tab.test.ts`
- [x] `git diff --check`

Note: local commands report the repo's engine warning because this environment has Node v22.22.2 while `package.json` currently requests Node >=24; checks still completed successfully.