### PR TITLE
docs: add deployment integration examples

### DIFF
--- a/osmium/src/utils.ts
+++ b/osmium/src/utils.ts
@@ -30,7 +30,7 @@ export function useProject() {
 			current: useSolidBaseRoute()().project ?? "solid",
 			projects: ("values" in projectConfig
 				? projectConfig.values
-				: { solid: { path: "", label: "Solid" } }) as Record<
+				: { solid: { path: "", label: "Solid2" } }) as Record<
 				string,
 				{ path: string; label: string }
 			>,

--- a/public/images/logos/solid2.svg
+++ b/public/images/logos/solid2.svg
@@ -1,0 +1,83 @@
+<svg
+		width="100%"
+		height="100%"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 166 155.3"
+	>
+		<defs>
+			<linearGradient
+				id="a"
+				gradientUnits="userSpaceOnUse"
+				x1="27.5"
+				y1="3"
+				x2="152"
+				y2="63.5"
+			>
+				<stop offset=".1" stop-color="#76b3e1" />
+				<stop offset=".3" stop-color="#dcf2fd" />
+				<stop offset="1" stop-color="#76b3e1" />
+			</linearGradient>
+			<linearGradient
+				id="b"
+				gradientUnits="userSpaceOnUse"
+				x1="95.8"
+				y1="32.6"
+				x2="74"
+				y2="105.2"
+			>
+				<stop offset="0" stop-color="#76b3e1" />
+				<stop offset=".5" stop-color="#4377bb" />
+				<stop offset="1" stop-color="#1f3b77" />
+			</linearGradient>
+			<linearGradient
+				id="c"
+				gradientUnits="userSpaceOnUse"
+				x1="18.4"
+				y1="64.2"
+				x2="144.3"
+				y2="149.8"
+			>
+				<stop offset="0" stop-color="#315aa9" />
+				<stop offset=".5" stop-color="#518ac8" />
+				<stop offset="1" stop-color="#315aa9" />
+			</linearGradient>
+			<linearGradient
+				id="d"
+				gradientUnits="userSpaceOnUse"
+				x1="75.2"
+				y1="74.5"
+				x2="24.4"
+				y2="260.8"
+			>
+				<stop offset="0" stop-color="#4377bb" />
+				<stop offset=".5" stop-color="#1a336b" />
+				<stop offset="1" stop-color="#1a336b" />
+			</linearGradient>
+		</defs>
+		<path
+			d="M163 35S110-4 69 5l-3 1c-6 2-11 5-14 9l-2 3-15 26 26 5c11 7 25 10 38 7l46 9 18-30z"
+			fill="#76b3e1"
+		/>
+		<path
+			d="M163 35S110-4 69 5l-3 1c-6 2-11 5-14 9l-2 3-15 26 26 5c11 7 25 10 38 7l46 9 18-30z"
+			opacity=".3"
+			fill="url(#a)"
+		/>
+		<path
+			d="m52 35-4 1c-17 5-22 21-13 35 10 13 31 20 48 15l62-21S92 26 52 35z"
+			fill="#518ac8"
+		/>
+		<path
+			d="m52 35-4 1c-17 5-22 21-13 35 10 13 31 20 48 15l62-21S92 26 52 35z"
+			opacity=".3"
+			fill="url(#b)"
+		/>
+		<path
+			d="M134 80a45 45 0 0 0-48-15L24 85 4 120l112 19 20-36c4-7 3-15-2-23z"
+			fill="url(#c)"
+		/>
+		<path
+			d="M114 115a45 45 0 0 0-48-15L4 120s53 40 94 30l3-1c17-5 23-21 13-34z"
+			fill="url(#d)"
+		/>
+	</svg>

--- a/src/routes/(3)building-apps/(7)deployment.mdx
+++ b/src/routes/(3)building-apps/(7)deployment.mdx
@@ -174,7 +174,7 @@ Use the top-level `nitro` property for deployment presets, prerendering, tasks, 
 
 #### Netlify
 
-The [Netlify Vite plugin](https://docs.netlify.com/build/frameworks/framework-setup-guides/solidstart/) prepares the server build for Netlify Functions and emulates Netlify platform features during development.
+The Netlify Vite plugin prepares the server build for Netlify Functions and emulates Netlify platform features during development.
 
 ```package-install-dev
 @netlify/vite-plugin
@@ -205,7 +205,7 @@ The [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plug
 @cloudflare/vite-plugin wrangler
 ```
 
-Map the Worker to SolidStart's `ssr` environment:
+Map the Worker to Solid's `ssr` environment:
 
 ```tsx title="vite.config.ts"
 import { cloudflare } from "@cloudflare/vite-plugin";

--- a/src/routes/(3)building-apps/(7)deployment.mdx
+++ b/src/routes/(3)building-apps/(7)deployment.mdx
@@ -123,3 +123,141 @@ The pinned Solid 2.0 sources define the `handleRequest(Request) -> Promise<Respo
 They do not include a verified catalog of provider-specific deployment adapters.
 Treat provider adapters and `start.external` integrations as integration-specific until their packages test this exact handler contract and Solid 2.0 version.
 :::
+
+### Integration examples
+
+#### Nitro
+
+[Nitro v3](https://nitro.build/) supports multiple deployment targets through presets.
+
+```package-install
+nitro
+```
+
+Add `nitro()` and configure the `ssr` environment:
+
+```tsx title="vite.config.ts"
+import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+import solid from "vite-plugin-solid";
+
+export default defineConfig({
+	plugins: [
+		solid({ start: { external: true }, ssr: true }),
+		nitro({ serverEntry: false }),
+	],
+	environments: {
+		ssr: {
+			build: {
+				rollupOptions: {
+					input: "./src/ssr.ts",
+				},
+			},
+		},
+	},
+});
+```
+
+Then add `src/ssr.ts`:
+
+```ts
+import { handleRequest } from "virtual:solid-ssr-handler";
+
+export default {
+	fetch(request: Request) {
+		return handleRequest(request);
+	},
+};
+```
+
+Use the top-level `nitro` property for deployment presets, prerendering, tasks, WebSockets, and other Nitro options. See the [Nitro configuration reference](https://nitro.build/config).
+
+#### Netlify
+
+The [Netlify Vite plugin](https://docs.netlify.com/build/frameworks/framework-setup-guides/solidstart/) prepares the server build for Netlify Functions and emulates Netlify platform features during development.
+
+```package-install-dev
+@netlify/vite-plugin
+```
+
+Add the plugin after `solid()` and enable its build support:
+
+```tsx title="vite.config.ts"
+import netlify from "@netlify/vite-plugin";
+import { defineConfig } from "vite";
+import solid from "vite-plugin-solid";
+
+export default defineConfig({
+	plugins: [
+		solid({ start: { external: true }, ssr: true }),
+		netlify({ build: { enabled: true } }),
+	],
+});
+```
+
+No Solid-specific adapter is required. Netlify detects Solid and can supply the build command and publish directory automatically.
+
+#### Cloudflare
+
+The [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/) runs the server build in the Workers runtime during development and prepares it for deployment to Cloudflare.
+
+```package-install-dev
+@cloudflare/vite-plugin wrangler
+```
+
+Map the Worker to SolidStart's `ssr` environment:
+
+```tsx title="vite.config.ts"
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+import solid from "vite-plugin-solid";
+
+export default defineConfig({
+	plugins: [
+		cloudflare({ viteEnvironment: { name: "ssr" } }),
+		solid({ start: { external: true }, ssr: true }),
+	],
+	environments: {
+		ssr: {
+			build: {
+				rollupOptions: {
+					input: "./src/ssr.ts",
+				},
+			},
+		},
+	},
+});
+```
+
+Then add `src/ssr.ts`:
+
+```ts
+import { handleRequest } from "virtual:solid-ssr-handler";
+
+export default {
+	fetch(request: Request) {
+		return handleRequest(request);
+	},
+};
+```
+
+Then configure the Worker in `wrangler.jsonc`:
+
+```jsonc
+{
+	"$schema": "./node_modules/wrangler/config-schema.json",
+	"name": "solid-2",
+	"main": "./src/ssr.ts",
+	"compatibility_date": "2026-07-22",
+	"compatibility_flags": ["nodejs_compat"],
+	"assets": {
+		"directory": "./dist/client",
+		"binding": "ASSETS",
+	},
+	"observability": {
+		"enabled": true,
+	},
+}
+```
+
+The `viteEnvironment` option merges the Workers runtime configuration with Solid's server environment. Follow the Cloudflare guide to add a Wrangler configuration and any platform bindings.


### PR DESCRIPTION
## Summary

- document Nitro, Netlify, and Cloudflare deployment integrations for Solid 2 start mode
- add fetch-handler and provider configuration examples
- label the default project as Solid2 and provide its matching logo asset

## Validation

- `pnpm check:lint`
- `pnpm check:types`
- `pnpm lint:tone` (0 errors; 11 existing generated-reference warnings)
- `pnpm build`