### PR TITLE
docs: note future A component deprecation

### DIFF
--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -18,8 +18,6 @@ description: >-
 
 `A` wraps the native [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) element with Solid Router path resolution, active-state classes, and the router `link` marker used by delegated navigation handling.
 
-You can normally just use the native `<a>` element with Solid Router, but `A` is provided for convenience for things like active state classes.
-
 ## Import
 
 ```tsx

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -13,7 +13,7 @@ description: >-
 ---
 
 :::note
-`A` will be deprecated in the future in favor of just using the native `<a>` element.
+`A` will be deprecated in favor of the native `<a>` element.
 :::
 
 `A` wraps the native [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) element with Solid Router path resolution, active-state classes, and the router `link` marker used by delegated navigation handling.

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -12,7 +12,13 @@ description: >-
   A wraps a native anchor element for Solid Router navigation.
 ---
 
+:::note
+`A` will be deprecated in the future in favor of just using the native `<a>` element.
+:::
+
 `A` wraps the native [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) element with Solid Router path resolution, active-state classes, and the router `link` marker used by delegated navigation handling.
+
+You can normally just use the native `<a>` element with Solid Router, but `A` is provided for convenience for things like active state classes.
 
 ## Import
 


### PR DESCRIPTION
## Summary

- note that Solid Router's `A` component will be deprecated in favor of native anchors
- clarify that `A` remains a convenience for features such as active-state classes

## Verification

- `pnpm exec prettier src/routes/solid-router/reference/components/a.mdx --check`
- `pnpm build`