### PR TITLE
Point Main Nav SolidStart link to /v2

### DIFF
--- a/osmium/src/ui/layout/main-header.tsx
+++ b/osmium/src/ui/layout/main-header.tsx
@@ -96,7 +96,7 @@ export function MainHeader(_props: MainHeaderProps) {
 									return (
 										<li>
 											<NavLink
-												href={`/${conf.path}`}
+												href={`/${conf.path}${p === "start" ? "/v2" : ""}`}
 												onClick={() => setNavOpen(false)}
 												active={project()?.current === p}
 											>


### PR DESCRIPTION
Change the top nav SolidStart link from

`https://docs.solidjs.com/solid-start` - Start v1 docs

to

`https://docs.solidjs.com/solid-start/v2` - Start v2