### PR TITLE
Update for Start rc.7+8 - Temporal values, serverFunctions.onError async handler

### DIFF
--- a/src/routes/solid-start/v2/(1)advanced/(4)serialization.mdx
+++ b/src/routes/solid-start/v2/(1)advanced/(4)serialization.mdx
@@ -45,7 +45,17 @@ If your app enforces a Content Security Policy, keep `json`.
 
 SolidStart preserves JavaScript [`Temporal`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) values in server function and action payloads. The value is reconstructed as the same Temporal type on the receiving side.
 
-SolidStart does not install a Temporal implementation. Both the client and server must provide a compatible global `Temporal` before a payload is serialized or deserialized. If any runtime targeted by your app does not provide it natively, install a global polyfill:
+SolidStart does not install a Temporal implementation. Native server-runtime availability is:
+
+| Runtime | Unflagged global `Temporal` support                              |
+| ------- | ---------------------------------------------------------------- |
+| Node.js | [26 and later](https://nodejs.org/en/blog/release/v26.0.0/)      |
+| Deno    | [2.7 and later](https://deno.com/blog/v2.7)                      |
+| Bun     | [No stable release](https://github.com/oven-sh/bun/issues/15853) |
+
+Server-runtime support does not guarantee browser support. Both the client and server must provide a compatible global `Temporal` before a payload is serialized or deserialized. Check `typeof globalThis.Temporal !== "undefined"` in each target environment.
+
+If any runtime targeted by your app does not provide `Temporal` natively, install a global polyfill:
 
 ```sh
 pnpm add temporal-polyfill

--- a/src/routes/solid-start/v2/(1)advanced/(4)serialization.mdx
+++ b/src/routes/solid-start/v2/(1)advanced/(4)serialization.mdx
@@ -41,6 +41,28 @@ export default defineConfig({
 
 If your app enforces a Content Security Policy, keep `json`.
 
+## Temporal values
+
+SolidStart preserves JavaScript [`Temporal`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) values in server function and action payloads. The value is reconstructed as the same Temporal type on the receiving side.
+
+SolidStart does not install a Temporal implementation. Both the client and server must provide a compatible global `Temporal` before a payload is serialized or deserialized. If any runtime targeted by your app does not provide it natively, install a global polyfill:
+
+```sh
+pnpm add temporal-polyfill
+```
+
+```ts title="src/temporal.ts"
+import "temporal-polyfill/global";
+```
+
+Import the shared module before application initialization in both entrypoints:
+
+```tsx title="src/entry-client.tsx and src/entry-server.tsx"
+import "./temporal";
+```
+
+Use the polyfill's global entrypoint. A local import such as `import { Temporal } from "temporal-polyfill"` does not define the global that serialization requires. Without a compatible global on either side, sending a Temporal value causes serialization or deserialization to fail.
+
 ## Custom types
 
 Use a custom Seroval plugin when a server function needs to accept or return a value that Seroval does not support, such as a database identifier, decimal type, or another custom class.

--- a/src/routes/solid-start/v2/(2)migrating-from-v1.mdx
+++ b/src/routes/solid-start/v2/(2)migrating-from-v1.mdx
@@ -24,7 +24,7 @@ Audit those dependencies before shipping a production upgrade.
 ### Update dependencies
 
 ```package-install
-@solidjs/start@2.0.0-rc.5 nitro@3 vite@8
+@solidjs/start@2.0.0-rc.7 nitro@3 vite@8
 ```
 
 ```package-remove

--- a/src/routes/solid-start/v2/reference/config/solid-start.mdx
+++ b/src/routes/solid-start/v2/reference/config/solid-start.mdx
@@ -143,7 +143,7 @@ Path to a module whose default export handles values thrown by server functions 
 
 The handler can report the original value and return a safer replacement for the client. Return `undefined` to preserve the original value. The module is bundled only into the server, so it can import server-only code.
 
-Starting with `@solidjs/start@2.0.0-rc.8`, the handler may be async. SolidStart awaits it before serializing the error, allowing monitoring services to flush first.
+The handler may be async. SolidStart awaits it before serializing the error, allowing monitoring services to flush first.
 
 ```tsx title="vite.config.ts"
 solidStart({

--- a/src/routes/solid-start/v2/reference/config/solid-start.mdx
+++ b/src/routes/solid-start/v2/reference/config/solid-start.mdx
@@ -143,6 +143,8 @@ Path to a module whose default export handles values thrown by server functions 
 
 The handler can report the original value and return a safer replacement for the client. Return `undefined` to preserve the original value. The module is bundled only into the server, so it can import server-only code.
 
+The handler may be async. SolidStart awaits it before serializing the error, allowing monitoring services to flush first.
+
 ```tsx title="vite.config.ts"
 solidStart({
 	serverFunctions: {

--- a/src/routes/solid-start/v2/reference/config/solid-start.mdx
+++ b/src/routes/solid-start/v2/reference/config/solid-start.mdx
@@ -108,6 +108,8 @@ Controls server-function argument and result serialization. `json` avoids `eval`
 
 The `plugins` option points to a module containing custom Seroval plugins for values that Seroval does not support by default.
 
+Built-in serialization of `Temporal` values requires a compatible global `Temporal` implementation on both the client and server. SolidStart does not install a polyfill.
+
 See [Serialization](/solid-start/v2/advanced/serialization).
 
 ### `solid`

--- a/src/routes/solid-start/v2/reference/config/solid-start.mdx
+++ b/src/routes/solid-start/v2/reference/config/solid-start.mdx
@@ -143,7 +143,7 @@ Path to a module whose default export handles values thrown by server functions 
 
 The handler can report the original value and return a safer replacement for the client. Return `undefined` to preserve the original value. The module is bundled only into the server, so it can import server-only code.
 
-The handler may be async. SolidStart awaits it before serializing the error, allowing monitoring services to flush first.
+Starting with `@solidjs/start@2.0.0-rc.8`, the handler may be async. SolidStart awaits it before serializing the error, allowing monitoring services to flush first.
 
 ```tsx title="vite.config.ts"
 solidStart({

--- a/src/routes/solid-start/v2/reference/config/solid-start.mdx
+++ b/src/routes/solid-start/v2/reference/config/solid-start.mdx
@@ -141,7 +141,7 @@ solidStart({
 
 Path to a module whose default export handles values thrown by server functions before SolidStart serializes them into a response.
 
-The handler can report the original value and return—or resolve to—a safer replacement for the client. SolidStart awaits the handler before serializing the response, allowing a monitoring service to flush first.
+The handler can report the original value and provide a safer replacement for the client. SolidStart awaits the handler before serializing the response, allowing a monitoring service to flush first.
 
 Returning or resolving to `undefined` or `null` preserves the original value. A `Response` preserves control flow, while any other value replaces the original. The module is bundled only into the server, so it can import server-only code.
 

--- a/src/routes/solid-start/v2/reference/config/solid-start.mdx
+++ b/src/routes/solid-start/v2/reference/config/solid-start.mdx
@@ -141,9 +141,9 @@ solidStart({
 
 Path to a module whose default export handles values thrown by server functions before SolidStart serializes them into a response.
 
-The handler can report the original value and return a safer replacement for the client. Return `undefined` to preserve the original value. The module is bundled only into the server, so it can import server-only code.
+The handler can report the original value and return—or resolve to—a safer replacement for the client. SolidStart awaits the handler before serializing the response, allowing a monitoring service to flush first.
 
-The handler may be async. SolidStart awaits it before serializing the error, allowing monitoring services to flush first.
+Returning or resolving to `undefined` or `null` preserves the original value. A `Response` preserves control flow, while any other value replaces the original. The module is bundled only into the server, so it can import server-only code.
 
 ```tsx title="vite.config.ts"
 solidStart({


### PR DESCRIPTION
We add seroval 1.6.0 in rc.7, and it support serialization of temporal. Temporal doesn't have broad browser/runtime support yet, so this adds a section about the need for the user to ensure it's available if it's being used.

We allow async serverFunctions.onError handler in rc.8