### PR TITLE
fix: use resolvable font stack in diagram SVGs

### DIFF
--- a/public/images/diagrams/async-update-timeline.svg
+++ b/public/images/diagrams/async-update-timeline.svg
@@ -14,7 +14,7 @@
 	<rect width="1200" height="675" rx="24" fill="#ffffff" />
 
 	<g
-		font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif"
+		font-family="Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"
 		fill="#0f172a"
 	>
 		<text x="600" y="60" text-anchor="middle" font-size="34" font-weight="700">

--- a/public/images/diagrams/derived-state-effects-sequence.svg
+++ b/public/images/diagrams/derived-state-effects-sequence.svg
@@ -28,7 +28,7 @@
 	<rect width="1200" height="675" rx="24" fill="#ffffff" />
 
 	<g
-		font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif"
+		font-family="Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"
 		fill="#0f172a"
 	>
 		<text x="600" y="62" text-anchor="middle" font-size="36" font-weight="750">


### PR DESCRIPTION
## Problem

The diagram labels on `/concepts/async-reactivity` render as garbled glyphs in Firefox.

Both diagram SVGs declare:

```
font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif"
```

Inter is not bundled with the repo, and an SVG loaded through `<img>` cannot use the page's webfonts — it can only use locally installed fonts. So resolution falls through to the system-font aliases, and every one of them is fragile:

- `ui-sans-serif` is not a supported generic family in Firefox
- `-apple-system` / `BlinkMacSystemFont` point at the macOS system font, which Firefox has historically had trouble accessing correctly

## Fix

Replace the aliases with real font files that exist on every platform:

```diff
- font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif"
+ font-family="Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"
```

Applied to both `async-update-timeline.svg` and `derived-state-effects-sequence.svg`.

## Verification

Rendered both SVGs in Firefox (headless, clean profile) before and after. The `async-update-timeline.svg` render is **byte-identical** across the change (85,729 bytes), confirming a healthy Firefox was already falling through to Helvetica — this only removes the ambiguity so it cannot land on a broken alias instead. No visual change on Chromium either.

## Scope

I audited all 30 SVGs in the repo. These two were the only ones affected:

| Files | `font-family` | Status |
|---|---|---|
| 2 diagrams in `public/images/diagrams/` | the stack above | fixed here |
| 6 Excalidraw diagrams | `Helvetica, Segoe UI Emoji` | safe — real font, no aliases |
| 22 logos / favicons / provider assets | none (no text elements) | n/a |

## Note

I was not able to reproduce the garbled rendering in a clean Firefox profile, so this is a fix for the most plausible cause rather than a confirmed repro. It is a strict robustness improvement regardless: the previous stack's behavior depended on browser-specific system-font alias handling, and the new one does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
