### PR TITLE
Adjust docs to start v2 rc

### DIFF
--- a/src/routes/solid-start/v2/(0)index.mdx
+++ b/src/routes/solid-start/v2/(0)index.mdx
@@ -16,29 +16,12 @@ description: >-
   Vite-based configuration.
 ---
 
-SolidStart v2 builds a full-stack app on top of [Solid v1](/), [Solid Router v1](/solid-router), and [Vite v8+](https://vite.dev). It uses Vite's Environment API for client and server builds and works with deployment Vite plugins such as [Nitro v3](https://nitro.build) and the [Cloudflare Vite plugin](https://www.npmjs.com/package/@cloudflare/vite-plugin).
+SolidStart v2 builds a full-stack app on top of [Solid v1](/) and [Vite v8+](https://vite.dev). If you're currently using SolidStart v1, it's mainly a tooling and stability upgrade.
 
-The framework is split into a handful of entry points:
+What's new in SolidStart v2 is that it uses Vite's Environment API for client and server builds and therefore works with deployment plugins such as [Nitro v3](https://nitro.build) and the [Cloudflare Vite plugin](https://www.npmjs.com/package/@cloudflare/vite-plugin).
 
-- `@solidjs/start/config` for the `solidStart()` Vite plugin
-- `@solidjs/start/router` for file-routed UI integration
-- `@solidjs/start/server` for server rendering helpers and server-side types
-- `@solidjs/start/http` for request, response, cookie, and session helpers
-- `@solidjs/start/middleware` for middleware composition
+SolidStart is router agnostic, and can be used with either the official [Solid Router v1](/solid-router) or [TanStack Solid Router v1](https://tanstack.com/router/latest).
 
-SolidStart v2 requires Node.js 24 or newer and Vite 8 or 9.
-
-## What v2 keeps
-
-The core model carries over from v1:
-
-- File-based routing from `src/routes`
-- API route handlers exported by HTTP method name
-- Server-backed data loading and mutation with `query` and `action`
-- Server-only code compiled from the `"use server"` directive
-
-## What changed from v1
-
-Configuration moved from `app.config.ts` to `vite.config.ts`. The `solidStart()` plugin configures the application, while a deployment Vite plugin configures the server runtime and deployment target.
+## Migrating from SolidStart v1
 
 If you are upgrading an existing app, start with the [migration guide](/solid-start/v2/migrating-from-v1).

--- a/src/routes/solid-start/v2/(0)index.mdx
+++ b/src/routes/solid-start/v2/(0)index.mdx
@@ -16,7 +16,7 @@ description: >-
   Vite-based configuration.
 ---
 
-SolidStart v2 builds a full-stack app on top of [Solid v1](/), [Solid Router](/solid-router), and [Vite 8+](https://vite.dev). It uses Vite's Environment API for client and server builds and works with deployment Vite plugins such as [Nitro v3](https://nitro.build) and the [Cloudflare Vite plugin](https://www.npmjs.com/package/@cloudflare/vite-plugin).
+SolidStart v2 builds a full-stack app on top of [Solid v1](/), [Solid Router v1](/solid-router), and [Vite v8+](https://vite.dev). It uses Vite's Environment API for client and server builds and works with deployment Vite plugins such as [Nitro v3](https://nitro.build) and the [Cloudflare Vite plugin](https://www.npmjs.com/package/@cloudflare/vite-plugin).
 
 The framework is split into a handful of entry points:
 

--- a/src/routes/solid-start/v2/(1)getting-started.mdx
+++ b/src/routes/solid-start/v2/(1)getting-started.mdx
@@ -68,6 +68,14 @@ export default defineConfig({
 
 Use the top-level `nitro` property for Nitro options such as deployment presets, prerendering, tasks, and WebSockets.
 
+## Path alias
+
+SolidStart provides a built-in `~` alias for the application root. With the default [`appRoot`](/solid-start/v2/reference/config/solid-start#approot), an import from `~/lib/db` resolves to `src/lib/db`.
+
+```ts
+import { db } from "~/lib/db";
+```
+
 ## Development toolbar
 
 During development, SolidStart adds a toolbar for inspecting application errors and server function calls. The toolbar is not included in production builds.

--- a/src/routes/solid-start/v2/reference/config/solid-start.mdx
+++ b/src/routes/solid-start/v2/reference/config/solid-start.mdx
@@ -133,6 +133,38 @@ solidStart({
 });
 ```
 
+### `serverFunctions.onError`
+
+- **Type:** `string`
+
+Path to a module whose default export handles values thrown by server functions before SolidStart serializes them into a response.
+
+The handler can report the original value and return a safer replacement for the client. Return `undefined` to preserve the original value. The module is bundled only into the server, so it can import server-only code.
+
+```tsx title="vite.config.ts"
+solidStart({
+	serverFunctions: {
+		onError: "src/server-function-error.ts",
+	},
+});
+```
+
+```ts title="src/server-function-error.ts"
+import type { ServerFunctionErrorHandler } from "@solidjs/start/server";
+
+const onServerFunctionError: ServerFunctionErrorHandler = (thrown) => {
+	console.error(thrown);
+
+	if (thrown instanceof Error) {
+		return new Error("The server function failed.");
+	}
+
+	return undefined;
+};
+
+export default onServerFunctionError;
+```
+
 ### `env`
 
 Configures SolidStart's environment-variable virtual modules.


### PR DESCRIPTION
I've adjusted for changes int hte latest rc release, and rewritten the index text for SolidStart v2, so it's listing correct compatibility versions.