### PR TITLE
docs: update navigation links to use native anchor tags

### DIFF
--- a/src/routes/(2)guides/(2)routing-and-navigation.mdx
+++ b/src/routes/(2)guides/(2)routing-and-navigation.mdx
@@ -126,13 +126,11 @@ render(
 
 **6. Create links to your routes**
 
-The [`<A>`](/solid-router/reference/components/a) component provides navigation to an application's routes.
-Alternatively, you can use the [native anchor tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a).
-However, the `<A>` component provides additional functionality including properties for CSS, `inactiveClass` and `activeClass`.
+ The [native anchor tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) provides soft navigation to an application's routes. 
 
 ```jsx
 import { render } from "solid-js/web";
-import { Router, Route, A } from "@solidjs/router";
+import { Router, Route } from "@solidjs/router";
 
 import Home from "./pages/Home";
 import Users from "./pages/Users";
@@ -141,8 +139,8 @@ import NotFound from "./pages/NotFound";
 const App = (props) => (
 	<>
 		<nav>
-			<A href="/">Home</A>
-			<A href="/users">Users</A>
+			<a href="/">Home</a>
+			<a href="/users">Users</a>
 		</nav>
 		<h1>Site Title</h1>
 		{props.children}

--- a/src/routes/(2)guides/(2)routing-and-navigation.mdx
+++ b/src/routes/(2)guides/(2)routing-and-navigation.mdx
@@ -126,7 +126,7 @@ render(
 
 **6. Create links to your routes**
 
- The [native anchor tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) provides soft navigation to an application's routes. 
+The [native anchor tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) provides soft navigation to an application's routes.
 
 ```jsx
 import { render } from "solid-js/web";

--- a/src/routes/(2)guides/(2)routing-and-navigation.mdx
+++ b/src/routes/(2)guides/(2)routing-and-navigation.mdx
@@ -400,7 +400,7 @@ function PageWrapper(props) {
 		<div>
 			<h1> We love our users! </h1>
 			{props.children}
-			<A href="/">Back Home</A>
+			<a href="/">Back Home</a>
 		</div>
 	);
 }

--- a/src/routes/(2)guides/(2)routing-and-navigation.mdx
+++ b/src/routes/(2)guides/(2)routing-and-navigation.mdx
@@ -126,7 +126,7 @@ render(
 
 **6. Create links to your routes**
 
-The [native anchor tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) provides soft navigation to an application's routes.
+Solid Router intercepts the [native `<a>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) to perform client-side navigation.
 
 ```jsx
 import { render } from "solid-js/web";


### PR DESCRIPTION
Replaced the <A> component with native anchor tags for navigation, removed conflicting description.

<!-- Thank you for taking the time to open this PR! We appreciate your contribution and effort in helping improve the project. -->

- [x] I have read the [Contribution guide](https://github.com/solidjs/solid-docs/blob/main/CONTRIBUTING.md)
- [x] This PR references an issue (except for typos, broken links, or other minor problems)

### Description(required)

<!-- Provide a detailed description of the changes in this PR. Why is it necessary, and what does it do?  -->
The [page for < A >](https://docs.solidjs.com/solid-router/reference/components/a) says that it will be deprecated in favour of the native anchor tag, but at the same time the [routing and navigation page](https://docs.solidjs.com/guides/routing-and-navigation) prefers using it instead of native anchor tag. 
This creates a confusion among readers.

### Related issues & labels

- Closes #1631 <!-- Add the issue number this PR closes (if applicable). For multiple issues, separate them with commas. Example: #123, #456 -->
- Suggested label(s) (optional): 'documentation' <!-- Suggest any labels that help categorize this PR, such as 'bug', 'enhancement', 'documentation', etc. -->
