### PR TITLE
chore: fix versions in start 2 migration guide

### DIFF
--- a/src/routes/solid-start/v2/(1)advanced/(0)middleware.mdx
+++ b/src/routes/solid-start/v2/(1)advanced/(0)middleware.mdx
@@ -136,7 +136,7 @@ export default createMiddleware([
 
 Middleware uses an onion model. Before-`next()` logic runs in declaration order; after-`next()` logic runs in reverse order.
 
-The v1 object form with `onRequest` and `onBeforeResponse` remains available for migration but is deprecated. In `2.0.0-rc.1`, deprecated `onBeforeResponse` arrays run in their declared order. Remove any manual reversal added as a workaround for earlier prereleases.
+The v1 object form with `onRequest` and `onBeforeResponse` remains available for migration but is deprecated. In `2.0.0`, deprecated `onBeforeResponse` arrays run in their declared order. Remove any manual reversal added as a workaround for earlier prereleases.
 
 ## Custom H3 handlers
 

--- a/src/routes/solid-start/v2/(2)migrating-from-v1.mdx
+++ b/src/routes/solid-start/v2/(2)migrating-from-v1.mdx
@@ -24,7 +24,7 @@ Audit those dependencies before shipping a production upgrade.
 ### Update dependencies
 
 ```package-install
-@solidjs/start@2.0.0 nitro@3 vite@8
+@solidjs/start@2.0.0 nitro@3.0.260610-beta vite@8
 ```
 
 ```package-remove

--- a/src/routes/solid-start/v2/(2)migrating-from-v1.mdx
+++ b/src/routes/solid-start/v2/(2)migrating-from-v1.mdx
@@ -24,7 +24,7 @@ Audit those dependencies before shipping a production upgrade.
 ### Update dependencies
 
 ```package-install
-@solidjs/start@2.0.0-rc.7 nitro@3 vite@8
+@solidjs/start@2.0.0 nitro@3 vite@8
 ```
 
 ```package-remove


### PR DESCRIPTION
There are two places where we write `@solidjs/start` version 2.0.0-rc.x , this makes it just 2.0.0

Also, update the get started to `nitro@3.0.260610-beta`, because `nitro@3` gets an unintentional published v3.0.0 release of nitro.