### PR TITLE
Improve sidebar styling

### DIFF
--- a/osmium/src/ui/layout/main-navigation.tsx
+++ b/osmium/src/ui/layout/main-navigation.tsx
@@ -118,7 +118,7 @@ export function MainNavigation(_props: MainNavigationProps) {
 	});
 
 	return (
-		<nav class="custom-scrollbar h-full overflow-y-auto pb-20 md:h-[calc(100vh-7rem)]">
+		<nav class="custom-scrollbar h-full scrollbar-gutter-stable overflow-y-auto pr-4 pb-20 md:h-[calc(100vh-7rem)]">
 			<VersionSelector />
 			<Tabs value={selectedTab()}>
 				<Tabs.List class="sticky top-0 z-10 grid w-full grid-cols-2 md:bg-slate-50 md:dark:bg-slate-900">
@@ -140,7 +140,7 @@ export function MainNavigation(_props: MainNavigationProps) {
 					>
 						Reference
 					</Tabs.Trigger>
-					<Tabs.Indicator class="absolute bottom-0 h-0.5 bg-blue-500 transition-all duration-250 dark:bg-blue-500" />
+					<Tabs.Indicator class="absolute bottom-0 h-0.5 bg-blue-500 transition-all duration-250" />
 				</Tabs.List>
 				<Tabs.Content value="learn" class="relative mt-5 w-full">
 					<Show

--- a/osmium/src/ui/layout/version-selector.tsx
+++ b/osmium/src/ui/layout/version-selector.tsx
@@ -38,28 +38,26 @@ export default function VersionSelector() {
 					sameWidth
 					placement="bottom-start"
 				>
-					<div class="mx-1">
-						<Popover.Trigger
-							class="flex h-10 w-full items-center justify-between rounded-lg text-left shadow-md ring-1 shadow-black/5 ring-black/90 ring-inset dark:ring-white/10"
-							aria-label="Change version"
-							disabled={options().length <= 1}
-						>
-							<span class="prose prose-slate flex items-center truncate pl-2 text-lg text-slate-700 dark:text-slate-300">
-								<Icon
-									class="mr-2 w-5 fill-slate-700 pl-1 dark:fill-slate-200"
-									path={tag}
-								/>
-								{getOptionLabel(current())}
-							</span>
+					<Popover.Trigger
+						class="flex h-10 w-full items-center justify-between rounded-lg text-left shadow-md ring-1 shadow-black/5 ring-black/90 ring-inset dark:ring-white/10"
+						aria-label="Change version"
+						disabled={options().length <= 1}
+					>
+						<span class="prose prose-slate flex items-center truncate pl-2 text-lg text-slate-700 dark:text-slate-300">
+							<Icon
+								class="mr-2 w-5 fill-slate-700 pl-1 dark:fill-slate-200"
+								path={tag}
+							/>
+							{getOptionLabel(current())}
+						</span>
 
-							<Show when={options().length > 1}>
-								<Icon
-									class="mr-2 w-6 fill-slate-700 pl-1 dark:fill-slate-200"
-									path={chevronUpDown}
-								/>
-							</Show>
-						</Popover.Trigger>
-					</div>
+						<Show when={options().length > 1}>
+							<Icon
+								class="mr-2 w-6 fill-slate-700 pl-1 dark:fill-slate-200"
+								path={chevronUpDown}
+							/>
+						</Show>
+					</Popover.Trigger>
 					<Popover.Portal>
 						<Popover.Content class="z-50 space-y-1 rounded-xl bg-white p-2 text-sm shadow-md ring-1 shadow-black/5 ring-black/5 dark:bg-slate-800 dark:ring-white/5">
 							<For each={options()}>


### PR DESCRIPTION
Fixes three issues with the sidebar:

1. Removes the extra margin around the version selector to improve alignment.

Before:
<img width="278" height="119" alt="Screenshot from 2026-07-27 21-00-18" src="https://github.com/user-attachments/assets/4d329da6-3c8d-48f6-bf14-0d9a73808353" />

After:
<img width="278" height="119" alt="Screenshot from 2026-07-27 21-00-29" src="https://github.com/user-attachments/assets/f4d1a2da-3f76-4b64-85e2-ae0e3c7f50a1" />

2. Fixes horizontal overflow when the "Reference" tab is selected. The issue was that Kobalte didn't calculate the width of the tab indicator (underline) correctly, causing it to overflow. The most straightforward fix I found was `scrollbar-gutter: stable`, which reserves space for the scrollbar so Kobalte takes it into account.

Before:
<img width="281" height="858" alt="Screenshot from 2026-07-27 21-04-45" src="https://github.com/user-attachments/assets/75ca90c8-d592-44a9-b7d6-503e5b256d97" />

After:
<img width="281" height="858" alt="Screenshot from 2026-07-27 21-04-56" src="https://github.com/user-attachments/assets/a3c9c3f7-a1ba-4c26-8fc9-a49ddffd0b7a" />

3. Fixes an issue in Firefox where the scrollbar overlapped the content by adding some padding.

Before:
<img width="278" height="160" alt="Screenshot from 2026-07-27 21-12-12" src="https://github.com/user-attachments/assets/2329ebf4-ceb0-4508-ad09-ea485b014a46" />

After:
<img width="278" height="160" alt="Screenshot from 2026-07-27 21-12-24" src="https://github.com/user-attachments/assets/802e41bc-2be8-4beb-a740-3180af66d850" />

Closes: #1591
Closes: #1478
