### PR TITLE
docs: apply Solid 2 RC follow-ups

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "solid-docs-dev",
+			"runtimeExecutable": "pnpm",
+			"runtimeArgs": ["dev"],
+			"port": 3000
+		}
+	]
+}

--- a/osmium/src/ui/layout/main-header.tsx
+++ b/osmium/src/ui/layout/main-header.tsx
@@ -114,7 +114,7 @@ export function MainHeader(_props: MainHeaderProps) {
 					)}
 				</Show>
 
-				<div class="order- flex basis-0 items-center justify-end gap-4 lg:order-2">
+				<div class="flex items-center justify-end gap-4 lg:col-start-3">
 					<ClientSearch />
 					<a
 						href={`${config().themeConfig?.github}/${project().projects[project().current].path || "solid"}`}

--- a/src/routes/(0)index.mdx
+++ b/src/routes/(0)index.mdx
@@ -18,13 +18,13 @@ description: >-
 ---
 
 :::note[These docs cover the release candidate]
-Solid 2.0 is a release candidate (RC).
+Solid 2.0 is in its release candidate (RC) phase.
 APIs may change before the stable release, and packages from the coordinated RC must use compatible versions.
 For Solid 1.x, SolidStart, and the current stable ecosystem, see the [current Solid documentation](https://docs.solidjs.com/).
 :::
 
 Solid is a framework for building user interfaces on the web.
-Solid 2.0 is a coordinated release of the whole platform: the core library, rendering, routing, head management, and the Vite plugin ship together and are designed to work together.
+Solid 2.0 is a coordinated release of the whole platform: the core library, rendering, routing, head management, and the Vite plugin are designed to work together.
 
 You can try Solid in the [playground](https://playground.solidjs.com/) or [start a project](/getting-started/quick-start) right away.
 
@@ -35,4 +35,4 @@ You can try Solid in the [playground](https://playground.solidjs.com/) or [start
 - [Building apps](/building-apps/app-structure): the application layer — structure, server functions, sessions, environment, deployment.
 - [Routing](/routing/overview): how routers plug in, with guides for Solid Router and TanStack Router.
 - [Migration](/migration/from-solid-1): moving from Solid 1.x, SolidStart, and earlier ecosystem versions.
-- Reference: API documentation for each package, organized by import specifier.
+- [Reference](/reference/solid-js/reactivity/create-effect): API documentation for each package, organized by import specifier.

--- a/src/routes/(1)getting-started/(0)quick-start.mdx
+++ b/src/routes/(1)getting-started/(0)quick-start.mdx
@@ -11,15 +11,15 @@ These versions satisfy the Vite 8 runtime requirement used by the maintained tem
 Run the Solid CLI:
 
 ```bash
-npm init solid
+npm init solid@latest
 ```
 
 Use the equivalent command for another package manager:
 
 ```bash
-pnpm create solid
-yarn create solid
-bun create solid
+pnpm create solid@latest
+yarn create solid@latest
+bun create solid@latest
 ```
 
 Choose the `basic` project shape when the CLI prompts you.

--- a/src/routes/(2)concepts/(0)reactivity.mdx
+++ b/src/routes/(2)concepts/(0)reactivity.mdx
@@ -79,6 +79,10 @@ console.log(model.fullName()); // "Grace Lovelace"
 model.dispose();
 ```
 
+:::note
+`model.fullName()` doesn't update until you call `flush()`.
+:::
+
 Use a memo when multiple consumers need the same derivation or when the derived value should form an equality boundary in the reactive graph.
 An expression used in only one JSX location can often read its sources directly.
 

--- a/src/routes/(2)concepts/(2)components-and-jsx.mdx
+++ b/src/routes/(2)concepts/(2)components-and-jsx.mdx
@@ -96,11 +96,6 @@ function SaveButton(props: { onSave: () => void }) {
 
 Use a `ref` directive with `addEventListener` when you need native listener options such as capture or passive handling.
 
-:::note
-If you are coming from React, you might be used to using onChange instead of onInput.
-In Solid, the event name is the same as the DOM event name.
-:::
-
 ## Refs and directives
 
 A `ref` callback receives an element after Solid creates it.
@@ -151,10 +146,6 @@ function listen(
 	};
 }
 ```
-
-:::note
-`onSettled` replaces `onMount` from Solid v1. Read the [onSettled](/reference/solid-js/lifecycle-actions/on-settled) reference for more information.
-:::
 
 The factory registers setup and cleanup while it has an owner.
 The returned callback only stores the element for the settled work.
@@ -293,9 +284,6 @@ function ThemeButton() {
 When a context has a default value, `useContext` returns that value outside a matching provider.
 When it has no default, reading it outside a matching provider throws `ContextNotFoundError`.
 Providers create a scoped owner, so nested providers can replace a value for their own descendants.
-
-If you are coming from Solid 1, you might be used to a `ThemeContext.Provider` component.
-In Solid 2, you can use the `ThemeContext` directly.
 
 ## Rendering lists
 

--- a/src/routes/(2)concepts/(2)components-and-jsx.mdx
+++ b/src/routes/(2)concepts/(2)components-and-jsx.mdx
@@ -96,6 +96,11 @@ function SaveButton(props: { onSave: () => void }) {
 
 Use a `ref` directive with `addEventListener` when you need native listener options such as capture or passive handling.
 
+:::note
+If you are coming from React, you might be used to using onChange instead of onInput.
+In Solid, the event name is the same as the DOM event name.
+:::
+
 ## Refs and directives
 
 A `ref` callback receives an element after Solid creates it.
@@ -146,6 +151,10 @@ function listen(
 	};
 }
 ```
+
+:::note
+`onSettled` replaces `onMount` from Solid v1. Read the [onSettled](/reference/solid-js/lifecycle-actions/on-settled) reference for more information.
+:::
 
 The factory registers setup and cleanup while it has an owner.
 The returned callback only stores the element for the settled work.
@@ -284,6 +293,9 @@ function ThemeButton() {
 When a context has a default value, `useContext` returns that value outside a matching provider.
 When it has no default, reading it outside a matching provider throws `ContextNotFoundError`.
 Providers create a scoped owner, so nested providers can replace a value for their own descendants.
+
+If you are coming from Solid 1, you might be used to a `ThemeContext.Provider` component.
+In Solid 2, you can use the `ThemeContext` directly.
 
 ## Rendering lists
 

--- a/src/routes/(2)concepts/(3)async-reactivity.mdx
+++ b/src/routes/(2)concepts/(3)async-reactivity.mdx
@@ -88,9 +88,6 @@ import { Loading, isPending } from "solid-js";
 The result becomes `true` when another answer for that expression is in flight and has not revealed.
 If the expression has no settled answer yet, its read still follows the surrounding `Loading` path.
 
-Read the async source itself.
-Reading only an upstream input such as `id` cannot reveal whether a separate downstream computation is pending.
-
 ## Work rejects: `Errored`
 
 If async work rejects, the error travels through the reactive graph.
@@ -304,6 +301,8 @@ const nextUser = () => latest(user);
 If the next answer exists, `latest(user)` returns it before the held update commits it.
 Otherwise, it returns the visible settled answer.
 Before any answer exists, the read still follows the normal `Loading` path.
+
+A common use case for `latest` is an autocomplete or typeahead interface that keeps results visible while the next value loads.
 
 ### Declare a committed first value
 

--- a/src/routes/(3)building-apps/(3)server-functions.mdx
+++ b/src/routes/(3)building-apps/(3)server-functions.mdx
@@ -211,6 +211,8 @@ export const renameCurrentUser = action(async (form: FormData) => {
 });
 ```
 
+Place the `"use server"` directive inside the callback passed to `query()` or `action()`.
+
 `query()` caches reads by its name and arguments and declares a wrapped server function as an HTTP `GET`.
 `action()` tracks mutation submissions and applies response metadata to the router's query cache.
 When the router registers its single-flight integration, an action response can carry refreshed route data with the mutation result.

--- a/src/routes/(4)routing/(1)solid-router/(1)setup.mdx
+++ b/src/routes/(4)routing/(1)solid-router/(1)setup.mdx
@@ -7,7 +7,7 @@ description: "Install Solid Router, create a route tree, and mount the router in
 Install Solid Router in a Solid 2 application:
 
 ```sh
-pnpm add @solidjs/router
+pnpm add @solidjs/router@next
 ```
 
 Define the route tree and create the router at module scope:


### PR DESCRIPTION
## Summary

- refine Solid 2 RC setup, migration, reactivity, and server function guidance
- fix desktop header action placement and link the reference section from the landing page
- add a Claude development launch configuration

## Testing

- `pnpm check:lint`
- `pnpm check:types`
- `pnpm lint:tone` (0 errors; 11 existing warnings in generated reference pages)
- `pnpm build`
- Prettier checks on all changed files
- `git diff --check`